### PR TITLE
chore: #137 Deprecate previous avatar in preparation for new avatar

### DIFF
--- a/src/components/avatar/__styles__/index.ts
+++ b/src/components/avatar/__styles__/index.ts
@@ -1,9 +1,11 @@
 import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
+/** @deprecated */
 export const elAvatarSmall = css``
 
-export const ElAvatar = styled.div`
+/** @deprecated will be replaced by new v5 ElAvatarRectangle */
+export const ElDeprecatedAvatar = styled.div`
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -29,7 +31,8 @@ export const ElAvatar = styled.div`
   }
 `
 
-export const ElAvatarImage = styled(ElAvatar)`
+/** @deprecated will be removed in future version */
+export const ElDeprecatedAvatarImage = styled(ElDeprecatedAvatar)`
   border-radius: 0;
   width: 4.5rem;
   height: 3.25rem;

--- a/src/components/avatar/__tests__/avatar.test.tsx
+++ b/src/components/avatar/__tests__/avatar.test.tsx
@@ -1,19 +1,19 @@
 import { render } from '@testing-library/react'
-import { Avatar } from '..'
+import { DeprecatedAvatar } from '..'
 
 describe('Avatar component', () => {
   it('should match a snapshot', () => {
-    const wrapper = render(<Avatar>Some Content</Avatar>)
+    const wrapper = render(<DeprecatedAvatar>Some Content</DeprecatedAvatar>)
     expect(wrapper).toMatchSnapshot()
   })
 
   it('should match a snapshot for an image src', () => {
-    const wrapper = render(<Avatar src="https://picsum.photos/200" />)
+    const wrapper = render(<DeprecatedAvatar src="https://picsum.photos/200" />)
     expect(wrapper).toMatchSnapshot()
   })
 
   it('should match a snapshot for an image type', () => {
-    const wrapper = render(<Avatar type="image" src="https://picsum.photos/200" />)
+    const wrapper = render(<DeprecatedAvatar type="image" src="https://picsum.photos/200" />)
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/avatar/avatar.mdx
+++ b/src/components/avatar/avatar.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, Controls } from '@storybook/blocks'
-import { Avatar } from '.'
 import { RenderHtmlMarkup } from '../../storybook/render-html-markup'
 import * as AvatarStories from './avatar.stories'
 
@@ -7,6 +6,7 @@ import * as AvatarStories from './avatar.stories'
 
 # Avatar
 
+{/* TODO: update the docs once the new v5 Avatar ready */}
 An avatar component to be used typically with a `Card`, `Nav`, or `Table` component. The default variant renders a circle with children.
 
 Passing an `src` will render it as an image tag and passing the `type` prop as `image` will render a rectangular image, suitable for property thumbnails or similar.
@@ -30,3 +30,4 @@ Passing an `src` will render it as an image tag and passing the `type` prop as `
 <Canvas of={AvatarStories.WithImage} />
 
 <RenderHtmlMarkup of={AvatarStories.WithImage} />
+DeprecatedAvatarDeprecatedAvatarAvatar: DeprecatedAvatar

--- a/src/components/avatar/avatar.stories.tsx
+++ b/src/components/avatar/avatar.stories.tsx
@@ -1,23 +1,28 @@
-import { Avatar } from '.'
+import { DeprecatedAvatar } from '.'
 import { Icon } from '../icon'
 
+{
+  /* TODO: update the stories once the new v5 Avatar ready */
+}
 export default {
   title: 'Avatar',
-  component: Avatar,
+  component: DeprecatedAvatar,
 }
 
 export const BasicUsage = {
   render: ({}) => (
-    <Avatar>
+    <DeprecatedAvatar>
       <Icon icon="placeholderSmall" />
-    </Avatar>
+    </DeprecatedAvatar>
   ),
 }
 
 export const WithSrc = {
-  render: ({}) => <Avatar alt="A stock image randomly generated" src="https://picsum.photos/200" />,
+  render: ({}) => <DeprecatedAvatar alt="A stock image randomly generated" src="https://picsum.photos/200" />,
 }
 
 export const WithImage = {
-  render: ({}) => <Avatar type="image" alt="A stock image randomly generated" src="https://picsum.photos/200/300" />,
+  render: ({}) => (
+    <DeprecatedAvatar type="image" alt="A stock image randomly generated" src="https://picsum.photos/200/300" />
+  ),
 }

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -1,21 +1,23 @@
-import React, { FC, HTMLAttributes } from 'react'
 import { cx } from '@linaria/core'
-import { ElAvatar, ElAvatarImage } from './__styles__'
+import { FC, HTMLAttributes } from 'react'
+import { ElDeprecatedAvatar, ElDeprecatedAvatarImage } from './__styles__'
 
-export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
+/** @deprecated will be replaced by new v5 AvatarRectangleProps */
+export interface DeprecatedAvatarProps extends HTMLAttributes<HTMLSpanElement> {
   type?: 'profile' | 'image'
   src?: string
   alt?: string
 }
 
-export const Avatar: FC<AvatarProps> = ({ children, src, alt, type, className, ...rest }) => {
+/** @deprecated will be replaced by new v5 AvatarRectangle */
+export const DeprecatedAvatar: FC<DeprecatedAvatarProps> = ({ children, src, alt, type, className, ...rest }) => {
   return type === 'image' ? (
-    <ElAvatarImage role="img" title="An avatar image" className={cx(className)} {...rest}>
+    <ElDeprecatedAvatarImage role="img" title="An avatar image" className={cx(className)} {...rest}>
       {src ? <img src={src} alt={alt ? alt : `An image with source ${src}`} /> : children}
-    </ElAvatarImage>
+    </ElDeprecatedAvatarImage>
   ) : (
-    <ElAvatar role="img" title="A profile image" className={cx(className)} {...rest}>
+    <ElDeprecatedAvatar role="img" title="A profile image" className={cx(className)} {...rest}>
       {src ? <img src={src} alt={alt ? alt : `An image with source ${src}`} /> : children}
-    </ElAvatar>
+    </ElDeprecatedAvatar>
   )
 }

--- a/src/components/card/__styles__/index.ts
+++ b/src/components/card/__styles__/index.ts
@@ -1,7 +1,7 @@
 import { styled } from '@linaria/react'
 import { css } from '@linaria/core'
 import { isTablet } from '../../../styles/media'
-import { ElAvatar } from '../../avatar'
+import { ElDeprecatedAvatar } from '../../avatar'
 
 export const elCardFocussed = css`
   background-color: var(--purple-050);
@@ -43,7 +43,7 @@ export const ElCardMainWrap = styled.div`
   display: flex;
   flex-wrap: nowrap;
 
-  ${ElAvatar} {
+  ${ElDeprecatedAvatar} {
     margin-right: 1rem;
 
     ${isTablet} {

--- a/src/components/card/card-components.tsx
+++ b/src/components/card/card-components.tsx
@@ -21,7 +21,7 @@ import { elCardFocussed, elCardSubHeadingWrapAvatar } from './__styles__'
 import { Icon, IconNames } from '../icon'
 import { elMb5, elMt5 } from '../../styles/spacing'
 import { Intent } from '../../helpers/intent'
-import { Avatar } from '../avatar'
+import { DeprecatedAvatar } from '../avatar'
 
 export interface CardListItemProps {
   // Card list items have a heading, a sub heading an icon name from our icon list and an onClick action
@@ -88,13 +88,13 @@ export const Card: FC<CardProps> = ({
         <>
           <CardMainWrap>
             {mainCardAvatarUrl ? (
-              <Avatar src={typeof mainCardAvatarUrl === 'string' ? mainCardAvatarUrl : undefined}>
+              <DeprecatedAvatar src={typeof mainCardAvatarUrl === 'string' ? mainCardAvatarUrl : undefined}>
                 {mainCardAvatarUrl}
-              </Avatar>
+              </DeprecatedAvatar>
             ) : mainCardImgUrl ? (
-              <Avatar src={typeof mainCardImgUrl === 'string' ? mainCardImgUrl : undefined} type="image">
+              <DeprecatedAvatar src={typeof mainCardImgUrl === 'string' ? mainCardImgUrl : undefined} type="image">
                 {mainCardImgUrl}
-              </Avatar>
+              </DeprecatedAvatar>
             ) : null}
             <CardHeadingWrap className={cx(mainCardAvatarUrl && elCardSubHeadingWrapAvatar)}>
               <CardHeading>{mainCardHeading}</CardHeading>

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -20,7 +20,7 @@ import { Icon } from '../icon'
 import { elMb5 } from '../../styles/spacing'
 import { Card } from './card-components'
 import { MediaStateProvider } from '../../hooks/use-media-query'
-import { Avatar } from '../avatar'
+import { DeprecatedAvatar } from '../avatar'
 
 export default {
   title: 'Card',
@@ -31,7 +31,7 @@ export const CardWithAvatar = {
   render: ({}) => (
     <CardWrap>
       <CardMainWrap>
-        <Avatar src="https://picsum.photos/200" />
+        <DeprecatedAvatar src="https://picsum.photos/200" />
         <CardHeadingWrap className={elCardSubHeadingWrapAvatar}>
           <CardHeading>Main Heading</CardHeading>
           <CardSubHeading>Sub Heading</CardSubHeading>
@@ -46,7 +46,7 @@ export const CardWithImage = {
   render: ({}) => (
     <CardWrap>
       <CardMainWrap>
-        <Avatar type="image" src="https://picsum.photos/200/300" />
+        <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
         <CardHeadingWrap>
           <CardHeading>Main Heading</CardHeading>
           <CardSubHeading>Sub Heading</CardSubHeading>
@@ -81,7 +81,7 @@ export const CardFocussed = {
   render: ({}) => (
     <CardWrap className={elCardFocussed}>
       <CardMainWrap>
-        <Avatar type="image" src="https://picsum.photos/200/300" />
+        <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
         <CardHeadingWrap>
           <CardHeading>Main Heading</CardHeading>
           <CardSubHeading>Sub Heading</CardSubHeading>
@@ -131,7 +131,7 @@ export const CardCompleteExample = {
   render: ({}) => (
     <CardWrap>
       <CardMainWrap>
-        <Avatar type="image" src="https://picsum.photos/200/300" />
+        <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
         <CardHeadingWrap>
           <CardHeading>Main Heading</CardHeading>
           <CardSubHeading>Sub Heading</CardSubHeading>

--- a/src/components/nav/__styles__/index.ts
+++ b/src/components/nav/__styles__/index.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
-import { ElAvatar } from '../../avatar'
+import { ElDeprecatedAvatar } from '../../avatar'
 import { elIsActive } from '../../../styles/states'
 
 export const ElNavBg = styled.div`
@@ -294,14 +294,14 @@ export const ElNavResponsiveAvatarWrap = styled.div`
   margin-right: 0.25rem;
   cursor: pointer;
 
-  ${ElAvatar} {
+  ${ElDeprecatedAvatar} {
     height: 2rem;
     width: 2rem;
     background-color: var(--intent-primary-lightest);
   }
 
   &:hover {
-    ${ElAvatar} {
+    ${ElDeprecatedAvatar} {
       background-color: var(--purple-100);
     }
   }

--- a/src/components/nav/nav-responsive.tsx
+++ b/src/components/nav/nav-responsive.tsx
@@ -23,7 +23,7 @@ import {
 } from './__styles__'
 import { elMlAuto, elMr2, elMr4 } from '../../styles/spacing'
 import { generateRandomId } from '../../storybook/random-id'
-import { Avatar } from '../avatar'
+import { DeprecatedAvatar } from '../avatar'
 import { Text2XS } from '../typography'
 import { elIsActive } from '../../styles/states'
 import { handleKeyboardEvent } from '../../storybook/handle-keyboard-event'
@@ -111,9 +111,9 @@ export const NavResponsiveAvatar: FC<NavResponsiveAvatarProps> = ({ options, isH
         role="button"
         tabIndex={0}
       >
-        <Avatar className={cx(elMr2)} type="profile">
+        <DeprecatedAvatar className={cx(elMr2)} type="profile">
           {text}
-        </Avatar>
+        </DeprecatedAvatar>
         {Boolean(options.length) && (
           <>
             <Icon intent="default" icon={avatarOpen ? 'chevronUp' : 'chevronDown'} />

--- a/src/components/page-header/__styles__/index.ts
+++ b/src/components/page-header/__styles__/index.ts
@@ -1,6 +1,6 @@
 import { styled } from '@linaria/react'
 import { isTablet } from '../../../styles/media'
-import { ElAvatar, ElAvatarImage } from '../../avatar'
+import { ElDeprecatedAvatar, ElDeprecatedAvatarImage } from '../../avatar'
 import { elTextL, elTextBase } from '../../typography'
 import { css } from '@linaria/core'
 
@@ -73,11 +73,11 @@ export const ElPageHeaderWrap = styled.div`
   border-bottom: var(--page-header-border);
   margin-bottom: 0.5rem;
 
-  ${ElAvatarImage} {
+  ${ElDeprecatedAvatarImage} {
     border-radius: 0.25rem;
   }
 
-  ${ElAvatar} {
+  ${ElDeprecatedAvatar} {
     margin-bottom: 0.5rem;
   }
 
@@ -87,7 +87,7 @@ export const ElPageHeaderWrap = styled.div`
     width: calc(100% + 3rem);
     translate: -1.5rem -2.5rem;
 
-    ${ElAvatar} {
+    ${ElDeprecatedAvatar} {
       width: 48px;
       height: 48px;
       margin-right: 1rem;
@@ -97,7 +97,7 @@ export const ElPageHeaderWrap = styled.div`
       }
     }
 
-    ${ElAvatarImage} {
+    ${ElDeprecatedAvatarImage} {
       width: 100px;
       height: 80px;
       border-radius: 0.5rem;

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -10,7 +10,7 @@ import {
 } from './__styles__'
 import { Text2XL, TextL, TextBase, TypographyProps } from '../typography'
 import { FlexContainer } from '../layout'
-import { Avatar, AvatarProps } from '../avatar'
+import { DeprecatedAvatar, DeprecatedAvatarProps } from '../avatar'
 import { Tag, TagGroup, TagProps } from '../tag'
 import { Button, DeprecatedButtonGroup, ButtonProps } from '../button'
 import { BreadCrumb, BreadCrumbProps } from '../breadcrumb'
@@ -18,7 +18,7 @@ import { elMb3, elMb6, elMr3 } from '../../styles/spacing'
 import { Tabs, TabsProps } from '../tabs'
 
 export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
-  avatar?: AvatarProps
+  avatar?: DeprecatedAvatarProps
   pageTitle: TypographyProps
   pageSubtitle?: TypographyProps
   pageInfo?: TypographyProps[]
@@ -71,7 +71,7 @@ export const PageHeader: FC<PageHeaderProps> = ({
         {breadcrumb && <BreadCrumb className={elMb6} {...breadcrumb} />}
         <PageHeaderContainer>
           <PageHeaderContainer>
-            {avatar && <Avatar {...avatar} />}
+            {avatar && <DeprecatedAvatar {...avatar} />}
             <FlexContainer isFlexColumn>
               <PageHeaderTitleContainer>
                 {pageTitle && <Text2XL className={elMr3} tag="h1" hasBoldText {...pageTitle} />}

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -19,7 +19,7 @@ import { StatusIndicator } from '../status-indicator'
 import { elMlAuto } from '../../styles/spacing'
 import { FormLayout, InputWrap } from '../form-layout'
 import { elIsActive } from '../../styles/states'
-import { Avatar } from '../avatar'
+import { DeprecatedAvatar } from '../avatar'
 import { Input } from '../input'
 import { TextBase } from '../typography'
 
@@ -45,7 +45,7 @@ export const BasicUsage = {
           </TableCell>
           <TableCell>First Column</TableCell>
           <TableCell narrowLabel="Image">
-            <Avatar type="image" src="https://picsum.photos/200/300" />
+            <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
           </TableCell>
           <TableCell>Second Column</TableCell>
           <TableCell>
@@ -60,7 +60,7 @@ export const BasicUsage = {
           </TableCell>
           <TableCell>First Column</TableCell>
           <TableCell narrowLabel="Image">
-            <Avatar type="image" src="https://picsum.photos/200/300" />
+            <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
           </TableCell>
           <TableCell>Second Column</TableCell>
           <TableCell>
@@ -89,7 +89,7 @@ export const ColumnWidths = {
           </TableCell>
           <TableCell>First Column</TableCell>
           <TableCell narrowLabel="Image">
-            <Avatar type="image" src="https://picsum.photos/200/300" />
+            <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
           </TableCell>
           <TableCell className={elSpan2}>Second Column with more data</TableCell>
           <TableCell className={elSpan3}>
@@ -104,7 +104,7 @@ export const ColumnWidths = {
           </TableCell>
           <TableCell>First Column</TableCell>
           <TableCell narrowLabel="Image">
-            <Avatar type="image" src="https://picsum.photos/200/300" />
+            <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
           </TableCell>
           <TableCell className={elSpan2}>Second Column with more data</TableCell>
           <TableCell className={elSpan3}>
@@ -136,7 +136,7 @@ export const BasicCustomisationTableCells = {
             <Input type="checkbox" />
           </TableCell>
           <TableCell narrowLabel="Image">
-            <Avatar type="image" src="https://picsum.photos/200/300" />
+            <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />
           </TableCell>
           <TableCell darkText narrowIsFullWidth>
             1 King Road, London, UK, S1 1AA
@@ -315,7 +315,7 @@ export const ReactShorthandUsage = {
           },
           {
             label: 'Property Image',
-            value: <Avatar type="image" src="https://picsum.photos/200/300" />,
+            value: <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />,
           },
           {
             label: 'Property',
@@ -364,7 +364,7 @@ export const ReactShorthandUsage = {
           },
           {
             label: 'Property Image',
-            value: <Avatar type="image" src="https://picsum.photos/200/300" />,
+            value: <DeprecatedAvatar type="image" src="https://picsum.photos/200/300" />,
           },
           {
             label: 'Property',


### PR DESCRIPTION
## Context
In preparation for the new v5 avatar release, there will be new Avatar components (`Avatar` and `AvatarRectangle`). Although the previous component was called 'avatar,' the next version will likely use `AvatarRectangle`, depending on whether an image needs to be displayed.

# Pull request checklist
- [x] deprecate previous avatar and consumer

**Detail as per issue below (required):**

fixes: 
- #137 

