### PR TITLE
refactor: #136 TextArea - Add JS fallback for resizing

### DIFF
--- a/src/components/textarea/__tests__/__snapshots__/textarea.test.tsx.snap
+++ b/src/components/textarea/__tests__/__snapshots__/textarea.test.tsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`content field-sizing a shadow text area is present when the CSS \`field-sizing\` property is not supported 1`] = `
+<DocumentFragment>
+  <mock-styled.textarea
+    classname=""
+    data-field-sizing="content"
+    style="--textarea-max-rows: Infinity; --textarea-min-rows: 3; block-size: 0px;"
+  />
+  <mock-styled.mock-styled.textarea
+    aria-hidden="true"
+    data-field-sizing="content"
+    style="--textarea-max-rows: Infinity; --textarea-min-rows: 3;"
+  />
+</DocumentFragment>
+`;
+
 exports[`content field-sizing can set custom min/max rows 1`] = `
 <DocumentFragment>
   <mock-styled.textarea

--- a/src/components/textarea/__tests__/textarea.test.tsx
+++ b/src/components/textarea/__tests__/textarea.test.tsx
@@ -1,7 +1,14 @@
+import isCSSContentFieldSizingSupported from '../is-css-content-fieldsizing-supported'
 import { render, screen } from '@testing-library/react'
 import { TextArea } from '../textarea'
 
+jest.mock('../is-css-content-fieldsizing-supported', () => jest.fn())
+
 describe('content field-sizing', () => {
+  beforeEach(() => {
+    jest.mocked(isCSSContentFieldSizingSupported).mockReturnValue(true)
+  })
+
   test('default min/max rows are 3 -> Infinity', () => {
     const { asFragment } = render(<TextArea fieldSizing="content" />)
     expect(asFragment()).toMatchSnapshot()
@@ -9,6 +16,13 @@ describe('content field-sizing', () => {
 
   test('can set custom min/max rows', () => {
     const { asFragment } = render(<TextArea fieldSizing="content" maxRows={10} minRows={3} />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('a shadow text area is present when the CSS `field-sizing` property is not supported', () => {
+    jest.mocked(isCSSContentFieldSizingSupported).mockReturnValue(false)
+
+    const { asFragment } = render(<TextArea fieldSizing="content" />)
     expect(asFragment()).toMatchSnapshot()
   })
 })
@@ -39,7 +53,14 @@ describe('manual field-sizing', () => {
 
 // TODO: This test is currently skipped because our Linaria styled global mock
 // is changing the tag name.
-test.skip('is accessible via the textbox role', () => {
-  render(<TextArea fieldSizing="content" maxRows={10} minRows={3} />)
+test.skip('is always accessible via the textbox role', () => {
+  jest.mocked(isCSSContentFieldSizingSupported).mockReturnValue(true)
+
+  const { rerender } = render(<TextArea fieldSizing="content" maxRows={10} minRows={3} />)
+  expect(screen.getByRole('textbox')).toBeDefined()
+
+  jest.mocked(isCSSContentFieldSizingSupported).mockReturnValue(false)
+
+  rerender(<TextArea fieldSizing="content" maxRows={10} minRows={3} />)
   expect(screen.getByRole('textbox')).toBeDefined()
 })

--- a/src/components/textarea/__tests__/use-resize-textarea-effect.test.tsx
+++ b/src/components/textarea/__tests__/use-resize-textarea-effect.test.tsx
@@ -1,0 +1,45 @@
+import { render, waitFor } from '@testing-library/react'
+import syncTextAreaHeight from '../sync-textarea-height'
+import { useRef } from 'react'
+import useResizeTextAreaEffect from '../use-resize-textarea-effect'
+
+jest.mock('../sync-textarea-height')
+
+beforeEach(() => {
+  jest.mocked(syncTextAreaHeight).mockClear()
+})
+
+test('does NOT sync height when `isEnabled` is false', async () => {
+  render(<TestComponent isEnabled={false} value="foo" />)
+  await waitFor(() => expect(syncTextAreaHeight).not.toHaveBeenCalled())
+})
+
+test('syncs height when `isEnabled` is true', async () => {
+  render(<TestComponent isEnabled value="foo" />)
+  await waitFor(() => expect(syncTextAreaHeight).toHaveBeenCalledTimes(1))
+})
+
+test('syncs height when `value` is undefined', async () => {
+  render(<TestComponent isEnabled />)
+  await waitFor(() => expect(syncTextAreaHeight).toHaveBeenCalledTimes(1))
+})
+
+test('syncs height when `value` changes', async () => {
+  const { rerender } = render(<TestComponent isEnabled value="foo" />)
+  rerender(<TestComponent isEnabled value="foo\nbar" />)
+
+  await waitFor(() => expect(syncTextAreaHeight).toHaveBeenCalledTimes(2))
+})
+
+function TestComponent({ isEnabled, value }: { isEnabled: boolean; value?: string }) {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+  const shadowTextAreaRef = useRef<HTMLTextAreaElement>(null)
+  useResizeTextAreaEffect({ isEnabled, shadowTextAreaRef, textAreaRef, value })
+
+  return (
+    <>
+      <textarea ref={textAreaRef} />
+      <textarea aria-hidden ref={shadowTextAreaRef} />
+    </>
+  )
+}

--- a/src/components/textarea/__tests__/use-resize-textarea-onchange.test.tsx
+++ b/src/components/textarea/__tests__/use-resize-textarea-onchange.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import syncTextAreaHeight from '../sync-textarea-height'
+import { useRef } from 'react'
+import useResizeTextAreaOnChange from '../use-resize-textarea-onchange'
+
+import type { ChangeEventHandler } from 'react'
+
+jest.mock('../sync-textarea-height')
+
+beforeEach(() => {
+  jest.mocked(syncTextAreaHeight).mockClear()
+})
+
+test('always calls `onChange`', async () => {
+  const onChange = jest.fn()
+
+  const { rerender } = render(<TestComponent isEnabled={false} onChange={onChange} />)
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'foo' } })
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1))
+
+  rerender(<TestComponent isEnabled={true} onChange={onChange} />)
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'foo\nbar' } })
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2))
+})
+
+test('syncs height when `isEnabled` is true', async () => {
+  const onChange = jest.fn()
+
+  render(<TestComponent isEnabled onChange={onChange} />)
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'foo' } })
+
+  await waitFor(() => expect(syncTextAreaHeight).toHaveBeenCalled())
+})
+
+test('syncs value when `isEnabled` is true', async () => {
+  const onChange = jest.fn()
+
+  render(<TestComponent isEnabled onChange={onChange} />)
+
+  const textArea = screen.getByRole('textbox') as HTMLTextAreaElement
+  fireEvent.change(textArea, { target: { value: 'foo' } })
+
+  const shadowTextArea = screen.getByTestId('shadow') as HTMLTextAreaElement
+  await waitFor(() => expect(shadowTextArea.value).toBe(textArea.value))
+})
+
+test('does NOT sync height when `isEnabled` is false', async () => {
+  const onChange = jest.fn()
+
+  render(<TestComponent isEnabled={false} onChange={onChange} />)
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'foo' } })
+
+  await waitFor(() => expect(syncTextAreaHeight).not.toHaveBeenCalled())
+})
+
+test('does NOT sync height when change event default is prevented', async () => {
+  const onChange = jest.fn().mockImplementation(((event) => event.preventDefault()) as ChangeEventHandler)
+
+  render(<TestComponent isEnabled onChange={onChange} />)
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'foo' } })
+
+  await waitFor(() => expect(syncTextAreaHeight).not.toHaveBeenCalled())
+})
+
+function TestComponent({ isEnabled, onChange }: { isEnabled: boolean; onChange: ChangeEventHandler }) {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+  const shadowTextAreaRef = useRef<HTMLTextAreaElement>(null)
+  const handleChange = useResizeTextAreaOnChange({ isEnabled, shadowTextAreaRef, textAreaRef })
+
+  return (
+    <>
+      <textarea ref={textAreaRef} onChange={handleChange(onChange)} />
+      <textarea data-testid="shadow" aria-hidden ref={shadowTextAreaRef} />
+    </>
+  )
+}

--- a/src/components/textarea/is-css-content-fieldsizing-supported.ts
+++ b/src/components/textarea/is-css-content-fieldsizing-supported.ts
@@ -1,0 +1,5 @@
+function isCSSContentFieldSizingSupported(): boolean {
+  return CSS.supports('field-sizing', 'content')
+}
+
+export default isCSSContentFieldSizingSupported

--- a/src/components/textarea/styles.ts
+++ b/src/components/textarea/styles.ts
@@ -78,6 +78,15 @@ export const ElTextArea = styled.textarea<ElTextAreaProps>`
     }
   }
 
