### PR TITLE
feat: #164 - add nav icon item component

### DIFF
--- a/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
+++ b/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`NavIconItem should render the component as HTMLAnchorElement 1`] = `
 <DocumentFragment>
   <mock-styled.a
+    aria-label="test icon"
     href="#"
-    role="button"
   >
     <span>
       test
@@ -16,7 +16,7 @@ exports[`NavIconItem should render the component as HTMLAnchorElement 1`] = `
 exports[`NavIconItem should render the component as HTMLButtonElement 1`] = `
 <DocumentFragment>
   <mock-styled.button
-    role="button"
+    aria-label="test icon"
   >
     <span>
       test

--- a/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
+++ b/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavIconItem should render the component as HTMLAnchorElement 1`] = `
+<DocumentFragment>
+  <mock-styled.a
+    href="#"
+    role="button"
+  >
+    <span>
+      test
+    </span>
+  </mock-styled.a>
+</DocumentFragment>
+`;
+
+exports[`NavIconItem should render the component as HTMLButtonElement 1`] = `
+<DocumentFragment>
+  <mock-styled.button
+    role="button"
+  >
+    <span>
+      test
+    </span>
+  </mock-styled.button>
+</DocumentFragment>
+`;

--- a/src/components/nav-icon-item/__tests__/nav-icon-item.test.tsx
+++ b/src/components/nav-icon-item/__tests__/nav-icon-item.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react'
+import { NavIconItem } from '../nav-icon-item'
+
+describe('NavIconItem', () => {
+  it('should render the component as HTMLAnchorElement', () => {
+    expect(render(<NavIconItem href="#" icon={<span>test</span>} />).asFragment()).toMatchSnapshot()
+  })
+
+  it('should render the component as HTMLButtonElement', () => {
+    expect(render(<NavIconItem onClick={() => {}} icon={<span>test</span>} />).asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/nav-icon-item/__tests__/nav-icon-item.test.tsx
+++ b/src/components/nav-icon-item/__tests__/nav-icon-item.test.tsx
@@ -3,10 +3,14 @@ import { NavIconItem } from '../nav-icon-item'
 
 describe('NavIconItem', () => {
   it('should render the component as HTMLAnchorElement', () => {
-    expect(render(<NavIconItem href="#" icon={<span>test</span>} />).asFragment()).toMatchSnapshot()
+    expect(
+      render(<NavIconItem aria-label="test icon" href="#" icon={<span>test</span>} />).asFragment(),
+    ).toMatchSnapshot()
   })
 
   it('should render the component as HTMLButtonElement', () => {
-    expect(render(<NavIconItem onClick={() => {}} icon={<span>test</span>} />).asFragment()).toMatchSnapshot()
+    expect(
+      render(<NavIconItem aria-label="test icon" onClick={() => {}} icon={<span>test</span>} />).asFragment(),
+    ).toMatchSnapshot()
   })
 })

--- a/src/components/nav-icon-item/index.ts
+++ b/src/components/nav-icon-item/index.ts
@@ -1,0 +1,2 @@
+export * from './nav-icon-item'
+export * from './styles'

--- a/src/components/nav-icon-item/nav-icon-item.mdx
+++ b/src/components/nav-icon-item/nav-icon-item.mdx
@@ -14,31 +14,21 @@ A versatile component designed to render navigation icon items within an AppBar
 
 ## Default State
 
-The default appearance of the NavIconItem
+The default appearance of the `NavIconItem`
 
 <Canvas of={NavIconItemStories.Default} />
 
-## Hover State
-
-The visual state of the NavIconItem when the mouse hovers over it
-
-<Canvas of={NavIconItemStories.HoverState} />
-
-## Focus State
-
-The visual state of the NavIconItem when it receives keyboard focus
-
-<Canvas of={NavIconItemStories.FocusState} />
-
 ## Active State
 
-The visual state of the NavIconItem when it's currently selected or active
+The visual state of the `NavIconItem` when it's currently selected or active
 
 <Canvas of={NavIconItemStories.ActiveState} />
 
 ## Style Anchor Usage
 
-Demonstrates how to use the NavIconItem using a standard `HTMLAnchorElement`
+Demonstrates how to use the `NavIconItem` using a standard `HTMLAnchorElement`
+
+**note:** to make the `NavIconItem` have an "active" state, you must pass the `aria-current` attribute with a value of `page`
 
 <Canvas of={NavIconItemStories.StyleAnchorUsage} />
 
@@ -46,7 +36,9 @@ Demonstrates how to use the NavIconItem using a standard `HTMLAnchorElement`
 
 ## Style Button Usage
 
-Demonstrates how to use the NavIconItem using a standard `HTMLButtonElement`
+Demonstrates how to use the `NavIconItem` using a standard `HTMLButtonElement`
+
+**note:** to make the `NavIconItem` have an "active" state, you must pass the `aria-current` attribute with a value of `true`
 
 <Canvas of={NavIconItemStories.StyleButtonUsage} />
 
@@ -54,7 +46,7 @@ Demonstrates how to use the NavIconItem using a standard `HTMLButtonElement`
 
 ## React Anchor Usage
 
-Demonstrates how to render the NavIconItem using a anchor version
+Demonstrates how to render the `NavIconItem` using a anchor version
 
 <Canvas of={NavIconItemStories.ReactAnchorUsage} />
 
@@ -62,7 +54,7 @@ Demonstrates how to render the NavIconItem using a anchor version
 
 ## React Button Usage
 
-Demonstrates how to render the NavIconItem using a button version
+Demonstrates how to render the `NavIconItem` using a button version
 
 <Canvas of={NavIconItemStories.ReactButtonUsage} />
 

--- a/src/components/nav-icon-item/nav-icon-item.mdx
+++ b/src/components/nav-icon-item/nav-icon-item.mdx
@@ -1,0 +1,69 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks'
+import { RenderHtmlMarkup } from '../../storybook/render-html-markup'
+import * as NavIconItemStories from './nav-icon-item.stories'
+
+<Meta of={NavIconItemStories} />
+
+# Nav Icon Item
+
+A versatile component designed to render navigation icon items within an AppBar
+
+`NavIconItem` is backed by `HTMLAnchorElement` and `HTMLButtonElement` to allow for flexibility in rendering the component
+
+<Controls />
+
+## Default State
+
+The default appearance of the NavIconItem
+
+<Canvas of={NavIconItemStories.Default} />
+
+## Hover State
+
+The visual state of the NavIconItem when the mouse hovers over it
+
+<Canvas of={NavIconItemStories.HoverState} />
+
+## Focus State
+
+The visual state of the NavIconItem when it receives keyboard focus
+
+<Canvas of={NavIconItemStories.FocusState} />
+
+## Active State
+
+The visual state of the NavIconItem when it's currently selected or active
+
+<Canvas of={NavIconItemStories.ActiveState} />
+
+## Style Anchor Usage
+
+Demonstrates how to use the NavIconItem using a standard `HTMLAnchorElement`
+
+<Canvas of={NavIconItemStories.StyleAnchorUsage} />
+
+<RenderHtmlMarkup of={NavIconItemStories.StyleAnchorUsage} />
+
+## Style Button Usage
+
+Demonstrates how to use the NavIconItem using a standard `HTMLButtonElement`
+
+<Canvas of={NavIconItemStories.StyleButtonUsage} />
+
+<RenderHtmlMarkup of={NavIconItemStories.StyleButtonUsage} />
+
+## React Anchor Usage
+
+Demonstrates how to render the NavIconItem using a anchor version
+
+<Canvas of={NavIconItemStories.ReactAnchorUsage} />
+
+<RenderHtmlMarkup of={NavIconItemStories.ReactAnchorUsage} />
+
+## React Button Usage
+
+Demonstrates how to render the NavIconItem using a button version
+
+<Canvas of={NavIconItemStories.ReactButtonUsage} />
+
+<RenderHtmlMarkup of={NavIconItemStories.ReactButtonUsage} />

--- a/src/components/nav-icon-item/nav-icon-item.stories.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.stories.tsx
@@ -37,6 +37,9 @@ const meta = {
       description: 'CSS class for additional styling',
     },
   },
+  args: {
+    'aria-label': 'Star Icon',
+  },
 } satisfies Meta<typeof NavIconItem>
 
 export default meta
@@ -44,40 +47,12 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    icon: <Icon icon="star" />,
+    icon: <Icon icon="star" style={{ color: 'inherit' }} />,
     onClick: action('handleOnClick'),
   },
   render: (args) => {
     return (
       <ElButtonNavIconItem onClick={action('handleClick')} data-state={undefined}>
-        {args?.icon}
-      </ElButtonNavIconItem>
-    )
-  },
-}
-
-export const HoverState: Story = {
-  args: {
-    icon: <Icon icon="star" />,
-    onClick: action('handleOnClick'),
-  },
-  render: (args) => {
-    return (
-      <ElButtonNavIconItem onClick={action('handleClick')} data-state="hover">
-        {args?.icon}
-      </ElButtonNavIconItem>
-    )
-  },
-}
-
-export const FocusState: Story = {
-  args: {
-    icon: <Icon icon="star" />,
-    onClick: action('handleOnClick'),
-  },
-  render: (args) => {
-    return (
-      <ElButtonNavIconItem onClick={action('handleClick')} data-state="focus">
         {args?.icon}
       </ElButtonNavIconItem>
     )
@@ -91,7 +66,7 @@ export const ActiveState: Story = {
   },
   render: (args) => {
     return (
-      <ElButtonNavIconItem onClick={action('handleClick')} data-state="active">
+      <ElButtonNavIconItem onClick={action('handleClick')} aria-current="true">
         {args?.icon}
       </ElButtonNavIconItem>
     )
@@ -106,10 +81,10 @@ export const StyleAnchorUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <ElAnchorNavIconItem href={args.href!} data-state={undefined} className="el-mx5">
+        <ElAnchorNavIconItem href={args.href!} aria-current={undefined} className="el-mx5">
           {args?.icon}
         </ElAnchorNavIconItem>
-        <ElAnchorNavIconItem href={args.href!} data-state="active" className="el-mx5">
+        <ElAnchorNavIconItem href={args.href!} aria-current="page" className="el-mx5">
           {args?.icon}
         </ElAnchorNavIconItem>
       </FlexContainer>
@@ -125,10 +100,10 @@ export const StyleButtonUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <ElButtonNavIconItem onClick={action('handleClick')} data-state={undefined} className="el-mx5">
+        <ElButtonNavIconItem onClick={action('handleClick')} aria-current={undefined} className="el-mx5">
           {args?.icon}
         </ElButtonNavIconItem>
-        <ElButtonNavIconItem onClick={action('handleClick')} data-state="active" className="el-mx5">
+        <ElButtonNavIconItem onClick={action('handleClick')} aria-current="true" className="el-mx5">
           {args?.icon}
         </ElButtonNavIconItem>
       </FlexContainer>

--- a/src/components/nav-icon-item/nav-icon-item.stories.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { NavIconItem } from './nav-icon-item'
+import { Icon } from '../icon'
+import { FlexContainer } from '../layout'
+import { ElAnchorNavIconItem, ElButtonNavIconItem } from './styles'
+import { action } from '@storybook/addon-actions'
+
+const meta = {
+  title: 'Components/Nav Icon Item',
+  component: NavIconItem,
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    icon: {
+      control: false,
+      description: 'The icon to be displayed',
+    },
+    isActive: {
+      control: false,
+      description: 'Whether the nav icon item is active or not',
+    },
+    href: {
+      control: false,
+      description: 'Specifies the URL for anchor-style nav icon item',
+    },
+    onClick: {
+      control: false,
+      description: 'Click handler for nav icon item',
+    },
+    'aria-label': {
+      control: false,
+      description: 'Accessible label for button',
+    },
+    className: {
+      control: false,
+      description: 'CSS class for additional styling',
+    },
+  },
+} satisfies Meta<typeof NavIconItem>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleOnClick'),
+  },
+  render: (args) => {
+    return (
+      <ElButtonNavIconItem onClick={action('handleClick')} data-state={undefined}>
+        {args?.icon}
+      </ElButtonNavIconItem>
+    )
+  },
+}
+
+export const HoverState: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleOnClick'),
+  },
+  render: (args) => {
+    return (
+      <ElButtonNavIconItem onClick={action('handleClick')} data-state="hover">
+        {args?.icon}
+      </ElButtonNavIconItem>
+    )
+  },
+}
+
+export const FocusState: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleOnClick'),
+  },
+  render: (args) => {
+    return (
+      <ElButtonNavIconItem onClick={action('handleClick')} data-state="focus">
+        {args?.icon}
+      </ElButtonNavIconItem>
+    )
+  },
+}
+
+export const ActiveState: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleOnClick'),
+  },
+  render: (args) => {
+    return (
+      <ElButtonNavIconItem onClick={action('handleClick')} data-state="active">
+        {args?.icon}
+      </ElButtonNavIconItem>
+    )
+  },
+}
+
+export const StyleAnchorUsage: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    href: '#',
+  },
+  render: (args) => {
+    return (
+      <FlexContainer>
+        <ElAnchorNavIconItem href={args.href!} data-state={undefined} className="el-mx5">
+          {args?.icon}
+        </ElAnchorNavIconItem>
+        <ElAnchorNavIconItem href={args.href!} data-state="active" className="el-mx5">
+          {args?.icon}
+        </ElAnchorNavIconItem>
+      </FlexContainer>
+    )
+  },
+}
+
+export const StyleButtonUsage: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleClick'),
+  },
+  render: (args) => {
+    return (
+      <FlexContainer>
+        <ElButtonNavIconItem onClick={action('handleClick')} data-state={undefined} className="el-mx5">
+          {args?.icon}
+        </ElButtonNavIconItem>
+        <ElButtonNavIconItem onClick={action('handleClick')} data-state="active" className="el-mx5">
+          {args?.icon}
+        </ElButtonNavIconItem>
+      </FlexContainer>
+    )
+  },
+}
+
+export const ReactAnchorUsage: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    href: '#',
+  },
+  render: (args) => {
+    return (
+      <FlexContainer>
+        <NavIconItem {...args} isActive={false} className="el-mx5" />
+        <NavIconItem {...args} isActive={true} className="el-ml2" />
+      </FlexContainer>
+    )
+  },
+}
+
+export const ReactButtonUsage: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleClick'),
+  },
+  render: (args) => {
+    return (
+      <FlexContainer>
+        <NavIconItem {...args} isActive={false} className="el-mx5" />
+        <NavIconItem {...args} isActive={true} className="el-ml2" />
+      </FlexContainer>
+    )
+  },
+}

