### PR TITLE
feat: #164 - add simple red dot badge to NavIconItem

### DIFF
--- a/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
+++ b/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
@@ -24,3 +24,18 @@ exports[`NavIconItem should render the component as HTMLButtonElement 1`] = `
   </mock-styled.button>
 </DocumentFragment>
 `;
+
+exports[`NavIconItem should render the component with a badge 1`] = `
+<DocumentFragment>
+  <mock-styled.button
+    aria-label="test icon"
+  >
+    <span>
+      test
+    </span>
+    <mock-styled.span
+      role="status"
+    />
+  </mock-styled.button>
+</DocumentFragment>
+`;

--- a/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
+++ b/src/components/nav-icon-item/__tests__/__snapshots__/nav-icon-item.test.tsx.snap
@@ -33,9 +33,7 @@ exports[`NavIconItem should render the component with a badge 1`] = `
     <span>
       test
     </span>
-    <mock-styled.span
-      role="status"
-    />
+    <mock-styled.span />
   </mock-styled.button>
 </DocumentFragment>
 `;

--- a/src/components/nav-icon-item/__tests__/nav-icon-item.test.tsx
+++ b/src/components/nav-icon-item/__tests__/nav-icon-item.test.tsx
@@ -13,4 +13,10 @@ describe('NavIconItem', () => {
       render(<NavIconItem aria-label="test icon" onClick={() => {}} icon={<span>test</span>} />).asFragment(),
     ).toMatchSnapshot()
   })
+
+  it('should render the component with a badge', () => {
+    expect(
+      render(<NavIconItem aria-label="test icon" onClick={() => {}} icon={<span>test</span>} hasBadge />).asFragment(),
+    ).toMatchSnapshot()
+  })
 })

--- a/src/components/nav-icon-item/nav-icon-item.mdx
+++ b/src/components/nav-icon-item/nav-icon-item.mdx
@@ -24,6 +24,12 @@ The visual state of the `NavIconItem` when it's currently selected or active
 
 <Canvas of={NavIconItemStories.ActiveState} />
 
+## Badge State
+
+The visual state of the `NavIconItem` when it's currently selected or active with a badge
+
+<Canvas of={NavIconItemStories.BadgeState} />
+
 ## Style Anchor Usage
 
 Demonstrates how to use the `NavIconItem` using a standard `HTMLAnchorElement`

--- a/src/components/nav-icon-item/nav-icon-item.stories.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { NavIconItem } from './nav-icon-item'
 import { Icon } from '../icon'
 import { FlexContainer } from '../layout'
-import { ElAnchorNavIconItem, ElButtonNavIconItem } from './styles'
+import { ElAnchorNavIconItem, ElButtonNavIconItem, ElNavIconItemBadge } from './styles'
 import { action } from '@storybook/addon-actions'
 
 const meta = {
@@ -19,6 +19,10 @@ const meta = {
     isActive: {
       control: false,
       description: 'Whether the nav icon item is active or not',
+    },
+    hasBadge: {
+      control: false,
+      description: 'Whether the nav icon item has a badge or not',
     },
     href: {
       control: false,
@@ -73,6 +77,22 @@ export const ActiveState: Story = {
   },
 }
 
+export const BadgeState: Story = {
+  args: {
+    icon: <Icon icon="star" />,
+    onClick: action('handleOnClick'),
+    hasBadge: true,
+  },
+  render: (args) => {
+    return (
+      <ElButtonNavIconItem onClick={action('handleClick')}>
+        {args?.icon}
+        <ElNavIconItemBadge role="status" />
+      </ElButtonNavIconItem>
+    )
+  },
+}
+
 export const StyleAnchorUsage: Story = {
   args: {
     icon: <Icon icon="star" />,
@@ -81,11 +101,15 @@ export const StyleAnchorUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <ElAnchorNavIconItem href={args.href!} aria-current={undefined} className="el-mx5">
+        <ElAnchorNavIconItem href={args.href!} aria-current={undefined} className="el-mr5">
           {args?.icon}
         </ElAnchorNavIconItem>
         <ElAnchorNavIconItem href={args.href!} aria-current="page" className="el-mx5">
           {args?.icon}
+        </ElAnchorNavIconItem>
+        <ElAnchorNavIconItem href={args.href!} aria-current={undefined} className="el-mx5">
+          {args?.icon}
+          <ElNavIconItemBadge role="status" />
         </ElAnchorNavIconItem>
       </FlexContainer>
     )
@@ -100,11 +124,15 @@ export const StyleButtonUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <ElButtonNavIconItem onClick={action('handleClick')} aria-current={undefined} className="el-mx5">
+        <ElButtonNavIconItem onClick={action('handleClick')} aria-current={undefined} className="el-mr5">
           {args?.icon}
         </ElButtonNavIconItem>
         <ElButtonNavIconItem onClick={action('handleClick')} aria-current="true" className="el-mx5">
           {args?.icon}
+        </ElButtonNavIconItem>
+        <ElButtonNavIconItem onClick={action('handleClick')} aria-current={undefined} className="el-mx5">
+          {args?.icon}
+          <ElNavIconItemBadge role="status" />
         </ElButtonNavIconItem>
       </FlexContainer>
     )
@@ -119,8 +147,9 @@ export const ReactAnchorUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <NavIconItem {...args} isActive={false} className="el-mx5" />
-        <NavIconItem {...args} isActive={true} className="el-ml2" />
+        <NavIconItem {...args} isActive={false} className="el-mr5" />
+        <NavIconItem {...args} isActive={true} className="el-mx5" />
+        <NavIconItem {...args} hasBadge={true} className="el-mx5" />
       </FlexContainer>
     )
   },
