### PR TITLE
chore: v5 update Avatar docs

### DIFF
--- a/src/components/avatar-rectangle/avatar-rectangle.mdx
+++ b/src/components/avatar-rectangle/avatar-rectangle.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls } from '@storybook/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/blocks'
 import { RenderHtmlMarkup } from '../../storybook/render-html-markup'
 import * as AvatarRectangleStories from './avatar-rectangle.stories'
 
@@ -12,8 +12,7 @@ A versatile component designed to render property image.
 
 ## Default Usage
 
-The default usage use the residential variant and medium size, each can be set using the `data-` attribute.
-
+<Description of={AvatarRectangleStories.DefaultUsage} />
 <Canvas of={AvatarRectangleStories.DefaultUsage} />
 <RenderHtmlMarkup of={AvatarRectangleStories.DefaultUsage} />
 
@@ -31,9 +30,3 @@ The default usage use the residential variant and medium size, each can be set u
 
 <Canvas of={AvatarRectangleStories.UsingCommercialPlaceholder} />
 <RenderHtmlMarkup of={AvatarRectangleStories.UsingCommercialPlaceholder} />
-
-## React Usage
-
-<Canvas of={AvatarRectangleStories.ReactUsage} />
-
-<RenderHtmlMarkup of={AvatarRectangleStories.ReactUsage} />

--- a/src/components/avatar-rectangle/avatar-rectangle.mdx
+++ b/src/components/avatar-rectangle/avatar-rectangle.mdx
@@ -10,21 +10,22 @@ A versatile component designed to render property image.
 
 <Controls />
 
-## Default Usage
+## Default
 
 <Description of={AvatarRectangleStories.DefaultUsage} />
 <Canvas of={AvatarRectangleStories.DefaultUsage} />
 <RenderHtmlMarkup of={AvatarRectangleStories.DefaultUsage} />
+
+## Avatar Rectangle Variant
+
+<Canvas of={AvatarRectangleStories.AvatarRectangleVariant} />
+<RenderHtmlMarkup of={AvatarRectangleStories.AvatarRectangleVariant} />
 
 ## Using Residential Placeholder
 
 <Canvas of={AvatarRectangleStories.UsingResidentialPlaceholder} />
 <RenderHtmlMarkup of={AvatarRectangleStories.UsingResidentialPlaceholder} />
 
-## Using Commercial Variant
-
-<Canvas of={AvatarRectangleStories.UsingCommercialVariant} />
-<RenderHtmlMarkup of={AvatarRectangleStories.UsingCommercialPlaceholder} />
 
 ## Using Commercial Placeholder
 