+  &[data-field-sizing='fixed'] {
+    // NOTE: field-sizing property is currently experimental
+    // @see https://drafts.csswg.org/css-ui/#field-sizing
+    // @see https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing
+    @supports (field-sizing: fixed) {
+      field-sizing: fixed;
+    }
+  }
+
   &[data-field-sizing='manual'] {
     resize: both;
   }
@@ -116,4 +125,14 @@ export const ElTextArea = styled.textarea<ElTextAreaProps>`
     font-family: var(--font-sans-serif);
     font-size: var(--font-size-small);
   }
+`
+
+export const ElShadowTextArea = styled(ElTextArea)`
+  position: absolute;
+  height: 0;
+  left: 0;
+  overflow: hidden;
+  top: 0;
+  transform: translateZ(0);
+  visibility: hidden;
 `

--- a/src/components/textarea/sync-textarea-height.ts
+++ b/src/components/textarea/sync-textarea-height.ts
@@ -1,0 +1,12 @@
+/**
+ * Makes the CSS height of the `to` text area equal to the scroll height of the `from` text area.
+ *
+ * @param from The text area element whose height we want to copy
+ * @param to The text area element whose height we want to set
+ */
+export default function syncTextAreaHeight(from: HTMLTextAreaElement, to: HTMLTextAreaElement) {
+  const currentHeight = from.scrollHeight
+  // NOTE: We use block-size instead of height because the latter is not writing-mode aware.
+  // @see https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode
+  to.style.blockSize = `${currentHeight}px`
+}

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -100,8 +100,11 @@ export const FixedSize: StoryObj<typeof TextArea> = {
 }
 
 /**
- * Importantly, when an explicit row count is specified, no resizing will occur, whether the text area's
- * value is controlled or not. This allows text areas to have a fixed size when necessary.
+ * To continue using the Elements v4 `TextArea` behaviour where manual resizing was permitted, consumers can
+ * use `fieldSizing="manual"`.
+ *
+ * **This option is deprecated and will be removed in a future version.** Prefer either `content` or `fixed`
+ * field sizing.
  *
  * @deprecated
  */