@@ -134,8 +163,9 @@ export const ReactButtonUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <NavIconItem {...args} isActive={false} className="el-mx5" />
-        <NavIconItem {...args} isActive={true} className="el-ml2" />
+        <NavIconItem {...args} isActive={false} className="el-mr5" />
+        <NavIconItem {...args} isActive={true} className="el-mx5" />
+        <NavIconItem {...args} hasBadge={true} className="el-mx5" />
       </FlexContainer>
     )
   },

--- a/src/components/nav-icon-item/nav-icon-item.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.tsx
@@ -58,7 +58,7 @@ export const NavIconItem: FC<NavIconItemProps> = (props) => {
     return (
       <ElButtonNavIconItem {...rest} aria-current={isActive ? 'true' : undefined}>
         {icon}
-        {hasBadge && <ElNavIconItemBadge role="status" />}
+        {hasBadge && <ElNavIconItemBadge />}
       </ElButtonNavIconItem>
     )
   } else {
@@ -67,7 +67,7 @@ export const NavIconItem: FC<NavIconItemProps> = (props) => {
     return (
       <ElAnchorNavIconItem {...rest} aria-current={isActive ? 'page' : undefined}>
         {icon}
-        {hasBadge && <ElNavIconItemBadge role="status" />}
+        {hasBadge && <ElNavIconItemBadge />}
       </ElAnchorNavIconItem>
     )
   }

--- a/src/components/nav-icon-item/nav-icon-item.tsx
+++ b/src/components/nav-icon-item/nav-icon-item.tsx
@@ -1,5 +1,5 @@
 import { AnchorHTMLAttributes, ButtonHTMLAttributes, FC, MouseEventHandler, ReactNode } from 'react'
-import { ElAnchorNavIconItem, ElButtonNavIconItem } from './styles'
+import { ElAnchorNavIconItem, ElButtonNavIconItem, ElNavIconItemBadge } from './styles'
 
 interface CommonNavIconItemProps {
   /**
@@ -17,6 +17,12 @@ interface CommonNavIconItemProps {
    * @default false
    **/
   isActive?: boolean
+
+  /**
+   * Optional badge to be displayed on the nav item
+   * @default false
+   */
+  hasBadge?: boolean
 }
 
 interface NavIconItemAsButtonElementProps
@@ -47,19 +53,21 @@ const isButtonElement = (props: NavIconItemProps): props is NavIconItemAsButtonE
  */
 export const NavIconItem: FC<NavIconItemProps> = (props) => {
   if (isButtonElement(props)) {
-    const { isActive, icon, ...rest } = props ?? {}
+    const { isActive, icon, hasBadge, ...rest } = props ?? {}
 
     return (
       <ElButtonNavIconItem {...rest} aria-current={isActive ? 'true' : undefined}>
         {icon}
+        {hasBadge && <ElNavIconItemBadge role="status" />}
       </ElButtonNavIconItem>
     )
   } else {
-    const { isActive, icon, ...rest } = props ?? {}
+    const { isActive, icon, hasBadge, ...rest } = props ?? {}
 
     return (
       <ElAnchorNavIconItem {...rest} aria-current={isActive ? 'page' : undefined}>
         {icon}
+        {hasBadge && <ElNavIconItemBadge role="status" />}
       </ElAnchorNavIconItem>
     )
   }

--- a/src/components/nav-icon-item/styles.ts
+++ b/src/components/nav-icon-item/styles.ts
@@ -2,9 +2,9 @@ import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
 import { styled } from '@linaria/react'
 import { ElIcon } from '../icon'
 
-// TODO: add red dot integration
 // TODO: add tooltip integration on hover state
 const baseStyles = `
+  position: relative;
   display: inline-flex;
   padding: var(--space-2, 8px);
   justify-content: center;
@@ -35,6 +35,16 @@ const baseStyles = `
     border-radius: var(--corner-default, 4px);
     background: var(--fill-default-lightest, #f2f4f6);
   }
+`
+
+export const ElNavIconItemBadge = styled.span`
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  width: var(--size-2, 8px);
+  height: var(--size-2, 8px);
+  background-color: var(--icon-error, #f01830);
+  border-radius: 100%;
 `
 
 export const ElButtonNavIconItem = styled.button<ButtonHTMLAttributes<HTMLButtonElement>>`


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**
part of #164 

Based on the [ticket discussion](https://github.com/reapit/elements/issues/164#issuecomment-2463641777), we're slightly agree to have the simple "red dot" within the `NavIconItem` component

Design Spec https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=18-6156&node-type=instance&m=dev

![{465ADA44-3707-4ECD-BD91-C18B971F2E7A}](https://github.com/user-attachments/assets/ee5e03a0-8c1d-4ffe-81da-ae87a4387690)



