### PR TITLE
feat: #163 new menu (keyboard interaction)

### DIFF
--- a/src/components/menu/__tests__/menu-popover.test.tsx
+++ b/src/components/menu/__tests__/menu-popover.test.tsx
@@ -16,7 +16,7 @@ describe('Menu Popover component', () => {
       </Menu>
     )
   }
-  
+
   it('should render and close Popover based on any element with data-close-menu="true" click and match snapshot', () => {
     const { asFragment, getByText } = render(<MockMenuPopoverComponent />)
 

--- a/src/components/menu/__tests__/menu-popover.test.tsx
+++ b/src/components/menu/__tests__/menu-popover.test.tsx
@@ -16,7 +16,7 @@ describe('Menu Popover component', () => {
       </Menu>
     )
   }
-
+  
   it('should render and close Popover based on any element with data-close-menu="true" click and match snapshot', () => {
     const { asFragment, getByText } = render(<MockMenuPopoverComponent />)
 
@@ -32,80 +32,99 @@ describe('Menu Popover component', () => {
     fireEvent.click(getByText('Non closing Menu Item'))
     expect(asFragment()).toEqual(openedMenu)
   })
-})
 
-describe('keyboard interaction handler', () => {
-  const menuItems = [
-    {
-      focus: jest.fn(),
-      click: jest.fn(),
-    },
-    {
-      focus: jest.fn(),
-      click: jest.fn(),
-    },
-    {
-      focus: jest.fn(),
-      click: jest.fn(),
-    },
-  ] as any as NodeListOf<HTMLElement>
+  describe('keyboard interaction handler', () => {
+    const menuItems = [
+      {
+        focus: jest.fn(),
+        click: jest.fn(),
+      },
+      {
+        focus: jest.fn(),
+        click: jest.fn(),
+      },
+      {
+        focus: jest.fn(),
+        click: jest.fn(),
+      },
+    ] as any as NodeListOf<HTMLElement>
 
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
-  describe('menuButtonHandler', () => {
-    it('should focus the first menu item when ArrowDown is pressed', () => {
-      menuButtonHandler(menuItems)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
-      expect(menuItems[0].focus).toHaveBeenCalled()
+    afterEach(() => {
+      jest.clearAllMocks()
     })
 
-    it('should not focus any item if there are no menu items', () => {
-      const emptyMenuItems = []
-      menuButtonHandler(emptyMenuItems as any)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
-      expect(menuItems[0].focus).not.toHaveBeenCalled()
-    })
-  })
+    describe('menuButtonHandler', () => {
+      it('should focus the first menu item when ArrowDown is pressed', () => {
+        menuButtonHandler(menuItems)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+        expect(menuItems[0].focus).toHaveBeenCalled()
+      })
 
-  describe('menuItemHandler', () => {
-    const closeMenu = jest.fn()
-    const menuButton = {
-      focus: jest.fn(),
-    } as any as HTMLButtonElement
-
-    it('should focus the next item or 1st item if the last item reached on ArrowDown key press', () => {
-      const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
-      menuItemHandler(menuButton, menuItems, 0, closeMenu)(event)
-      expect(menuItems[1].focus).toHaveBeenCalled()
-      menuItemHandler(menuButton, menuItems, 2, closeMenu)(event)
-      // focus back to first item
-      expect(menuItems[0].focus).toHaveBeenCalled()
+      it('should not focus any item if there are no menu items', () => {
+        const emptyMenuItems = []
+        menuButtonHandler(emptyMenuItems as any)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+        expect(menuItems[0].focus).not.toHaveBeenCalled()
+      })
     })
 
-    it('should focus the previous item or last item if at first item on ArrowUp key press', () => {
-      const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
-      menuItemHandler(menuButton, menuItems, 1, closeMenu)(event)
-      expect(menuItems[0].focus).toHaveBeenCalled()
-      // focus to last item
-      menuItemHandler(menuButton, menuItems, 0, closeMenu)(event)
-      expect(menuItems[2].focus).toHaveBeenCalled()
-    })
+    describe('menuItemHandler', () => {
+      const closeMenu = jest.fn()
+      const menuButton = {
+        focus: jest.fn(),
+      } as any as HTMLButtonElement
 
-    it('should close the menu on Escape key press', () => {
-      menuItemHandler(menuButton, menuItems, 0, closeMenu)(new KeyboardEvent('keydown', { key: 'Escape' }))
-      expect(closeMenu).toHaveBeenCalled()
-      expect(menuButton.focus).toHaveBeenCalled()
-    })
+      it('should focus the next item or 1st item if the last item reached on ArrowDown key press', () => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
+        menuItemHandler(menuButton, menuItems, 0, closeMenu)(event)
+        expect(menuItems[1].focus).toHaveBeenCalled()
+        menuItemHandler(menuButton, menuItems, 2, closeMenu)(event)
+        // focus back to first item
+        expect(menuItems[0].focus).toHaveBeenCalled()
+      })
 
-    it('should click the item on Enter or Space key press', () => {
-      let event = new KeyboardEvent('keydown', { key: 'Enter' })
-      const handler = menuItemHandler(menuButton, menuItems, 0, closeMenu)
-      handler(event)
-      expect(menuItems[0].click).toHaveBeenCalled()
+      it('should focus the previous item or last item if at first item on ArrowUp key press', () => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
+        menuItemHandler(menuButton, menuItems, 1, closeMenu)(event)
+        expect(menuItems[0].focus).toHaveBeenCalled()
+        // focus to last item
+        menuItemHandler(menuButton, menuItems, 0, closeMenu)(event)
+        expect(menuItems[2].focus).toHaveBeenCalled()
+      })
 
-      event = new KeyboardEvent('keydown', { key: ' ' })
-      handler(event)
-      expect(menuItems[0].click).toHaveBeenCalled()
+      it('should close the menu on Escape key press', () => {
+        menuItemHandler(menuButton, menuItems, 0, closeMenu)(new KeyboardEvent('keydown', { key: 'Escape' }))
+        expect(closeMenu).toHaveBeenCalled()
+        expect(menuButton.focus).toHaveBeenCalled()
+      })
+
+      it('should click the item on Enter or Space key press', () => {
+        let event = new KeyboardEvent('keydown', { key: 'Enter' })
+        const handler = menuItemHandler(menuButton, menuItems, 0, closeMenu)
+        handler(event)
+        expect(menuItems[0].click).toHaveBeenCalled()
+
+        event = new KeyboardEvent('keydown', { key: ' ' })
+        handler(event)
+        expect(menuItems[0].click).toHaveBeenCalled()
+      })
+
+      it('should closeMenu when focus of menu items move out to outside', () => {
+        const { asFragment, getByText } = render(
+          <div>
+            <button>outside button</button>
+            <MockMenuPopoverComponent />
+          </div>,
+        )
+        const closedMenu = asFragment()
+        // focus in and out menu
+        fireEvent.click(getByText('Trigger'))
+        fireEvent.keyDown(getByText('Trigger'), {
+          key: 'arrowDown',
+        })
+
+        fireEvent.focusOut(document.querySelector('[role="menu"]')!)
+
+        expect(asFragment()).toEqual(closedMenu)
+      })
     })
   })
 })

--- a/src/components/menu/__tests__/menu-popover.test.tsx
+++ b/src/components/menu/__tests__/menu-popover.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react'
 import { Menu } from '../menu'
+import { menuButtonHandler, menuItemHandler } from '../menu-popover'
 
 describe('Menu Popover component', () => {
   const MockMenuPopoverComponent = () => {
@@ -30,5 +31,81 @@ describe('Menu Popover component', () => {
     fireEvent.click(getByText('Trigger'))
     fireEvent.click(getByText('Non closing Menu Item'))
     expect(asFragment()).toEqual(openedMenu)
+  })
+})
+
+describe('keyboard interaction handler', () => {
+  const menuItems = [
+    {
+      focus: jest.fn(),
+      click: jest.fn(),
+    },
+    {
+      focus: jest.fn(),
+      click: jest.fn(),
+    },
+    {
+      focus: jest.fn(),
+      click: jest.fn(),
+    },
+  ] as any as NodeListOf<HTMLElement>
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('menuButtonHandler', () => {
+    it('should focus the first menu item when ArrowDown is pressed', () => {
+      menuButtonHandler(menuItems)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+      expect(menuItems[0].focus).toHaveBeenCalled()
+    })
+
+    it('should not focus any item if there are no menu items', () => {
+      const emptyMenuItems = []
+      menuButtonHandler(emptyMenuItems as any)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+      expect(menuItems[0].focus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('menuItemHandler', () => {
+    const closeMenu = jest.fn()
+    const menuButton = {
+      focus: jest.fn(),
+    } as any as HTMLButtonElement
+
+    it('should focus the next item or 1st item if the last item reached on ArrowDown key press', () => {
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
+      menuItemHandler(menuButton, menuItems, 0, closeMenu)(event)
+      expect(menuItems[1].focus).toHaveBeenCalled()
+      menuItemHandler(menuButton, menuItems, 2, closeMenu)(event)
+      // focus back to first item
+      expect(menuItems[0].focus).toHaveBeenCalled()
+    })
+
+    it('should focus the previous item or last item if at first item on ArrowUp key press', () => {
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
+      menuItemHandler(menuButton, menuItems, 1, closeMenu)(event)
+      expect(menuItems[0].focus).toHaveBeenCalled()
+      // focus to last item
+      menuItemHandler(menuButton, menuItems, 0, closeMenu)(event)
+      expect(menuItems[2].focus).toHaveBeenCalled()
+    })
+
+    it('should close the menu on Escape key press', () => {
+      menuItemHandler(menuButton, menuItems, 0, closeMenu)(new KeyboardEvent('keydown', { key: 'Escape' }))
+      expect(closeMenu).toHaveBeenCalled()
+      expect(menuButton.focus).toHaveBeenCalled()
+    })
+
+    it('should click the item on Enter or Space key press', () => {
+      let event = new KeyboardEvent('keydown', { key: 'Enter' })
+      const handler = menuItemHandler(menuButton, menuItems, 0, closeMenu)
+      handler(event)
+      expect(menuItems[0].click).toHaveBeenCalled()
+
+      event = new KeyboardEvent('keydown', { key: ' ' })
+      handler(event)
+      expect(menuItems[0].click).toHaveBeenCalled()
+    })
   })
 })

--- a/src/components/menu/__tests__/menu-popover.test.tsx
+++ b/src/components/menu/__tests__/menu-popover.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render } from '@testing-library/react'
 import { Menu } from '../menu'
-import { menuButtonKeyDownHandler, menuItemKeyDownHandler, menuListFocusOutHandler } from '../menu-popover'
 
 describe('Menu Popover component', () => {
   const MockMenuPopoverComponent = () => {
@@ -31,104 +30,5 @@ describe('Menu Popover component', () => {
     fireEvent.click(getByText('Trigger'))
     fireEvent.click(getByText('Non closing Menu Item'))
     expect(asFragment()).toEqual(openedMenu)
-  })
-
-  describe('keyboard interaction handler', () => {
-    const menuItems = [
-      {
-        focus: jest.fn(),
-        click: jest.fn(),
-      },
-      {
-        focus: jest.fn(),
-        click: jest.fn(),
-      },
-      {
-        focus: jest.fn(),
-        click: jest.fn(),
-      },
-    ] as any as NodeListOf<HTMLElement>
-
-    afterEach(() => {
-      jest.clearAllMocks()
-    })
-
-    describe('menuButtonKeyDownHandler', () => {
-      it('should focus the first menu item when ArrowDown is pressed', () => {
-        menuButtonKeyDownHandler(menuItems)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
-        expect(menuItems[0].focus).toHaveBeenCalled()
-      })
-
-      it('should not focus any item if there are no menu items', () => {
-        const emptyMenuItems = []
-        menuButtonKeyDownHandler(emptyMenuItems as any)(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
-        expect(menuItems[0].focus).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('menuItemKeyDownHandler', () => {
-      const closeMenu = jest.fn()
-      const menuButton = {
-        focus: jest.fn(),
-      } as any as HTMLButtonElement
-
-      it('should focus the next item or 1st item if the last item reached on ArrowDown key press', () => {
-        const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
-        menuItemKeyDownHandler(menuButton, menuItems, 0, closeMenu)(event)
-        expect(menuItems[1].focus).toHaveBeenCalled()
-        menuItemKeyDownHandler(menuButton, menuItems, 2, closeMenu)(event)
-        // focus back to first item
-        expect(menuItems[0].focus).toHaveBeenCalled()
-      })
-
-      it('should focus the previous item or last item if at first item on ArrowUp key press', () => {
-        const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
-        menuItemKeyDownHandler(menuButton, menuItems, 1, closeMenu)(event)
-        expect(menuItems[0].focus).toHaveBeenCalled()
-        // focus to last item
-        menuItemKeyDownHandler(menuButton, menuItems, 0, closeMenu)(event)
-        expect(menuItems[2].focus).toHaveBeenCalled()
-      })
-
-      it('should close the menu on Escape key press', () => {
-        menuItemKeyDownHandler(menuButton, menuItems, 0, closeMenu)(new KeyboardEvent('keydown', { key: 'Escape' }))
-        expect(closeMenu).toHaveBeenCalled()
-        expect(menuButton.focus).toHaveBeenCalled()
-      })
-
-      it('should click the item on Enter or Space key press', () => {
-        let event = new KeyboardEvent('keydown', { key: 'Enter' })
-        const handler = menuItemKeyDownHandler(menuButton, menuItems, 0, closeMenu)
-        handler(event)
-        expect(menuItems[0].click).toHaveBeenCalled()
-
-        event = new KeyboardEvent('keydown', { key: ' ' })
-        handler(event)
-        expect(menuItems[0].click).toHaveBeenCalled()
-      })
-    })
-
-    describe('menuListFocusOutHandler', () => {
-      let menuList, closeMenu
-
-      beforeEach(() => {
-        menuList = document.createElement('div')
-        closeMenu = jest.fn()
-      })
-
-      it('calls closeMenu if focus moves out of menuList', () => {
-        const event = { relatedTarget: document.createElement('div') }
-        menuListFocusOutHandler(menuList, closeMenu)(event)
-        expect(closeMenu).toHaveBeenCalled()
-      })
-
-      it('does not call closeMenu if focus stays within menuList', () => {
-        const internalElement = document.createElement('button')
-        menuList.appendChild(internalElement)
-        const event = { relatedTarget: internalElement }
-        menuListFocusOutHandler(menuList, closeMenu)(event)
-        expect(closeMenu).not.toHaveBeenCalled()
-      })
-    })
   })
 })

--- a/src/components/menu/menu-context.tsx
+++ b/src/components/menu/menu-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC } from 'react'
+import { createContext, useContext, type FC } from 'react'
 import { useMenu } from '../../hooks/use-menu'
 
 const MenuContext = createContext<useMenu | null>(null)
@@ -12,7 +12,7 @@ const MenuProvider: FC = ({ children }) => {
 export { MenuContext, MenuProvider }
 
 export const useMenuContext = () => {
-  const context = React.useContext(MenuContext)
+  const context = useContext(MenuContext)
   if (!context) {
     throw new Error('useMenuContext must be used within a MenuProvider')
   }

--- a/src/components/menu/menu-popover.tsx
+++ b/src/components/menu/menu-popover.tsx
@@ -52,6 +52,15 @@ export const MenuPopover: FC = ({ children }) => {
       const controller = new AbortController()
       const { signal } = controller
 
+      menuContainer?.querySelector('[role="menu"]')?.addEventListener(
+        'focusout',
+        (event) => {
+          if (!menuContainer.contains((event as FocusEvent).relatedTarget as Node)) {
+            closeMenu()
+          }
+        },
+        { signal },
+      )
       menuButton.addEventListener('keydown', menuButtonHandler(menuItems), { signal })
 
       menuItems.forEach((menuItem, index) => {

--- a/src/components/menu/menu-popover.tsx
+++ b/src/components/menu/menu-popover.tsx
@@ -1,78 +1,13 @@
-import { FC, MutableRefObject, useEffect, useRef } from 'react'
+import { type FC, type MutableRefObject, useRef } from 'react'
 import { useClickOutside } from '../../hooks/use-click-outside'
 import { useMenuContext } from './menu-context'
 import { ElMenuPopover } from './styles'
-
-// close menu when focus move out of menu
-export const menuListFocusOutHandler = (menuList: HTMLDivElement, closeMenu: VoidFunction) => (event) => {
-  if (!menuList.contains((event as FocusEvent).relatedTarget as Node)) {
-    closeMenu()
-  }
-}
-
-// focus to the first menuitems when "arrowDown" pressed while `Menu` open
-export const menuButtonKeyDownHandler = (menuItems: NodeListOf<HTMLElement>) => (event) => {
-  if (event.key === 'ArrowDown') {
-    if (menuItems.length) menuItems[0].focus()
-  }
-}
-
-// handle basic navigation key refer to https://www.w3.org/WAI/ARIA/apg/patterns/menubar
-export const menuItemKeyDownHandler =
-  (menuButton: HTMLButtonElement, menuItems: NodeListOf<HTMLElement>, index: number, closeMenu: VoidFunction) =>
-  (event) => {
-    switch (event.key) {
-      case 'ArrowDown': {
-        const nextItem = menuItems[(index + 1) % menuItems.length]
-        nextItem.focus()
-        break
-      }
-      case 'ArrowUp': {
-        event.preventDefault()
-        const prevItem = menuItems[(index - 1 + menuItems.length) % menuItems.length]
-        prevItem.focus()
-        break
-      }
-      case 'Escape':
-        closeMenu()
-        menuButton.focus()
-        break
-      case 'Enter':
-      case ' ': {
-        const menuItem = menuItems[index]
-        menuItem.click()
-        break
-      }
-    }
-  }
 
 export const MenuPopover: FC = ({ children }) => {
   const { isOpen, closeMenu, getPopoverProps } = useMenuContext()
   const popoverRef = useRef<HTMLDivElement>(null)
 
   useClickOutside(popoverRef, closeMenu)
-
-  useEffect(() => {
-    if (isOpen) {
-      const menuContainer = popoverRef.current?.parentElement
-      const menuItems = menuContainer!.querySelectorAll('[role="menuitem"]') as NodeListOf<HTMLElement>
-      const menuButton = menuContainer!.querySelector('[role="button"][aria-expanded="true"]') as HTMLButtonElement
-      const menuList = menuContainer?.querySelector('[role="menu"]') as HTMLDivElement
-
-      const controller = new AbortController()
-      const { signal } = controller
-
-      menuList.addEventListener('focusout', menuListFocusOutHandler(menuList, closeMenu), { signal })
-      menuButton.addEventListener('keydown', menuButtonKeyDownHandler(menuItems), { signal })
-      menuItems.forEach((menuItem, index) => {
-        menuItem.addEventListener('keydown', menuItemKeyDownHandler(menuButton, menuItems, index, closeMenu), {
-          signal,
-        })
-      })
-
-      return () => controller.abort()
-    }
-  }, [isOpen])
 
   if (isOpen) {
     const onClick = (event) => {

--- a/src/components/menu/menu-popover.tsx
+++ b/src/components/menu/menu-popover.tsx
@@ -48,21 +48,21 @@ export const MenuPopover: FC = ({ children }) => {
       const menuContainer = popoverRef.current?.parentElement
       const menuItems = menuContainer!.querySelectorAll('[role="menuitem"]') as NodeListOf<HTMLElement>
       const menuButton = menuContainer!.querySelector('[role="button"][aria-expanded="true"]') as HTMLButtonElement
+      const menuList = menuContainer?.querySelector('[role="menu"]')
 
       const controller = new AbortController()
       const { signal } = controller
 
-      menuContainer?.querySelector('[role="menu"]')?.addEventListener(
+      menuList?.addEventListener(
         'focusout',
         (event) => {
-          if (!menuContainer.contains((event as FocusEvent).relatedTarget as Node)) {
+          if (!menuList.contains((event as FocusEvent).relatedTarget as Node)) {
             closeMenu()
           }
         },
         { signal },
       )
       menuButton.addEventListener('keydown', menuButtonHandler(menuItems), { signal })
-
       menuItems.forEach((menuItem, index) => {
         menuItem.addEventListener('keydown', menuItemHandler(menuButton, menuItems, index, closeMenu), {
           signal,

--- a/src/components/menu/menu-popover.tsx
+++ b/src/components/menu/menu-popover.tsx
@@ -1,4 +1,4 @@
-import { FC, MutableRefObject, useRef } from 'react'
+import { FC, MutableRefObject, useEffect, useRef } from 'react'
 import { useClickOutside } from '../../hooks/use-click-outside'
 import { useMenuContext } from './menu-context'
 import { ElMenuPopover } from './styles'
@@ -8,6 +8,57 @@ export const MenuPopover: FC = ({ children }) => {
   const popoverRef = useRef<HTMLDivElement>(null)
 
   useClickOutside(popoverRef, closeMenu)
+
+  useEffect(() => {
+    if (isOpen) {
+      const menuItems = document.querySelectorAll('[role="menuitem"]') as NodeListOf<HTMLElement>
+      const menuContainer = popoverRef.current?.parentElement
+      const menuButton = menuContainer?.querySelector('[role="button"][aria-expanded="true"]') as HTMLButtonElement
+
+      const controller = new AbortController()
+      const { signal } = controller
+
+      menuButton.addEventListener(
+        'keydown',
+        (e) => {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault()
+            menuItems[0].focus()
+          }
+        },
+        { signal },
+      )
+
+      menuItems.forEach((menuItem, index) => {
+        menuItem.addEventListener(
+          'keydown',
+          (e) => {
+            switch (e.key) {
+              case 'ArrowDown':
+                e.preventDefault()
+                menuItems[(index + 1) % menuItems.length].focus()
+                break
+              case 'ArrowUp':
+                e.preventDefault()
+                menuItems[(index - 1 + menuItems.length) % menuItems.length].focus()
+                break
+              case 'Escape':
+                closeMenu()
+                menuButton.focus()
+                break
+              case 'Enter':
+              case ' ':
+                menuItem.click()
+                break
+            }
+          },
+          { signal },
+        )
+      })
+
+      return () => controller.abort()
+    }
+  }, [isOpen])
 
   if (isOpen) {
     const onClick = (event) => {

--- a/src/components/menu/menu.atoms.tsx
+++ b/src/components/menu/menu.atoms.tsx
@@ -1,4 +1,11 @@
-import { AnchorHTMLAttributes, ButtonHTMLAttributes, FC, HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  FC,
+  HTMLAttributes,
+  MouseEventHandler,
+  ReactNode,
+} from 'react'
 import { ElMenuItemAnchor, ElMenuItemButton, ElMenuItemGroup, ElMenuItemGroupTitle, ElMenuList } from './styles'
 
 interface CommonMenuItemProps {

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -38,6 +38,9 @@ const baseMenuItemStyles = `
     color: var(--text-white);
     background: var(--fill-action-dark);
   }
+  &:focus-visible {
+    outline: none;
+  }
 `
 
 export const ElMenuItemButton = styled.button`

--- a/src/hooks/use-menu/__tests__/index.test.tsx
+++ b/src/hooks/use-menu/__tests__/index.test.tsx
@@ -2,46 +2,6 @@ import { renderHook } from '@testing-library/react-hooks'
 import { useMenu } from '..'
 
 describe('useMenu', () => {
-  it('getTriggerProps should apply aria and class attributes correctly', () => {
-    const { result } = renderHook(() => useMenu())
-    const triggerProps = result.current.getTriggerProps({
-      className: 'custom-class',
-    })
-
-    expect(triggerProps['className']).toBe('custom-class')
-    expect(triggerProps['aria-haspopup']).toBe(true)
-    expect(triggerProps['aria-expanded']).toBe(false)
-  })
-
-  it('getPopoverProps should apply data-open attribute correctly', () => {
-    const { result } = renderHook(() => useMenu())
-
-    const popoverProps = result.current.getPopoverProps()
-    const triggerProps = result.current.getTriggerProps()
-    expect(popoverProps['data-open']).toBe(false)
-    expect(triggerProps['aria-expanded']).toBe(false)
-
-    result.current.openMenu()
-    const updatedPopoverProps = result.current.getPopoverProps()
-    const updatedTriggerProps = result.current.getTriggerProps()
-    expect(updatedPopoverProps['data-open']).toBe(true)
-    expect(updatedTriggerProps['aria-expanded']).toBe(true)
-  })
-
-  it('should toggle isOpen state when trigger is clicked', () => {
-    const { result } = renderHook(() => useMenu())
-
-    let triggerProps = result.current.getTriggerProps()
-    triggerProps.onClick?.({} as any)
-
-    expect(result.current.isOpen).toBe(true)
-
-    triggerProps = result.current.getTriggerProps()
-    triggerProps.onClick?.({} as any)
-
-    expect(result.current.isOpen).toBe(false)
-  })
-
   it('should open menu when openMenu is called', () => {
     const { result } = renderHook(() => useMenu())
 
@@ -54,5 +14,209 @@ describe('useMenu', () => {
 
     result.current.closeMenu()
     expect(result.current.isOpen).toBe(false)
+  })
+
+  describe('getTriggerProps', () => {
+    it('should toggle isOpen state when trigger is clicked', () => {
+      const { result } = renderHook(() => useMenu())
+
+      let triggerProps = result.current.getTriggerProps()
+      triggerProps.onClick?.({} as any)
+
+      expect(result.current.isOpen).toBe(true)
+
+      triggerProps = result.current.getTriggerProps()
+      triggerProps.onClick?.({} as any)
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it('should toggle isOpen state when trigger is clicked', () => {
+      const { result } = renderHook(() => useMenu())
+
+      let triggerProps = result.current.getTriggerProps()
+      triggerProps.onClick?.({} as any)
+
+      expect(result.current.isOpen).toBe(true)
+
+      triggerProps = result.current.getTriggerProps()
+      triggerProps.onClick?.({} as any)
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it('should apply aria and class attributes correctly', () => {
+      const { result } = renderHook(() => useMenu())
+      const triggerProps = result.current.getTriggerProps({
+        className: 'custom-class',
+      })
+
+      expect(triggerProps['className']).toBe('custom-class')
+      expect(triggerProps['aria-haspopup']).toBe(true)
+      expect(triggerProps['aria-expanded']).toBe(false)
+    })
+
+    it('should focus the first menu item on ArrowDown key press', () => {
+      const mockCustomOnKeyDown = jest.fn()
+      const { result } = renderHook(() => useMenu())
+      const triggerProps = result.current.getTriggerProps({
+        onKeyDown: mockCustomOnKeyDown,
+      })
+      const mockFocusFn = jest.fn()
+      const event = {
+        key: 'ArrowDown',
+        currentTarget: {
+          parentElement: {
+            querySelectorAll: () => [
+              {
+                focus: mockFocusFn,
+              },
+            ],
+          },
+        },
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>
+
+      triggerProps.onKeyDown!(event)
+
+      expect(mockFocusFn).toHaveBeenCalled()
+      expect(mockCustomOnKeyDown).toHaveBeenCalled()
+    })
+  })
+
+  describe('getPopoverProps', () => {
+    it('should apply data-open attribute correctly', () => {
+      const { result } = renderHook(() => useMenu())
+
+      const popoverProps = result.current.getPopoverProps()
+      const triggerProps = result.current.getTriggerProps()
+      expect(popoverProps['data-open']).toBe(false)
+      expect(triggerProps['aria-expanded']).toBe(false)
+
+      result.current.openMenu()
+      const updatedPopoverProps = result.current.getPopoverProps()
+      const updatedTriggerProps = result.current.getTriggerProps()
+      expect(updatedPopoverProps['data-open']).toBe(true)
+      expect(updatedTriggerProps['aria-expanded']).toBe(true)
+    })
+
+    describe('onKeyDown', () => {
+      let mockEvent
+      let mockMenuItems
+      let mockTriggerButton
+
+      const setMockActiveElement = (element: HTMLElement) => {
+        Object.defineProperty(document, 'activeElement', {
+          configurable: true,
+          get: () => element,
+        })
+      }
+
+      beforeEach(() => {
+        mockMenuItems = [
+          {
+            focus: jest.fn(),
+            click: jest.fn(),
+          },
+          {
+            focus: jest.fn(),
+            click: jest.fn(),
+          },
+        ]
+        mockTriggerButton = {
+          focus: jest.fn(),
+        }
+        mockEvent = {
+          currentTarget: {
+            querySelectorAll: () => mockMenuItems,
+            querySelector: () => {
+              return mockTriggerButton
+            },
+          },
+        } as any
+        setMockActiveElement(mockMenuItems[0])
+      })
+
+      it('should focus next item on ArrowDown key press', () => {
+        const { result } = renderHook(() => useMenu())
+
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: 'ArrowDown',
+        })
+        expect(mockMenuItems[1].focus).toHaveBeenCalled()
+        expect(mockMenuItems[0].focus).not.toHaveBeenCalled()
+        setMockActiveElement(mockMenuItems[1])
+
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: 'ArrowDown',
+        })
+        expect(mockMenuItems[0].focus).toHaveBeenCalled()
+      })
+
+      it('should focus previous item on ArrowUp key press', () => {
+        const { result } = renderHook(() => useMenu())
+
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: 'ArrowUp',
+        })
+        // focus to the last item because pressed arrow up key on the first item
+        expect(mockMenuItems[1].focus).toHaveBeenCalled()
+
+        setMockActiveElement(mockMenuItems[1])
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: 'ArrowUp',
+        })
+        expect(mockMenuItems[0].focus).toHaveBeenCalled()
+      })
+
+      it('should focus button and close menu on Escape key press', () => {
+        const { result } = renderHook(() => useMenu())
+        result.current.openMenu()
+        expect(result.current.isOpen).toBe(true)
+
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: 'Escape',
+        })
+
+        expect(result.current.isOpen).toBe(false)
+        expect(mockTriggerButton.focus).toHaveBeenCalled()
+      })
+
+      it('should activate menu item on Enter or Space key press', () => {
+        const { result } = renderHook(() => useMenu())
+
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: 'Enter',
+        })
+        expect(mockMenuItems[0].click).toHaveBeenCalled()
+
+        result.current.getPopoverProps().onKeyDown!({
+          ...mockEvent,
+          key: ' ',
+        })
+        expect(mockMenuItems[0].click).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe('onBlur', () => {
+      it('should close menu if focus moves outside', () => {
+        const { result } = renderHook(() => useMenu())
+        result.current.openMenu()
+        expect(result.current.isOpen).toBe(true)
+
+        result.current.getPopoverProps().onBlur!({
+          currentTarget: {
+            contains: () => false,
+          },
+          relatedTarget: null,
+        } as any)
+        expect(result.current.isOpen).toBe(false)
+      })
+    })
   })
 })

--- a/src/hooks/use-menu/index.tsx
+++ b/src/hooks/use-menu/index.tsx
@@ -29,9 +29,7 @@ export const useMenu = (): useMenu => {
           if (menuItems.length) menuItems[0].focus()
         }
 
-        if (props?.onKeyDown) {
-          props.onKeyDown(e)
-        }
+        props?.onKeyDown?.(e)
       },
       onClick: (e) => {
         setIsOpen((prev) => !prev)

--- a/src/hooks/use-menu/index.tsx
+++ b/src/hooks/use-menu/index.tsx
@@ -20,6 +20,19 @@ export const useMenu = (): useMenu => {
       'aria-haspopup': true,
       'aria-expanded': isOpen,
       role: 'button',
+      onKeyDown: (e) => {
+        if (e.key === 'ArrowDown') {
+          const menuItems = e.currentTarget.parentElement!.querySelectorAll(
+            '[role="menuitem"]',
+          ) as NodeListOf<HTMLElement>
+
+          if (menuItems.length) menuItems[0].focus()
+        }
+
+        if (props?.onKeyDown) {
+          props.onKeyDown(e)
+        }
+      },
       onClick: (e) => {
         setIsOpen((prev) => !prev)
         if (props?.onClick) {
@@ -33,6 +46,48 @@ export const useMenu = (): useMenu => {
     return {
       ...props,
       'data-open': isOpen,
+      // close menu when "focus" move out of menu
+      onBlur: (e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          closeMenu()
+        }
+      },
+      // handle basic navigation key refer to https://www.w3.org/WAI/ARIA/apg/patterns/menubar
+      onKeyDown: (e) => {
+        const menu = e.currentTarget
+        const menuButton = menu?.querySelector('[role="button"]') as HTMLButtonElement
+        const menuItems = menu?.querySelectorAll('[role="menuitem"]') as NodeListOf<HTMLElement>
+
+        let currentIndex = -1
+        menuItems.forEach((item, index) => {
+          if (item === document.activeElement) {
+            currentIndex = index
+          }
+        })
+
+        switch (e.key) {
+          case 'ArrowDown': {
+            const nextItem = menuItems[(currentIndex + 1) % menuItems.length]
+            nextItem.focus()
+            break
+          }
+          case 'ArrowUp': {
+            const prevItem = menuItems[(currentIndex - 1 + menuItems.length) % menuItems.length]
+            prevItem.focus()
+            break
+          }
+          case 'Escape':
+            closeMenu()
+            menuButton.focus()
+            break
+          case 'Enter':
+          case ' ': {
+            const menuItem = menuItems[currentIndex]
+            menuItem.click()
+            break
+          }
+        }
+      },
     }
   }
 


### PR DESCRIPTION
continuing the sequence of pr for menu that have been discussed https://github.com/reapit/elements/issues/163, this is the 4th pr which only focus on keyboard interaction based on https://www.w3.org/WAI/ARIA/apg/patterns/menubar, here I provide basic keyboard interaction only for menu and menu items related component.

an exception here: since the menu doesn't have sub-menu, the keyboard interaction only focus to the menu-button and menu items

# Pull request checklist
- [x] button `arrowDown` handler when menu open
- [x] menu item `arrowUp` and `arrowDown` handler
- [x] menu item `escape` handler
- [x] menu item `enter` and `space` handler
- [x] menu item `tab` handler (close menu when focus move out of menu)

**Detail as per issue below (required):**
- new menu keyboard interaction

![menu item custom handler](https://github.com/user-attachments/assets/4a07ce57-6421-41bb-bb72-74aacde0dc8f)