--- a/src/components/textarea/use-resize-textarea-effect.ts
+++ b/src/components/textarea/use-resize-textarea-effect.ts
@@ -1,0 +1,29 @@
+import syncTextAreaHeight from './sync-textarea-height'
+import { useLayoutEffect } from 'react'
+
+import type { RefObject } from 'react'
+
+type UseResizeTextAreaEffectConfig = {
+  isEnabled: boolean
+  shadowTextAreaRef: RefObject<HTMLTextAreaElement>
+  textAreaRef: RefObject<HTMLTextAreaElement>
+  value?: unknown
+}
+
+export default function useResizeTextAreaEffect({
+  isEnabled,
+  shadowTextAreaRef,
+  textAreaRef,
+  value,
+}: UseResizeTextAreaEffectConfig): void {
+  useLayoutEffect(
+    function syncTextAreaHeightEffect() {
+      if (isEnabled && textAreaRef.current && shadowTextAreaRef.current) {
+        syncTextAreaHeight(shadowTextAreaRef.current, textAreaRef.current)
+      }
+    },
+    // NOTE: We include `value` here to ensure this effect runs every time it changes. This allows
+    // us to handle resizing of the text area when its value is controlled.
+    [isEnabled, shadowTextAreaRef, textAreaRef, value],
+  )
+}