--- a/src/components/nav-icon-item/nav-icon-item.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.tsx
@@ -1,0 +1,63 @@
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, FC, MouseEventHandler, ReactNode } from 'react'
+import { ElAnchorNavIconItem, ElButtonNavIconItem } from './styles'
+
+interface CommonNavIconItemProps {
+  /**
+   * The JSX element to render as the icon
+   */
+  icon: ReactNode
+
+  /**
+   * Whether the nav item is active
+   * @default false
+   **/
+  isActive?: boolean
+}
+
+interface NavIconItemAsButtonElementProps extends CommonNavIconItemProps, ButtonHTMLAttributes<HTMLButtonElement> {
+  href?: never
+  target?: never
+  ref?: never
+  onClick: MouseEventHandler<HTMLButtonElement>
+}
+
+interface NavIconItemAsAnchorElementProps extends CommonNavIconItemProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+  href?: string
+  target?: string
+  rel?: string
+  onClick?: MouseEventHandler<HTMLAnchorElement>
+}
+
+export type NavIconItemProps = NavIconItemAsButtonElementProps | NavIconItemAsAnchorElementProps
+
+const isButtonElement = (props: NavIconItemProps): props is NavIconItemAsButtonElementProps => {
+  return !props.href
+}
+
+export const NavIconItem: FC<NavIconItemProps> = (props) => {
+  if (!isButtonElement(props)) {
+    const { isActive, onClick, icon, ...rest } = props ?? {}
+
+    return (
+      <ElAnchorNavIconItem
+        {...rest}
+        role="button"
+        data-state={isActive ? 'active' : undefined}
+        onClick={(e) => {
+          e.preventDefault()
+          onClick?.(e)
+        }}
+      >
+        {icon}
+      </ElAnchorNavIconItem>
+    )
+  } else {
+    const { isActive, icon, ...rest } = props ?? {}
+
+    return (
+      <ElButtonNavIconItem {...rest} role="button" data-state={isActive ? 'active' : undefined}>
+        {icon}
+      </ElButtonNavIconItem>
+    )
+  }
+}

