### PR TITLE
feat: #192 - add simple red dot badge to BottomBarItem

### DIFF
--- a/src/components/bottom-bar-item/__tests__/__snapshots__/bottom-bar-item.test.tsx.snap
+++ b/src/components/bottom-bar-item/__tests__/__snapshots__/bottom-bar-item.test.tsx.snap
@@ -73,9 +73,7 @@ exports[`BottomBarItem should render the component as HTMLButtonElement with bad
     <mock-styled.span>
       Label
     </mock-styled.span>
-    <mock-styled.span
-      role="status"
-    />
+    <mock-styled.span />
   </mock-styled.button>
 </DocumentFragment>
 `;

--- a/src/components/bottom-bar-item/__tests__/__snapshots__/bottom-bar-item.test.tsx.snap
+++ b/src/components/bottom-bar-item/__tests__/__snapshots__/bottom-bar-item.test.tsx.snap
@@ -58,6 +58,28 @@ exports[`BottomBarItem should render the component as HTMLButtonElement with act
 </DocumentFragment>
 `;
 
+exports[`BottomBarItem should render the component as HTMLButtonElement with badge state 1`] = `
+<DocumentFragment>
+  <mock-styled.button
+    aria-current="true"
+  >
+    <mock-styled.div
+      role="presentation"
+    >
+      <span>
+        icon
+      </span>
+    </mock-styled.div>
+    <mock-styled.span>
+      Label
+    </mock-styled.span>
+    <mock-styled.span
+      role="status"
+    />
+  </mock-styled.button>
+</DocumentFragment>
+`;
+
 exports[`BottomBarItem should render the component as HTMLButtonElement with default state 1`] = `
 <DocumentFragment>
   <mock-styled.button

--- a/src/components/bottom-bar-item/__tests__/bottom-bar-item.test.tsx
+++ b/src/components/bottom-bar-item/__tests__/bottom-bar-item.test.tsx
@@ -41,4 +41,14 @@ describe('BottomBarItem', () => {
       ).asFragment(),
     ).toMatchSnapshot()
   })
+
+  it('should render the component as HTMLButtonElement with badge state', () => {
+    expect(
+      render(
+        <BottomBarItem onClick={jest.fn()} isActive icon={<span>icon</span>} hasBadge>
+          Label
+        </BottomBarItem>,
+      ).asFragment(),
+    ).toMatchSnapshot()
+  })
 })

--- a/src/components/bottom-bar-item/bottom-bar-item.mdx
+++ b/src/components/bottom-bar-item/bottom-bar-item.mdx
@@ -24,6 +24,12 @@ The visual state of the `BottomBarItem` when it's currently selected or active
 
 <Canvas of={BottomBarItemStories.ActiveState} />
 
+## Badge State
+
+The visual state of the `BottomBarItem` when it's currently selected or active with a badge
+
+<Canvas of={BottomBarItemStories.BadgeState} />
+
 ## Style Anchor Usage
 
 Demonstrates how to use the `BottomBarItem` using a standard `HTMLAnchorElement`

--- a/src/components/bottom-bar-item/bottom-bar-item.stories.tsx
+++ b/src/components/bottom-bar-item/bottom-bar-item.stories.tsx
@@ -6,6 +6,7 @@ import { FlexContainer } from '../layout'
 import { Icon } from '../icon'
 import {
   ElAnchorBottomBarItemContainer,
+  ElBottomBarItemBadge,
   ElBottomBarItemIcon,
   ElBottomBarItemLabel,
   ElButtonBottomBarItemContainer,
@@ -25,6 +26,10 @@ const meta = {
     isActive: {
       control: false,
       description: 'Whether the bottom bar item is active or not',
+    },
+    hasBadge: {
+      control: false,
+      description: 'Whether the bottom bar item has a badge or not',
     },
     href: {
       control: false,
@@ -64,6 +69,13 @@ export const ActiveState: Story = {
   },
 }
 
+export const BadgeState: Story = {
+  args: {
+    children: 'Label',
+    icon: <Icon icon="star" />,
+    hasBadge: true,
+  },
+}
 export const StyleAnchorUsage: Story = {
   args: {
     href: '#',
@@ -73,7 +85,7 @@ export const StyleAnchorUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <ElAnchorBottomBarItemContainer href={args.href} aria-current={undefined} className="el-mx5">
+        <ElAnchorBottomBarItemContainer href={args.href} aria-current={undefined} className="el-mr5">
           <ElBottomBarItemIcon>{args?.icon}</ElBottomBarItemIcon>
           <ElBottomBarItemLabel>{args?.children}</ElBottomBarItemLabel>
         </ElAnchorBottomBarItemContainer>
@@ -81,6 +93,12 @@ export const StyleAnchorUsage: Story = {
         <ElAnchorBottomBarItemContainer href={args.href} aria-current="page" className="el-mx5">
           <ElBottomBarItemIcon>{args?.icon}</ElBottomBarItemIcon>
           <ElBottomBarItemLabel>{args?.children}</ElBottomBarItemLabel>
+        </ElAnchorBottomBarItemContainer>
+
+        <ElAnchorBottomBarItemContainer href={args.href} aria-current={undefined} className="el-mx5">
+          <ElBottomBarItemIcon>{args?.icon}</ElBottomBarItemIcon>
+          <ElBottomBarItemLabel>{args?.children}</ElBottomBarItemLabel>
+          <ElBottomBarItemBadge role="status" />
         </ElAnchorBottomBarItemContainer>
       </FlexContainer>
     )
@@ -95,7 +113,7 @@ export const StyleButtonUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <ElButtonBottomBarItemContainer onClick={action('handleClick')} aria-current={undefined} className="el-mx5">
+        <ElButtonBottomBarItemContainer onClick={action('handleClick')} aria-current={undefined} className="el-mr5">
           <ElBottomBarItemIcon>{args?.icon}</ElBottomBarItemIcon>
           <ElBottomBarItemLabel>{args?.children}</ElBottomBarItemLabel>
         </ElButtonBottomBarItemContainer>
@@ -103,6 +121,12 @@ export const StyleButtonUsage: Story = {
         <ElButtonBottomBarItemContainer onClick={action('handleClick')} aria-current="true" className="el-mx5">
           <ElBottomBarItemIcon>{args?.icon}</ElBottomBarItemIcon>
           <ElBottomBarItemLabel>{args?.children}</ElBottomBarItemLabel>
+        </ElButtonBottomBarItemContainer>
+
+        <ElButtonBottomBarItemContainer onClick={action('handleClick')} aria-current={undefined} className="el-mx5">
+          <ElBottomBarItemIcon>{args?.icon}</ElBottomBarItemIcon>
+          <ElBottomBarItemLabel>{args?.children}</ElBottomBarItemLabel>
+          <ElBottomBarItemBadge role="status" />
         </ElButtonBottomBarItemContainer>
       </FlexContainer>
     )
@@ -118,8 +142,9 @@ export const ReactAnchorUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <BottomBarItem {...args} isActive={false} className="el-mx5" />
+        <BottomBarItem {...args} isActive={false} className="el-mr5" />
         <BottomBarItem {...args} isActive className="el-mx5" />
+        <BottomBarItem {...args} hasBadge className="el-mx5" />
       </FlexContainer>
     )
   },
@@ -134,8 +159,9 @@ export const ReactButtonUsage: Story = {
   render: (args) => {
     return (
       <FlexContainer>
-        <BottomBarItem {...args} isActive={false} className="el-mx5" />
+        <BottomBarItem {...args} isActive={false} className="el-mr5" />
         <BottomBarItem {...args} isActive className="el-mx5" />
+        <BottomBarItem {...args} hasBadge className="el-mx5" />
       </FlexContainer>
     )
   },

--- a/src/components/bottom-bar-item/bottom-bar-item.tsx
+++ b/src/components/bottom-bar-item/bottom-bar-item.tsx
@@ -70,7 +70,7 @@ export const BottomBarItem: FC<BottomBarItemProps> = (props) => {
       <ElButtonBottomBarItemContainer {...rest} aria-current={isActive ? 'true' : undefined}>
         <ElBottomBarItemIcon role="presentation">{icon}</ElBottomBarItemIcon>
         <ElBottomBarItemLabel>{children}</ElBottomBarItemLabel>
-        {hasBadge && <ElBottomBarItemBadge role="status" />}
+        {hasBadge && <ElBottomBarItemBadge />}
       </ElButtonBottomBarItemContainer>
     )
   } else {
@@ -80,7 +80,7 @@ export const BottomBarItem: FC<BottomBarItemProps> = (props) => {
       <ElAnchorBottomBarItemContainer {...rest} aria-current={isActive ? 'page' : undefined}>
         <ElBottomBarItemIcon role="presentation">{icon}</ElBottomBarItemIcon>
         <ElBottomBarItemLabel>{children}</ElBottomBarItemLabel>
-        {hasBadge && <ElBottomBarItemBadge role="status" />}
+        {hasBadge && <ElBottomBarItemBadge />}
       </ElAnchorBottomBarItemContainer>
     )
   }

--- a/src/components/bottom-bar-item/bottom-bar-item.tsx
+++ b/src/components/bottom-bar-item/bottom-bar-item.tsx
@@ -1,6 +1,7 @@
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes, FC, MouseEventHandler, ReactNode } from 'react'
 import {
   ElAnchorBottomBarItemContainer,
+  ElBottomBarItemBadge,
   ElBottomBarItemIcon,
   ElBottomBarItemLabel,
   ElButtonBottomBarItemContainer,
@@ -27,6 +28,13 @@ interface CommonBottomBarItemProps {
    * @default false
    **/
   isActive?: boolean
+
+  /**
+   * Optional badge to be displayed on the bottom bar item
+   *
+   * @default false
+   */
+  hasBadge?: boolean
 }
 
 interface BottomBarItemAsButtonElementProps
@@ -56,21 +64,23 @@ const isButtonElement = (props: BottomBarItemProps): props is BottomBarItemAsBut
  */
 export const BottomBarItem: FC<BottomBarItemProps> = (props) => {
   if (isButtonElement(props)) {
-    const { isActive, icon, children, ...rest } = props ?? {}
+    const { isActive, icon, hasBadge, children, ...rest } = props ?? {}
 
     return (
       <ElButtonBottomBarItemContainer {...rest} aria-current={isActive ? 'true' : undefined}>
         <ElBottomBarItemIcon role="presentation">{icon}</ElBottomBarItemIcon>
         <ElBottomBarItemLabel>{children}</ElBottomBarItemLabel>
+        {hasBadge && <ElBottomBarItemBadge role="status" />}
       </ElButtonBottomBarItemContainer>
     )
   } else {
-    const { isActive, icon, children, ...rest } = props ?? {}
+    const { isActive, icon, hasBadge, children, ...rest } = props ?? {}
 
     return (
       <ElAnchorBottomBarItemContainer {...rest} aria-current={isActive ? 'page' : undefined}>
         <ElBottomBarItemIcon role="presentation">{icon}</ElBottomBarItemIcon>
         <ElBottomBarItemLabel>{children}</ElBottomBarItemLabel>
+        {hasBadge && <ElBottomBarItemBadge role="status" />}
       </ElAnchorBottomBarItemContainer>
     )
   }

--- a/src/components/bottom-bar-item/styles.ts
+++ b/src/components/bottom-bar-item/styles.ts
@@ -19,10 +19,10 @@ export const ElBottomBarItemLabel = styled.span`
   letter-spacing: var(--letter-spacing-2xs, 0px);
 `
 
-// TODO: add red dot integration
 const baseStyles = `
   background-color: var(--fill-white, white);
   outline: none;
+  width: 44px; 
   border: var(--border-none, 0);
   display: flex;
   cursor: pointer;
@@ -37,7 +37,16 @@ const baseStyles = `
   &:active, &[aria-current="true"], &[aria-current="page"] {
     color: var(--icon-action, #4e56ea)
   }
+`
 
+export const ElBottomBarItemBadge = styled.span`
+  position: absolute;
+  top: 1px;
+  right: 6px;
+  width: var(--size-2, 8px);
+  height: var(--size-2, 8px);
+  background-color: var(--icon-error, #f01830);
+  border-radius: 100%;
 `
 
 export const ElAnchorBottomBarItemContainer = styled.a<AnchorHTMLAttributes<HTMLAnchorElement>>`


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**
part of #192 

Based on the Ticket NavIconItem [discussion](https://github.com/reapit/elements/issues/164#issuecomment-2463641777), we're slightly agree to have the simple "red dot" within the BottomBarItem component

Design spec https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=16-4741&node-type=ellipse&m=dev

![{56541F53-31AC-474D-8A17-D8CE7393F87C}](https://github.com/user-attachments/assets/ab87306f-d749-4c8d-b89f-e2e88ccd9dce)


