### PR TITLE
feat: #241 init v5 new Tag component

### DIFF
--- a/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Tag > should render properly and match snapshot 1`] = `
 <DocumentFragment>
-  <div
+  <ul
     class="mocked-styled-1 el-tag-group"
   >
-    <div
+    <li
       class="mocked-styled-0 el-tag"
     >
       Tag
-    </div>
-  </div>
+    </li>
+  </ul>
 </DocumentFragment>
 `;

--- a/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Tag > should render properly and match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="mocked-styled-1 el-tag-group"
+  >
+    <div
+      class="mocked-styled-0 el-tag"
+    >
+      Tag
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/tag/__tests__/tag.test.tsx
+++ b/src/components/tag/__tests__/tag.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react'
+import { Tag, TagGroup } from '../tag'
+
+describe('Tag', () => {
+  it('should render properly and match snapshot', () => {
+    const { asFragment } = render(
+      <TagGroup>
+        <Tag>Tag</Tag>
+      </TagGroup>,
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -1,0 +1,2 @@
+export * from './tag'
+export * from './styles'

--- a/src/components/tag/styles.tsx
+++ b/src/components/tag/styles.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@linaria/react'
 
-export const ElTag = styled.div`
+export const ElTag = styled.li`
   width: fit-content;
   padding: var(--spacing-half) var(--spacing-3);
   border-radius: var(--corner-xl);
@@ -13,7 +13,7 @@ export const ElTag = styled.div`
   letter-spacing: var(--letter-spacing-xs);
 `
 
-export const ElTagGroup = styled.div`
+export const ElTagGroup = styled.ul`
   display: inline-flex;
   align-items: flex-start;
   gap: var(--spacing-1);

--- a/src/components/tag/styles.tsx
+++ b/src/components/tag/styles.tsx
@@ -1,0 +1,20 @@
+import { styled } from '@linaria/react'
+
+export const ElTag = styled.div`
+  width: fit-content;
+  padding: var(--spacing-half) var(--spacing-3);
+  border-radius: var(--corner-xl);
+  background: var(--fill-default-light);
+  color: var(--text-tertiary);
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-xs);
+  letter-spacing: var(--letter-spacing-xs);
+`
+
+export const ElTagGroup = styled.div`
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--spacing-1);
+`

--- a/src/components/tag/tag.mdx
+++ b/src/components/tag/tag.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas, Controls, Description } from '@storybook/blocks'
+import { RenderHtmlMarkup } from '../../storybook/render-html-markup'
+import * as TagStories from './tag.stories'
+
+<Meta of={TagStories} />
+
+# Tag / Tag Group
+
+<Description of={TagStories.Default} />
+
+<Controls />
+
+## Default
+
+<Canvas of={TagStories.Default} />
+
+<RenderHtmlMarkup of={TagStories.Default} />
+
+## Tag Group
+
+<Description of={TagStories.TagGroup} />
+
+<Canvas of={TagStories.TagGroup} />
+
+<RenderHtmlMarkup of={TagStories.TagGroup} />
+
+

--- a/src/components/tag/tag.stories.tsx
+++ b/src/components/tag/tag.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Tag, TagGroup as TagGroupComponent } from './tag'
+
+export default {
+  title: 'Components/Tag',
+  component: Tag,
+  args: {
+    children: 'Tag',
+  },
+} as Meta<typeof Tag>
+
+type Story = StoryObj<typeof Tag>
+
+/**
+ * The `Tag` component is used to label, categorise or organise items using keywords.
+ */
+export const Default: Story = {}
+
+/**
+ * The `TagGroup` Component is useful to render multiple `Tag`
+ */
+export const TagGroup: Story = {
+  render: () => (
+    <TagGroupComponent>
+      <Tag>Tag</Tag>
+      <Tag>Tag</Tag>
+      <Tag>Tag</Tag>
+      <Tag>Tag</Tag>
+      <Tag>Tag</Tag>
+    </TagGroupComponent>
+  ),
+}

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,0 +1,4 @@
+import { ElTag, ElTagGroup } from './styles'
+
+export const Tag = ElTag
+export const TagGroup = ElTagGroup


### PR DESCRIPTION
## Context
There is new v5 tag #241 that will replace the previous (v4) tag component.

_note: #269 need to be merged first in order deprecate older component_

this pr is to create the new component to replace the previous one

# Pull request checklist

**Detail as per issue below (required):**
[x] new tag component

result preview:

https://github.com/user-attachments/assets/cad5ef0d-c4d9-4463-8223-683cb20d543f