--- a/src/components/textarea/use-resize-textarea-onchange.ts
+++ b/src/components/textarea/use-resize-textarea-onchange.ts
@@ -1,0 +1,31 @@
+import syncTextAreaHeight from './sync-textarea-height'
+
+import type { ChangeEvent, ChangeEventHandler, RefObject } from 'react'
+
+type UseResizeTextAreaOnChangeConfig = {
+  isEnabled: boolean
+  shadowTextAreaRef: RefObject<HTMLTextAreaElement>
+  textAreaRef: RefObject<HTMLTextAreaElement>
+}
+
+type UseResizeTextAreaOnChangeDecorator = (onChange?: ChangeEventHandler) => ChangeEventHandler
+
+export default function useResizeTextAreaOnChange({
+  isEnabled,
+  shadowTextAreaRef,
+  textAreaRef,
+}: UseResizeTextAreaOnChangeConfig): UseResizeTextAreaOnChangeDecorator {
+  return function decorateTextAreaChangeHandler(onChange?: ChangeEventHandler) {
+    return function syncTextAreaHeightAfterOnChange(event: ChangeEvent) {
+      onChange?.(event)
+      // We sync the height _after_ calling the text area's own change handler because we want
+      // to allow the handler to prevent this default auto-sizing behaviour.
+      if (isEnabled && !event.defaultPrevented && textAreaRef.current && shadowTextAreaRef.current) {
+        // NOTE: Since the text area's are uncontrolled, we need to manually sync the current value to
+        // the shadow text area.
+        shadowTextAreaRef.current.value = textAreaRef.current.value
+        syncTextAreaHeight(shadowTextAreaRef.current, textAreaRef.current)
+      }
+    }
+  }
+}

--- a/src/helpers/mergeRefs.ts
+++ b/src/helpers/mergeRefs.ts
@@ -1,0 +1,23 @@
+import type { MutableRefObject, Ref, RefCallback } from 'react'
+
+/**
+ * Assigns a value to a ref function or object
+ */
+function assignRef<T = unknown>(ref: Ref<T> | RefCallback<T>, value: T) {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref) {
+    ;(ref as MutableRefObject<T>).current = value
+  }
+}
+
+/**
+ * Combine multiple React refs into a single ref function. This is used mostly when you
+ * need to allow consumers to forward refs to an internal component that is already
+ * receiving a ref.
+ */
+export default function mergeRefs<T = unknown>(...refs: Array<Ref<T> | RefCallback<T>>): RefCallback<T> {
+  return (node) => {
+    refs.forEach((ref) => assignRef(ref, node))
+  }
+}

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,6 +16,10 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
+### **5.0.0-beta.14 - 06/08/24**
+
+- **Breaking:** `TextArea` no longer supports manual resizing; instead, it can automatically resize between a min and max row count.
+
 ### **5.0.0-beta.12 - 24/06/24**
 
 - Adds code to import Figma design tokens into project
@@ -511,4 +515,4 @@ We hope the migration process will be relatively smooth in virtually all cases h
 ### **3.0.0-beta.1 - 05/07/21**
 
 - Initial 3.x.x full ground up re-build with zero compat from v2.x.x
-- For migration information see aboveimport { text } from 'stream/consumers'
+- For migration information see above


### PR DESCRIPTION
### Context

- #136 describes updates needed for the TextArea component to align with the Design System;
- The key breaking change is that the TextArea can no longer be manually resized; rather, it should grow/shrink based on the amount of content entered.
- I am leveraging an experimental CSS property, [field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing) to achieve the resizing behaviour for CSS-only and React consumers on Chrome and Edge browsers, with a fallback to a JS-based resizing solution for React-only consumers on other browsers.
- This work is split across two PRs:
  - #150 
  - 👉 **Part 2: Add JS fallback for resizing**

### This PR (Part 2)

Resolves #136 

- Adds a JS-based fallback for resizing the text area that we use when the [field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing) CSS property is not supported;
- Adds a new styled component, `ElShadowTextArea`, that is used to calculate the height that the visible text area should be given;
- Adds two new hooks that take care of resizing the text area:
  - `useResizeTextAreaEffect` is an effect that handles resizing on initial mount of the component, and whenever its `value` prop changes (i.e. when the text area is a controlled component);
  - `useResizeTextAreaOnChange` provides a higher-order function that is used to wrap the text area's `onChange` handler. This is necessary when the text area is an uncontrolled component.
- Updates `TextArea` to conditionally render a "shadow" text area and wires up the new hooks to both text area elements so that we can "sync" the height from the shadow text area to the primary text area;
- Adds a new `mergeRefs` utility to allow multiple refs to be attached to the text area (a forwarded ref and an internal ref).

![textarea p2](https://github.com/user-attachments/assets/14e3ec95-24e3-49ca-8dc3-3f5f3441aa0d)

**note:** The GIF above shows Storybook being used via Safari, which does not currently support the `field-sizing` CSS property. Despite that, you can see that the resizing behaviour is still functioning as expected.

**note:** The design guidelines have not be finalised for this component, so there may be some additional changes once they are, particularly the treatment of default min/max rows values or the TextArea being resizable by default as opposed to fixed size by default.