### PR TITLE
fix: Menu onBlur trigger before trigger click handler

### DIFF
--- a/src/hooks/use-menu/__tests__/index.test.tsx
+++ b/src/hooks/use-menu/__tests__/index.test.tsx
@@ -217,6 +217,23 @@ describe('useMenu', () => {
         } as any)
         expect(result.current.isOpen).toBe(false)
       })
+
+      it('should not close menu if focus moves outside by clicking trigger button', () => {
+        const { result } = renderHook(() => useMenu())
+        result.current.openMenu()
+        expect(result.current.isOpen).toBe(true)
+
+        result.current.getPopoverProps().onBlur!({
+          currentTarget: {
+            contains: () => false,
+            parentElement: {
+              querySelector: () => 'trigger button',
+            },
+          },
+          relatedTarget: 'trigger button',
+        } as any)
+        expect(result.current.isOpen).toBe(true)
+      })
     })
   })
 })

--- a/src/hooks/use-menu/__tests__/index.test.tsx
+++ b/src/hooks/use-menu/__tests__/index.test.tsx
@@ -218,7 +218,7 @@ describe('useMenu', () => {
         expect(result.current.isOpen).toBe(false)
       })
 
-      it('should not close menu if focus moves outside by clicking trigger button', () => {
+      it('should not close the menu on blur if focus is moving to the trigger button.', () => {
         const { result } = renderHook(() => useMenu())
         result.current.openMenu()
         expect(result.current.isOpen).toBe(true)

--- a/src/hooks/use-menu/index.tsx
+++ b/src/hooks/use-menu/index.tsx
@@ -46,7 +46,8 @@ export const useMenu = (): useMenu => {
       'data-open': isOpen,
       // close menu when "focus" move out of menu
       onBlur: (e) => {
-        if (!e.currentTarget.contains(e.relatedTarget)) {
+        const triggerButton = e.currentTarget.parentElement?.querySelector('[role="button"]')
+        if (!e.currentTarget.contains(e.relatedTarget) && e.relatedTarget !== triggerButton) {
           closeMenu()
         }
       },


### PR DESCRIPTION
When a menu item is clicked and configured to keep the menu open, it receives focus. An onBlur handler is set to close the menu when focus moves outside the Menu, causing an issue when focus shifts to the trigger button. The fix is to prevent the onBlur handler from executing if the focus is moving to the trigger button. 

![onblur issue](https://github.com/user-attachments/assets/9a3899df-5906-48c4-8d3d-2673674f7dc5)
# Pull request checklist

**Detail as per issue below (required):**

fixes: 
- part of the #163 

fixed result:
![onblur issue fix](https://github.com/user-attachments/assets/eb684434-03bf-481e-94e5-744936c50514)
