### PR TITLE
fix: #220 ensure svgr plugin provides `icon` option

### DIFF
--- a/src/components/accordion/__tests__/__snapshots__/accordion.atoms.test.tsx.snap
+++ b/src/components/accordion/__tests__/__snapshots__/accordion.atoms.test.tsx.snap
@@ -24,11 +24,11 @@ exports[`Accordion basic usage > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name car"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -57,11 +57,11 @@ exports[`Accordion basic usage > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -88,11 +88,11 @@ exports[`Accordion basic usage > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name chevronUp"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -128,11 +128,11 @@ exports[`Accordion basic usage > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name car"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -161,11 +161,11 @@ exports[`Accordion basic usage > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -192,11 +192,11 @@ exports[`Accordion basic usage > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name chevronDown"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/src/components/accordion/__tests__/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__tests__/__snapshots__/accordion.test.tsx.snap
@@ -29,11 +29,11 @@ exports[`Accordion react shorthand > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name car"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -62,11 +62,11 @@ exports[`Accordion react shorthand > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -94,12 +94,12 @@ exports[`Accordion react shorthand > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 1.25rem;"
               title="Icon image with name chevronDown"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -144,11 +144,11 @@ exports[`Accordion react shorthand > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name car"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -177,11 +177,11 @@ exports[`Accordion react shorthand > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -209,12 +209,12 @@ exports[`Accordion react shorthand > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 1.25rem;"
               title="Icon image with name chevronDown"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/src/components/avatar-rectangle/__tests__/__snapshots__/avatar-rectangle.test.tsx.snap
+++ b/src/components/avatar-rectangle/__tests__/__snapshots__/avatar-rectangle.test.tsx.snap
@@ -6,9 +6,9 @@ exports[`AvatarRectangle > renders correctly with commercial variant and medium 
     aria-label="Image placeholder"
     class="mocked-styled-5 el-avatar-rect-commercial-placeholder"
     fill="currentColor"
-    height="54"
+    height="1em"
     viewBox="0 0 72 54"
-    width="72"
+    width="1em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <g
@@ -45,9 +45,9 @@ exports[`AvatarRectangle > renders correctly with commercial variant and small s
       aria-hidden="true"
       class="mocked-styled-1 el-avatar-rect-bottom-small-placeholder"
       fill="none"
-      height="36"
+      height="1em"
       viewBox="0 0 48 36"
-      width="48"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -82,9 +82,9 @@ exports[`AvatarRectangle > renders correctly with residential variant and small 
     aria-label="Image placeholder"
     class="mocked-styled-4 el-avatar-rect-residential-small-placeholder"
     fill="none"
-    height="48"
+    height="1em"
     viewBox="0 0 64 48"
-    width="64"
+    width="1em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <rect
@@ -106,9 +106,9 @@ exports[`AvatarRectangle > simulate error and renders correctly when image fails
     aria-label="Image placeholder"
     class="mocked-styled-5 el-avatar-rect-commercial-placeholder"
     fill="currentColor"
-    height="54"
+    height="1em"
     viewBox="0 0 72 54"
-    width="72"
+    width="1em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <g

--- a/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.tsx.snap
@@ -27,12 +27,12 @@ exports[`BreadCrumb > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 12px;"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -60,12 +60,12 @@ exports[`BreadCrumb > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 12px;"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -93,12 +93,12 @@ exports[`BreadCrumb > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 12px;"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/button/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__tests__/__snapshots__/button.test.tsx.snap
@@ -55,11 +55,11 @@ exports[`Button > should match snapshot for <ElAnchorButton> as a link button 1`
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name add"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -88,11 +88,11 @@ exports[`Button > should match snapshot for icon-only button 1`] = `
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name star"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -121,11 +121,11 @@ exports[`Button > should match snapshot with variant and icons 1`] = `
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name star"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -144,11 +144,11 @@ exports[`Button > should match snapshot with variant and icons 1`] = `
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name star"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -341,11 +341,11 @@ exports[`FloatingButton > should render FloatingButton with icon 1`] = `
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name star"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/src/components/card/__tests__/__snapshots__/card-components.test.tsx.snap
+++ b/src/components/card/__tests__/__snapshots__/card-components.test.tsx.snap
@@ -68,11 +68,11 @@ exports[`Card > should match a snapshot and render children with full props 1`] 
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name user"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -116,11 +116,11 @@ exports[`Card > should match a snapshot and render children with full props 1`] 
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name property"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/src/components/deprecated-table/__tests__/__snapshots__/molecules.test.tsx.snap
+++ b/src/components/deprecated-table/__tests__/__snapshots__/molecules.test.tsx.snap
@@ -11,12 +11,12 @@ exports[`DeprecatedTableCell Component > should match a snapshot with full props
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         style="font-size: 1.25rem;"
         title="Icon image with name add"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -133,11 +133,11 @@ exports[`TableCtaTriggerCell Component > should match a snapshot with no childre
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name add"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -211,11 +211,11 @@ exports[`TableExpandableRowTriggerCell Component > should match a snapshot with 
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name more"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -248,11 +248,11 @@ exports[`TableExpandableRowTriggerCell Component > should match a snapshot with 
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name more"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/src/components/deprecated-table/__tests__/__snapshots__/table.test.tsx.snap
+++ b/src/components/deprecated-table/__tests__/__snapshots__/table.test.tsx.snap
@@ -29,11 +29,11 @@ exports[`DeprecatedTable Component > should match a snapshot for cta content alt
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name settings"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -64,11 +64,11 @@ exports[`DeprecatedTable Component > should match a snapshot for cta content alt
             >
               <svg
                 fill="none"
-                height="24"
+                height="1em"
                 role="img"
                 title="Icon image with name property"
                 viewBox="0 0 24 24"
-                width="24"
+                width="1em"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -122,11 +122,11 @@ exports[`DeprecatedTable Component > should match a snapshot for expandable cont
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name more"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -247,12 +247,12 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 1.25rem;"
               title="Icon image with name property"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -278,12 +278,12 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 1.25rem;"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -371,11 +371,11 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
             >
               <svg
                 fill="none"
-                height="24"
+                height="1em"
                 role="img"
                 title="Icon image with name property"
                 viewBox="0 0 24 24"
-                width="24"
+                width="1em"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -463,11 +463,11 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name settings"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -495,12 +495,12 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 1.25rem;"
               title="Icon image with name property"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -526,12 +526,12 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 1.25rem;"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -616,11 +616,11 @@ exports[`DeprecatedTable Component > should match a snapshot with full props and
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name more"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/src/components/drawer/__tests__/__snapshots__/drawer.test.tsx.snap
+++ b/src/components/drawer/__tests__/__snapshots__/drawer.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`Drawer component > should match a snapshot when open 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name close"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/file-input/__tests__/__snapshots__/file-input.test.tsx.snap
+++ b/src/components/file-input/__tests__/__snapshots__/file-input.test.tsx.snap
@@ -104,12 +104,12 @@ exports[`FileInput component > should match a snapshot with full props 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             style="font-size: 1rem;"
             title="Icon image with name view"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -125,12 +125,12 @@ exports[`FileInput component > should match a snapshot with full props 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             style="font-size: 1rem;"
             title="Icon image with name close"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/src/components/icon/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/icon/__tests__/__snapshots__/index.test.tsx.snap
@@ -7,11 +7,11 @@ exports[`Icon component > should match a snapshot 1`] = `
   >
     <svg
       fill="none"
-      height="24"
+      height="1em"
       role="img"
       title="Icon image with name add"
       viewBox="0 0 24 24"
-      width="24"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -30,11 +30,11 @@ exports[`Icon component > should match a snapshot when intent prop is supplied 1
   >
     <svg
       fill="none"
-      height="24"
+      height="1em"
       role="img"
       title="Icon image with name add"
       viewBox="0 0 24 24"
-      width="24"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/src/components/input-group/__tests__/__snapshots__/input-group.test.tsx.snap
+++ b/src/components/input-group/__tests__/__snapshots__/input-group.test.tsx.snap
@@ -14,11 +14,11 @@ exports[`InputGroup component > should match a snapshot when used in explicit mo
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name email"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -86,12 +86,12 @@ exports[`InputGroup component > should match a snapshot when used in react short
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         style="font-size: 1rem;"
         title="Icon image with name email"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -120,12 +120,12 @@ exports[`InputGroup component > should match a snapshot when used in react short
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         style="font-size: 1rem;"
         title="Icon image with name email"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/src/components/key-value-list/__tests__/__snapshots__/key-value-list.test.tsx.snap
+++ b/src/components/key-value-list/__tests__/__snapshots__/key-value-list.test.tsx.snap
@@ -17,11 +17,11 @@ exports[`KeyValueList component > should match a snapshot 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name user"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -66,11 +66,11 @@ exports[`KeyValueList component > should match a snapshot 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name email"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -107,11 +107,11 @@ exports[`KeyValueList component > should match a snapshot 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name car"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -158,11 +158,11 @@ exports[`KeyValueList component > should match a snapshot 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name calendar"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -199,11 +199,11 @@ exports[`KeyValueList component > should match a snapshot 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name property"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -240,11 +240,11 @@ exports[`KeyValueList component > should match a snapshot 1`] = `
         >
           <svg
             fill="none"
-            height="24"
+            height="1em"
             role="img"
             title="Icon image with name edit"
             viewBox="0 0 24 24"
-            width="24"
+            width="1em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -292,11 +292,11 @@ exports[`KeyValueList component > should match a snapshot for a grid 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name user"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -344,11 +344,11 @@ exports[`KeyValueList component > should match a snapshot for a grid 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name email"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -388,11 +388,11 @@ exports[`KeyValueList component > should match a snapshot for a grid 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name car"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -442,11 +442,11 @@ exports[`KeyValueList component > should match a snapshot for a grid 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name calendar"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -486,11 +486,11 @@ exports[`KeyValueList component > should match a snapshot for a grid 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name property"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -530,11 +530,11 @@ exports[`KeyValueList component > should match a snapshot for a grid 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               title="Icon image with name edit"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/src/components/mobile-controls/__tests__/__snapshots__/mobile-controls.test.tsx.snap
+++ b/src/components/mobile-controls/__tests__/__snapshots__/mobile-controls.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`MobileControls component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name menu"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -89,11 +89,11 @@ exports[`MobileControls component > should match a snapshot with full props 1`] 
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name add"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/multi-select/__tests__/__snapshots__/multi-select.test.tsx.snap
+++ b/src/components/multi-select/__tests__/__snapshots__/multi-select.test.tsx.snap
@@ -124,11 +124,11 @@ exports[`MultiSelectInput > should match a snapshot and render non selected mess
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name task"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/nav-search-button/__tests__/__snapshots__/nav-search-button.test.tsx.snap
+++ b/src/components/nav-search-button/__tests__/__snapshots__/nav-search-button.test.tsx.snap
@@ -9,9 +9,9 @@ exports[`NavSearchButton > render without shortcut and match snapshot 1`] = `
       aria-hidden="true"
       class="mocked-styled-1 el-nav-search-button-icon"
       fill="none"
-      height="16"
+      height="1em"
       viewBox="0 0 16 16"
-      width="16"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -37,9 +37,9 @@ exports[`NavSearchButton > should match snapshot 1`] = `
       aria-hidden="true"
       class="mocked-styled-1 el-nav-search-button-icon"
       fill="none"
-      height="16"
+      height="1em"
       viewBox="0 0 16 16"
-      width="16"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/src/components/nav/__tests__/__snapshots__/nav-responsive.test.tsx.snap
+++ b/src/components/nav/__tests__/__snapshots__/nav-responsive.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`NavResponsive component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="0.2em"
+          height="1em"
           role="img"
           style="width: 100px;"
           title="Icon image with name reapitLogo"
@@ -76,11 +76,11 @@ exports[`NavResponsive component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name more"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/page-header/__tests__/__snapshots__/page-header.test.tsx.snap
+++ b/src/components/page-header/__tests__/__snapshots__/page-header.test.tsx.snap
@@ -33,12 +33,12 @@ exports[`PageHeader component > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 12px;"
               title="Icon image with name chevronRight"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -66,12 +66,12 @@ exports[`PageHeader component > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 12px;"
               title="Icon image with name chevronRight"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -99,12 +99,12 @@ exports[`PageHeader component > should match a snapshot 1`] = `
           >
             <svg
               fill="none"
-              height="24"
+              height="1em"
               role="img"
               style="font-size: 12px;"
               title="Icon image with name chevronRight"
               viewBox="0 0 24 24"
-              width="24"
+              width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/src/components/pagination/__tests__/__snapshots__/pagination.test.tsx.snap
+++ b/src/components/pagination/__tests__/__snapshots__/pagination.test.tsx.snap
@@ -17,11 +17,11 @@ exports[`Pagination > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronLeft"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -53,11 +53,11 @@ exports[`Pagination > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -88,11 +88,11 @@ exports[`Pagination > should match a snapshot with start end buttons 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronLeft"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -114,11 +114,11 @@ exports[`Pagination > should match a snapshot with start end buttons 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronLeft"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -132,11 +132,11 @@ exports[`Pagination > should match a snapshot with start end buttons 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronLeft"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -168,11 +168,11 @@ exports[`Pagination > should match a snapshot with start end buttons 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -186,11 +186,11 @@ exports[`Pagination > should match a snapshot with start end buttons 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -212,11 +212,11 @@ exports[`Pagination > should match a snapshot with start end buttons 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           title="Icon image with name chevronRight"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/persistent-notification/__tests__/__snapshots__/persistent-notification.test.tsx.snap
+++ b/src/components/persistent-notification/__tests__/__snapshots__/persistent-notification.test.tsx.snap
@@ -16,12 +16,12 @@ exports[`PersistentNotification component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1.25rem;"
           title="Icon image with name info"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -57,12 +57,12 @@ exports[`PersistentNotification component > should match a snapshot for an inlin
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1.25rem;"
           title="Icon image with name info"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -98,12 +98,12 @@ exports[`PersistentNotification component > should match a snapshot when expande
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1.25rem;"
           title="Icon image with name info"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -139,12 +139,12 @@ exports[`PersistentNotification component > should match a snapshot when given a
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1.25rem;"
           title="Icon image with name info"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/searchable-dropdown/__tests__/__snapshots__/searchable-dropdown.test.tsx.snap
+++ b/src/components/searchable-dropdown/__tests__/__snapshots__/searchable-dropdown.test.tsx.snap
@@ -24,12 +24,12 @@ exports[`ControlledSearchableDropdown component > should display default value 1
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1rem;"
           title="Icon image with name search"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -50,11 +50,11 @@ exports[`ControlledSearchableDropdown component > should display default value 1
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         title="Icon image with name close"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -91,12 +91,12 @@ exports[`ControlledSearchableDropdown component > should match a snapshot 1`] = 
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1rem;"
           title="Icon image with name search"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -140,12 +140,12 @@ exports[`SearchableDropdown component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1rem;"
           title="Icon image with name search"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/src/components/snack/__tests__/__snapshots__/snack.test.tsx.snap
+++ b/src/components/snack/__tests__/__snapshots__/snack.test.tsx.snap
@@ -23,12 +23,12 @@ exports[`Snack component > should match a snapshot if an icon is supplied 1`] = 
     >
       <svg
         fill="none"
-        height="24"
+        height="1em"
         role="img"
         style="font-size: 1.25rem;"
         title="Icon image with name email"
         viewBox="0 0 24 24"
-        width="24"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -57,12 +57,12 @@ exports[`SnackHolder component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1.25rem;"
           title="Icon image with name info"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -79,12 +79,12 @@ exports[`SnackHolder component > should match a snapshot 1`] = `
       >
         <svg
           fill="none"
-          height="24"
+          height="1em"
           role="img"
           style="font-size: 1.25rem;"
           title="Icon image with name close"
           viewBox="0 0 24 24"
-          width="24"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
   },
   plugins: [
     react(),
-    svgr(),
+    svgr({
+      svgrOptions: {
+        icon: true,
+      },
+    }),
     wyw({
       babelOptions: {
         presets: ['@babel/preset-typescript', '@babel/preset-react'],


### PR DESCRIPTION
Fixes #220 

#212 missed providing the `icon: true` config to the SVGR plugin when `vite-plugin-svgr` replaced `@svgr/rollup`. This PR adds that config back in to allow icons to be sized correctly.

<img width="640" alt="Screenshot 2024-11-25 at 9 30 24 AM" src="https://github.com/user-attachments/assets/35ca4cd9-60d4-4cb6-9fa7-f490ef9a4e41">