--- a/src/components/avatar-rectangle/avatar-rectangle.stories.tsx
+++ b/src/components/avatar-rectangle/avatar-rectangle.stories.tsx
@@ -1,11 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { AvatarRectangle } from '.'
-import {
-  ElAvatarRectangle,
-  ElAvatarRectResidentialPlaceholder,
-  ElAvatarRectBottomImage,
-  ElAvatarRectCommercialPlaceholder,
-} from './styles'
+import { ElAvatarRectResidentialPlaceholder, ElAvatarRectCommercialPlaceholder } from './styles'
 
 export default {
   title: 'Components/Avatar Rectangle',
@@ -13,6 +8,7 @@ export default {
   args: {
     variant: 'residential',
     size: 'medium',
+    src: 'https://picsum.photos/id/206/100/100',
   },
   argTypes: {
     variant: {
@@ -26,36 +22,23 @@ export default {
   },
 } as Meta<typeof AvatarRectangle>
 
-const exampleImageUrl = 'https://picsum.photos/id/206/100/100'
+type Story = StoryObj<typeof AvatarRectangle>
 
-export const DefaultUsage = {
-  render: ({}) => (
-    <ElAvatarRectangle>
-      <img src={exampleImageUrl} alt="example" />
-    </ElAvatarRectangle>
-  ),
-}
+/**
+ * The default usage use the residential variant and medium size, each can be set using the `data-` attribute.
+ */
+export const DefaultUsage: Story = {}
 
 export const UsingResidentialPlaceholder = {
-  render: ({}) => <ElAvatarRectResidentialPlaceholder aria-label="Image placeholder" />,
+  render: () => <ElAvatarRectResidentialPlaceholder aria-label="Image placeholder" />,
 }
 
-export const UsingCommercialVariant = {
-  render: ({}) => (
-    <ElAvatarRectangle data-variant="commercial">
-      <img src={exampleImageUrl} alt="example" />
-      <ElAvatarRectBottomImage aria-hidden="true" />
-    </ElAvatarRectangle>
-  ),
+export const UsingCommercialVariant: Story = {
+  args: {
+    variant: 'commercial',
+  },
 }
 
 export const UsingCommercialPlaceholder = {
-  render: ({}) => <ElAvatarRectCommercialPlaceholder aria-label="Image placeholder" />,
-}
-
-export const ReactUsage: StoryObj<typeof AvatarRectangle> = {
-  args: {
-    src: exampleImageUrl,
-  },
-  render: (props) => <AvatarRectangle {...props}></AvatarRectangle>,
+  render: () => <ElAvatarRectCommercialPlaceholder aria-label="Image placeholder" />,
 }

--- a/src/components/avatar-rectangle/avatar-rectangle.stories.tsx
+++ b/src/components/avatar-rectangle/avatar-rectangle.stories.tsx
@@ -29,14 +29,14 @@ type Story = StoryObj<typeof AvatarRectangle>
  */
 export const DefaultUsage: Story = {}
 
-export const UsingResidentialPlaceholder = {
-  render: () => <ElAvatarRectResidentialPlaceholder aria-label="Image placeholder" />,
-}
-
-export const UsingCommercialVariant: Story = {
+export const AvatarRectangleVariant: Story = {
   args: {
     variant: 'commercial',
   },
+}
+
+export const UsingResidentialPlaceholder = {
+  render: () => <ElAvatarRectResidentialPlaceholder aria-label="Image placeholder" />,
 }
 
 export const UsingCommercialPlaceholder = {

--- a/src/components/avatar/avatar.mdx
+++ b/src/components/avatar/avatar.mdx
@@ -1,4 +1,5 @@
-import { Meta, Story, Canvas, Controls } from '@storybook/blocks'
+import { Meta, Story, Canvas, Controls, Description
+} from '@storybook/blocks'
 import { RenderHtmlMarkup } from '../../storybook/render-html-markup'
 import * as AvatarStories from './avatar.stories'
 
@@ -6,42 +7,37 @@ import * as AvatarStories from './avatar.stories'
 
 # Avatar
 
-An avatar component to be used typically with a `Card` or `Nav` component. The default variant renders a circle with children.
-
-There are multiple variants that can be used by utilizing the data props, such as size, colour, and shape (see the HTML version of React usage). In addition to text, it also accepts an Icon as a child.
-
-## Style Only Usage
-
-<Canvas of={AvatarStories.StyleOnlyUsage} />
-
-<RenderHtmlMarkup of={AvatarStories.StyleOnlyUsage} />
-
-<Canvas of={AvatarStories.WithIconUsage} />
-
-<RenderHtmlMarkup of={AvatarStories.WithIconUsage} />
-
-## With Colour
-
-<Canvas of={AvatarStories.WithColour} />
-
-<RenderHtmlMarkup of={AvatarStories.WithColour} />
-
-## With Square Shape
-
-<Canvas of={AvatarStories.WithSquareShape} />
-
-<RenderHtmlMarkup of={AvatarStories.WithSquareShape} />
-
-## With Small Size
-
-<Canvas of={AvatarStories.WithSmallSize} />
-
-<RenderHtmlMarkup of={AvatarStories.WithSmallSize} />
-
-## React Usage
+<Description of={AvatarStories.Default} />
 
 <Controls />
 
-<Canvas of={AvatarStories.ReactUsage} />
+## Default
 
-<RenderHtmlMarkup of={AvatarStories.ReactUsage} />WithColourWithColour
+<Canvas of={AvatarStories.Default} />
+
+<RenderHtmlMarkup of={AvatarStories.Default} />
+
+## With Icon
+
+<Canvas of={AvatarStories.AvatarWithIcon} />
+
+<RenderHtmlMarkup of={AvatarStories.AvatarWithIcon} />
+
+
+## With Purple Colour
+
+<Canvas of={AvatarStories.AvatarWithPurpleColour} />
+
+<RenderHtmlMarkup of={AvatarStories.AvatarWithPurpleColour} />
+
+## With Square Shape
+
+<Canvas of={AvatarStories.AvatarWithSquareShape} />
+
+<RenderHtmlMarkup of={AvatarStories.AvatarWithSquareShape} />
+
+## With Small Size
+
+<Canvas of={AvatarStories.AvatarWithSmallSize} />
+
+<RenderHtmlMarkup of={AvatarStories.AvatarWithSmallSize} />

--- a/src/components/avatar/avatar.mdx
+++ b/src/components/avatar/avatar.mdx
@@ -17,27 +17,27 @@ import * as AvatarStories from './avatar.stories'
 
 <RenderHtmlMarkup of={AvatarStories.Default} />
 
-## With Icon
+## Avatar with Icon
 
 <Canvas of={AvatarStories.AvatarWithIcon} />
 
 <RenderHtmlMarkup of={AvatarStories.AvatarWithIcon} />
 
 
-## With Purple Colour
+## Avatar Colour
 
-<Canvas of={AvatarStories.AvatarWithPurpleColour} />
+<Canvas of={AvatarStories.AvatarColour} />
 
-<RenderHtmlMarkup of={AvatarStories.AvatarWithPurpleColour} />
+<RenderHtmlMarkup of={AvatarStories.AvatarColour} />
 
-## With Square Shape
+## Avatar Shape
 
-<Canvas of={AvatarStories.AvatarWithSquareShape} />
+<Canvas of={AvatarStories.AvatarShape} />
 
-<RenderHtmlMarkup of={AvatarStories.AvatarWithSquareShape} />
+<RenderHtmlMarkup of={AvatarStories.AvatarShape} />
 
-## With Small Size
+## Avatar Size
 
-<Canvas of={AvatarStories.AvatarWithSmallSize} />
+<Canvas of={AvatarStories.AvatarSize} />
 
-<RenderHtmlMarkup of={AvatarStories.AvatarWithSmallSize} />
+<RenderHtmlMarkup of={AvatarStories.AvatarSize} />

--- a/src/components/avatar/avatar.stories.tsx
+++ b/src/components/avatar/avatar.stories.tsx
@@ -30,19 +30,19 @@ export const AvatarWithIcon: Story = {
   ),
 }
 
-export const AvatarWithPurpleColour: Story = {
+export const AvatarColour: Story = {
   args: {
     colour: 'purple',
   },
 }
 
-export const AvatarWithSquareShape: Story = {
+export const AvatarShape: Story = {
   args: {
     shape: 'square',
   },
 }
 
-export const AvatarWithSmallSize: Story = {
+export const AvatarSize: Story = {
   args: {
     size: 'small',
   },

--- a/src/components/avatar/avatar.stories.tsx
+++ b/src/components/avatar/avatar.stories.tsx
@@ -1,49 +1,49 @@
-import type { StoryObj } from '@storybook/react'
-import { Avatar, ElAvatar } from '.'
+import type { Meta, StoryObj } from '@storybook/react'
+import { Avatar } from '.'
 import { Icon } from '../icon'
 
 export default {
   title: 'Components/Avatar',
   component: Avatar,
-}
-
-export const StyleOnlyUsage = {
-  render: ({}) => <ElAvatar>AD</ElAvatar>,
-}
-
-export const WithIconUsage = {
-  render: ({}) => (
-    <ElAvatar>
-      <Icon icon="contact" />
-    </ElAvatar>
-  ),
-}
-
-export const WithColour = {
-  render: ({}) => <ElAvatar data-colour="purple">AD</ElAvatar>,
-  name: 'Colour: Purple',
-}
-
-export const WithSquareShape = {
-  render: ({}) => <ElAvatar data-shape="square">AD</ElAvatar>,
-  name: 'Shape: Square',
-}
-
-export const WithSmallSize = {
-  render: ({}) => (
-    <ElAvatar data-size="small">
-      <Icon icon="contact" />
-    </ElAvatar>
-  ),
-  name: 'Size: Small',
-}
-
-export const ReactUsage: StoryObj<typeof Avatar> = {
   args: {
-    shape: 'circle',
-    size: 'medium',
-    colour: 'default',
     children: 'AD',
   },
-  render: (props) => <Avatar {...props}>{props.children}</Avatar>,
+} as Meta<typeof Avatar>
+
+type Story = StoryObj<typeof Avatar>
+
+/**
+ * An avatar component to be used typically with a `Card` or `Nav` component.
+ * The default variant renders a circle with children.
+ *
+ * There are multiple variants that can be used by utilizing the `data-` props
+ * such as `size`, `colour`, and `shape` (see the HTML version of each version).
+ * In addition to text, it also accepts an Icon as a child.
+ */
+export const Default: Story = {}
+
+export const AvatarWithIcon: Story = {
+  render: (props) => (
+    <Avatar {...props}>
+      <Icon icon="contact" />
+    </Avatar>
+  ),
+}
+
+export const AvatarWithPurpleColour: Story = {
+  args: {
+    colour: 'purple',
+  },
+}
+
+export const AvatarWithSquareShape: Story = {
+  args: {
+    shape: 'square',
+  },
+}
+
+export const AvatarWithSmallSize: Story = {
+  args: {
+    size: 'small',
+  },
 }


### PR DESCRIPTION
This pr is to update `Avatar` and `AvatarRectangle` docs to be more aligned with other existing docs.

# Pull request checklist

- [x] rename stories from `Size: Small` to `Avatar with small size` .etc
- [x] standardize first section of mdx docs to display available props
- [x] remove `StylesOnlyUsage` and `ReactUsage`
- [x] use `<Description />` from `@storybook/blocks` if necessary

updated docs:




https://github.com/user-attachments/assets/13acc7a9-caad-4ada-a2b8-7c4ec45949a8



