### PR TITLE
task: #160 remove cross-env in favour of Yarn's built-in shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   ],
   "scripts": {
     "build": "yarn build:storybook & yarn build:types & yarn build:dist",
-    "build:storybook": "cross-env NODE_ENV=production && rimraf public/dist && storybook build -o public/dist",
-    "build:dist": "cross-env NODE_ENV=production && vite build",
+    "build:storybook": "rimraf public/dist && NODE_ENV=production storybook build -o public/dist",
+    "build:dist": "vite build",
     "build:sd": "node ./src/tokens/build.mjs && eslint --cache --ext=ts tokens --fix",
     "build:types": "tsc --project tsconfig.build.json",
     "commit": "yarn test run --coverage --silent && yarn coverage:badges && yarn lint --fix && yarn check",
@@ -111,7 +111,6 @@
     "concurrently": "^8.2.2",
     "constructs": "^10.3.0",
     "coverage-badges-cli": "^2.1.0",
-    "cross-env": "^7.0.3",
     "dashify": "2.0.0",
     "eslint": "8.56.0",
     "eslint-config-prettier": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,7 +2865,6 @@ __metadata:
     concurrently: "npm:^8.2.2"
     constructs: "npm:^10.3.0"
     coverage-badges-cli: "npm:^2.1.0"
-    cross-env: "npm:^7.0.3"
     dashify: "npm:2.0.0"
     eslint: "npm:8.56.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -6431,19 +6430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: "npm:^7.0.1"
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 10/e99911f0d31c20e990fd92d6fd001f4b01668a303221227cc5cb42ed155f086351b1b3bd2699b200e527ab13011b032801f8ce638e6f09f854bdf744095e604c
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
Closes #160 

We do not need to use `cross-env` in order to support POSIX-like env var assignment in our package scripts. Yarn runs all package scripts within a POSIX-like shell interpreter, thus providing cross-platform support by default.