--- a/src/components/nav-icon-item/nav-icon-item.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.tsx
@@ -8,20 +8,29 @@ interface CommonNavIconItemProps {
   icon: ReactNode
 
   /**
+   * Defines a string value that labels the current element
+   */
+  'aria-label': string
+
+  /**
    * Whether the nav item is active
    * @default false
    **/
   isActive?: boolean
 }
 
-interface NavIconItemAsButtonElementProps extends CommonNavIconItemProps, ButtonHTMLAttributes<HTMLButtonElement> {
+interface NavIconItemAsButtonElementProps
+  extends CommonNavIconItemProps,
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
   href?: never
   target?: never
-  ref?: never
+  rel?: never
   onClick: MouseEventHandler<HTMLButtonElement>
 }
 
-interface NavIconItemAsAnchorElementProps extends CommonNavIconItemProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+interface NavIconItemAsAnchorElementProps
+  extends CommonNavIconItemProps,
+    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-label'> {
   href?: string
   target?: string
   rel?: string
@@ -35,29 +44,21 @@ const isButtonElement = (props: NavIconItemProps): props is NavIconItemAsButtonE
 }
 
 export const NavIconItem: FC<NavIconItemProps> = (props) => {
-  if (!isButtonElement(props)) {
-    const { isActive, onClick, icon, ...rest } = props ?? {}
+  if (isButtonElement(props)) {
+    const { isActive, icon, ...rest } = props ?? {}
 
     return (
-      <ElAnchorNavIconItem
-        {...rest}
-        role="button"
-        data-state={isActive ? 'active' : undefined}
-        onClick={(e) => {
-          e.preventDefault()
-          onClick?.(e)
-        }}
-      >
+      <ElButtonNavIconItem {...rest} aria-current={isActive ? 'true' : undefined}>
         {icon}
-      </ElAnchorNavIconItem>
+      </ElButtonNavIconItem>
     )
   } else {
     const { isActive, icon, ...rest } = props ?? {}
 
     return (
-      <ElButtonNavIconItem {...rest} role="button" data-state={isActive ? 'active' : undefined}>
+      <ElAnchorNavIconItem {...rest} aria-current={isActive ? 'page' : undefined}>
         {icon}
-      </ElButtonNavIconItem>
+      </ElAnchorNavIconItem>
     )
   }
 }

--- a/src/components/nav-icon-item/nav-icon-item.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.tsx
@@ -23,8 +23,6 @@ interface NavIconItemAsButtonElementProps
   extends CommonNavIconItemProps,
     Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
   href?: never
-  target?: never
-  rel?: never
   onClick: MouseEventHandler<HTMLButtonElement>
 }
 
