### PR TITLE
fix: #184 index.css correctly includes design tokens

### DIFF
--- a/src/styles/globals.ts
+++ b/src/styles/globals.ts
@@ -1,4 +1,6 @@
 import { css } from '@linaria/core'
+import '../../tokens/reapit/tokens.css'
+
 // export javascript colours for the SVG background in the button
 export const intentPrimary = '#4e56ea'
 export const intentNeutral = '#0080ff'
@@ -15,8 +17,6 @@ export const intentSecondary = '#4e56ea'
 export const elGlobals = css`
   :global() {
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Code+Pro&display=swap');
-    /* Root color pallet */
-    @import url('./../../tokens/reapit/tokens.css');
     /* Reset CSS */
     html,
     body,


### PR DESCRIPTION
Fixes #184 

Changes from using an `@import url(...)` statement within the global `css` block to using a bare ES module import so that the token.css file's content is correclty included in the Rollup build. See #184 for more details.

**Before:**

<img width="1041" alt="Screenshot 2024-10-25 at 8 55 14 AM" src="https://github.com/user-attachments/assets/a5533979-b326-4735-98d1-c8696cc69464">

**After:**

<img width="847" alt="Screenshot 2024-10-25 at 8 45 01 AM" src="https://github.com/user-attachments/assets/2ce9b248-33aa-45f5-b155-11363ecdc3bb">