@@ -32,8 +30,6 @@ interface NavIconItemAsAnchorElementProps
   extends CommonNavIconItemProps,
     Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-label'> {
   href?: string
-  target?: string
-  rel?: string
   onClick?: MouseEventHandler<HTMLAnchorElement>
 }
 
@@ -43,6 +39,12 @@ const isButtonElement = (props: NavIconItemProps): props is NavIconItemAsButtonE
   return !props.href
 }
 
+/**
+ * The `NavIconItem` component is a small part of `AppBar` component
+ * It's used to render a nav item with an icon
+ *
+ * To ensure it's aligned with the design, the children component should have a CSS color property with 'inherit' value
+ */
 export const NavIconItem: FC<NavIconItemProps> = (props) => {
   if (isButtonElement(props)) {
     const { isActive, icon, ...rest } = props ?? {}

--- a/src/components/nav-icon-item/styles.ts
+++ b/src/components/nav-icon-item/styles.ts
@@ -2,6 +2,8 @@ import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
 import { styled } from '@linaria/react'
 import { ElIcon } from '../icon'
 
+// TODO: add red dot integration
+// TODO: add tooltip integration on hover state
 const baseStyles = `
   display: inline-flex;
   padding: var(--space-2, 8px);

--- a/src/components/nav-icon-item/styles.ts
+++ b/src/components/nav-icon-item/styles.ts
@@ -1,0 +1,61 @@
+import { styled } from '@linaria/react'
+import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
+
+type CommonNavIconItemProps = {
+  /**
+   * NOTE: data attribute to indicate the state of the nav item
+   * by default the styles is already applied with pseudo-class selector
+   * but to make it more flexible, consumer could use this attribute to
+   * change the styles
+   */
+  'data-state'?: 'focus' | 'hover' | 'active'
+}
+
+const baseStyles = `
+  display: inline-flex;
+  padding: var(--spacing-2, 8px);
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-none, 0px);
+  border-radius: var(--corner-default, 0.25rem);
+  background: var(--white, #ffffff);
+  border: none;
+  outline: none;
+
+  /* change children color by default */
+  > * {
+    color: var(--neutral-400, #798da1) !important;
+  }
+
+  &:focus, &[data-state='focus'] {
+    border-radius: var(--corner-default, 0.25rem);
+    background: var(--white, #ffffff);
+    box-shadow:
+      0px 0px 0px 1px #fff,
+      0px 0px 0px 4px var(--icon-button_primary-hover, #7e9bfa);
+  }
+
+  &:hover, &[data-state='hover'] {
+    cursor: pointer;
+    border-radius: var(--corner-default, 0.25rem);
+    background: var(--neutral-050, #f2f4f6);
+  }
+
+  &:active, &[data-state='active'] {
+    > * {
+      color: var(--intent-primary, #4e56ea) !important;
+    }
+    border-radius: var(--corner-default, 0.25rem);
+    background: var(--neutral-050, #f2f4f6);
+  }
+`
+
+type ElButtonNavIconItemProps = ButtonHTMLAttributes<HTMLButtonElement> & CommonNavIconItemProps
+export const ElButtonNavIconItem = styled.button<ElButtonNavIconItemProps>`
+  ${baseStyles}
+`
+
+type ElAnchorNavIconItemProps = AnchorHTMLAttributes<HTMLAnchorElement> & CommonNavIconItemProps
+export const ElAnchorNavIconItem = styled.a<ElAnchorNavIconItemProps>`
+  ${baseStyles}
+`

--- a/src/components/nav-icon-item/styles.ts
+++ b/src/components/nav-icon-item/styles.ts
@@ -1,61 +1,52 @@
-import { styled } from '@linaria/react'
 import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
-
-type CommonNavIconItemProps = {
-  /**
-   * NOTE: data attribute to indicate the state of the nav item
-   * by default the styles is already applied with pseudo-class selector
-   * but to make it more flexible, consumer could use this attribute to
-   * change the styles
-   */
-  'data-state'?: 'focus' | 'hover' | 'active'
-}
+import { styled } from '@linaria/react'
+import { ElIcon } from '../icon'
 
 const baseStyles = `
   display: inline-flex;
-  padding: var(--spacing-2, 8px);
+  padding: var(--space-2, 8px);
   justify-content: center;
   align-items: center;
-  gap: var(--spacing-none, 0px);
-  border-radius: var(--corner-default, 0.25rem);
-  background: var(--white, #ffffff);
-  border: none;
+  gap: var(--space-none, 0px);
+  border-radius: var(--corner-default, 4px);
+  background: var(--fill-white, #ffffff);
+  border: var(--border-none, 0px);
+  color: var(--icon-app_bar-default, #798da1);
   outline: none;
 
-  /* change children color by default */
-  > * {
-    color: var(--neutral-400, #798da1) !important;
-  }
-
-  &:focus, &[data-state='focus'] {
-    border-radius: var(--corner-default, 0.25rem);
-    background: var(--white, #ffffff);
+  &:focus-visible {
+    border-radius: var(--corner-default, 4px);
+    background: var(--fill-white, #ffffff);
     box-shadow:
       0px 0px 0px 1px #fff,
       0px 0px 0px 4px var(--icon-button_primary-hover, #7e9bfa);
   }
 
-  &:hover, &[data-state='hover'] {
+  &:hover {
     cursor: pointer;
-    border-radius: var(--corner-default, 0.25rem);
-    background: var(--neutral-050, #f2f4f6);
+    border-radius: var(--corner-default, 4px);
+    background: var(--fill-default-lightest, #f2f4f6);
   }
 
-  &:active, &[data-state='active'] {
-    > * {
-      color: var(--intent-primary, #4e56ea) !important;
-    }
-    border-radius: var(--corner-default, 0.25rem);
-    background: var(--neutral-050, #f2f4f6);
+  &:active, &[aria-current="page"], &[aria-current="true"] {
+    color: var(--fill-action-dark, #4e56ea);
+    border-radius: var(--corner-default, 4px);
+    background: var(--fill-default-lightest, #f2f4f6);
   }
 `
 
-type ElButtonNavIconItemProps = ButtonHTMLAttributes<HTMLButtonElement> & CommonNavIconItemProps
-export const ElButtonNavIconItem = styled.button<ElButtonNavIconItemProps>`
+export const ElButtonNavIconItem = styled.button<ButtonHTMLAttributes<HTMLButtonElement>>`
   ${baseStyles}
+
+  ${ElIcon} {
+    color: inherit;
+  }
 `
 
-type ElAnchorNavIconItemProps = AnchorHTMLAttributes<HTMLAnchorElement> & CommonNavIconItemProps
-export const ElAnchorNavIconItem = styled.a<ElAnchorNavIconItemProps>`
+export const ElAnchorNavIconItem = styled.a<AnchorHTMLAttributes<HTMLAnchorElement>>`
   ${baseStyles}
+
+  ${ElIcon} {
+    color: inherit;
+  }
 `


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**
Following on the discussion on #164 , we've made an agreement on separating the `NavIconItem` and `BottomBarItem` as a different component

**Context:**
The `NavIconItem` component is a small part of the `AppBar` component. It appears as a secondary navigation item on the AppBar when the screen width exceeds 1440 pixels (see the placement on the image attachment)

This PR initiates the construction of the `NavIconItem` component. It prioritizes the implementation of fundamental states (default, focus, hover, and active) while deferring the addition of supplementary elements such as tooltips and indicators. Further deliberation with the design team is required to finalize these details

**View Preview:**

https://github.com/user-attachments/assets/8d851872-3769-492d-b217-ca153ec2b526

**[Design Specification](https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=16-4749&node-type=frame&m=dev):**
![{756E86AF-D52F-4B0C-B90F-09233B57CF15}](https://github.com/user-attachments/assets/134b5d3d-486a-4170-9da0-0ef820e1f47d)

**[Future placement on AppBar component](https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=15-3629&node-type=frame&m=dev):**
![image](https://github.com/user-attachments/assets/123a0f23-11b9-4b7a-ad1e-074d8b23039e)
