### PR TITLE
feat: #241 v5 new Tag component props refactor

### DIFF
--- a/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tag > should render standalone tag properly and match snapshot 1`] = `
 <DocumentFragment>
   <span
-    class="mocked-styled-0 el-tag"
+    class="el-tag"
   >
     Tag
   </span>
@@ -13,10 +13,10 @@ exports[`Tag > should render standalone tag properly and match snapshot 1`] = `
 exports[`Tag > should render tag group properly and match snapshot 1`] = `
 <DocumentFragment>
   <ul
-    class="mocked-styled-2 el-tag-group"
+    class="mocked-styled-0 el-tag-group"
   >
     <li
-      class="mocked-styled-1 el-tag-group-item"
+      class="el-tag"
     >
       Tag
     </li>

--- a/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tag > should render standalone tag properly and match snapshot 1`] = `
 <DocumentFragment>
   <span
-    class="mocked-styled-0 el-standalone-tag"
+    class="mocked-styled-0 el-tag"
   >
     Tag
   </span>
@@ -16,7 +16,7 @@ exports[`Tag > should render tag group properly and match snapshot 1`] = `
     class="mocked-styled-2 el-tag-group"
   >
     <li
-      class="mocked-styled-1 el-tag"
+      class="mocked-styled-1 el-tag-group-item"
     >
       Tag
     </li>

--- a/src/components/tag/__tests__/tag.test.tsx
+++ b/src/components/tag/__tests__/tag.test.tsx
@@ -11,7 +11,7 @@ describe('Tag', () => {
     expect(asFragment()).toMatchSnapshot()
   })
   it('should render standalone tag properly and match snapshot', () => {
-    const { asFragment } = render(<Tag isStandalone>Tag</Tag>)
+    const { asFragment } = render(<Tag as="span">Tag</Tag>)
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/src/components/tag/styles.tsx
+++ b/src/components/tag/styles.tsx
@@ -1,6 +1,7 @@
+import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
-const baseTagStyle = `
+export const elTag = css`
   width: fit-content;
   padding: var(--spacing-half) var(--spacing-3);
   border-radius: var(--corner-xl);
@@ -16,13 +17,6 @@ const baseTagStyle = `
   &::marker {
     content: '';
   }
-`
-
-export const ElTag = styled.span`
-  ${baseTagStyle}
-`
-export const ElTagGroupItem = styled.li`
-  ${baseTagStyle}
 `
 
 export const ElTagGroup = styled.ul`

--- a/src/components/tag/styles.tsx
+++ b/src/components/tag/styles.tsx
@@ -18,10 +18,10 @@ const baseTagStyle = `
   }
 `
 
-export const ElStandaloneTag = styled.span`
+export const ElTag = styled.span`
   ${baseTagStyle}
 `
-export const ElTag = styled.li`
+export const ElTagGroupItem = styled.li`
   ${baseTagStyle}
 `
 

--- a/src/components/tag/tag.stories.tsx
+++ b/src/components/tag/tag.stories.tsx
@@ -6,12 +6,12 @@ export default {
   component: Tag,
   args: {
     children: 'Tag',
-    isStandalone: false,
   },
   argTypes: {
-    isStandalone: {
-      control: 'boolean',
+    as: {
+      control: 'inline-radio',
       description: 'whether the component will be rendered as `span` or `li`',
+      options: ['li', 'span'],
     },
   },
 } as Meta<typeof Tag>
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof Tag>
  */
 export const Default: Story = {
   args: {
-    isStandalone: true,
+    as: 'span',
   },
 }
 

--- a/src/components/tag/tag.stories.tsx
+++ b/src/components/tag/tag.stories.tsx
@@ -10,7 +10,8 @@ export default {
   argTypes: {
     as: {
       control: 'inline-radio',
-      description: 'whether the component will be rendered as `span` or `li`',
+      description:
+        'whether the component will be rendered as `li` or `span`, defaults to `li` for easier use with `TagGroup`',
       options: ['li', 'span'],
     },
   },
@@ -23,7 +24,7 @@ type Story = StoryObj<typeof Tag>
  */
 export const Default: Story = {
   args: {
-    as: 'span',
+    as: 'li',
   },
 }
 

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,11 +1,11 @@
-import { ElStandaloneTag, ElTag, ElTagGroup } from './styles'
+import { ElTag, ElTagGroupItem, ElTagGroup } from './styles'
 
 export interface TagProps extends React.HTMLAttributes<HTMLLIElement | HTMLSpanElement> {
-  isStandalone?: boolean
+  as?: 'span' | 'li'
 }
 
-export const Tag: React.FC<TagProps> = ({ children, isStandalone = false, ...props }) => {
-  return isStandalone ? <ElStandaloneTag {...props}>{children}</ElStandaloneTag> : <ElTag {...props}>{children}</ElTag>
+export const Tag: React.FC<TagProps> = ({ children, as = 'li', ...props }) => {
+  return as == 'span' ? <ElTag {...props}>{children}</ElTag> : <ElTagGroupItem {...props}>{children}</ElTagGroupItem>
 }
 
 export const TagGroup = ElTagGroup

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,9 +1,16 @@
 import { cx } from '@linaria/core'
 import { elTag, ElTagGroup } from './styles'
+import type { HTMLAttributes } from 'react'
 
-export interface TagProps extends React.HTMLAttributes<HTMLLIElement | HTMLSpanElement> {
-  as?: 'span' | 'li'
+interface TagAsSpanProps extends HTMLAttributes<HTMLSpanElement> {
+  as: 'span'
 }
+
+interface TagAsListItemProps extends HTMLAttributes<HTMLLIElement> {
+  as?: 'li'
+}
+
+export type TagProps = TagAsSpanProps | TagAsListItemProps
 
 export const Tag: React.FC<TagProps> = ({ children, as: Element = 'li', ...props }) => {
   return (

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,3 +1,4 @@
+import { cx } from '@linaria/core'
 import { elTag, ElTagGroup } from './styles'
 
 export interface TagProps extends React.HTMLAttributes<HTMLLIElement | HTMLSpanElement> {
@@ -6,7 +7,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLLIElement | HTMLSpanE
 
 export const Tag: React.FC<TagProps> = ({ children, as: Element = 'li', ...props }) => {
   return (
-    <Element className={elTag} {...props}>
+    <Element {...props} className={cx(elTag, props.className)}>
       {children}
     </Element>
   )

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,11 +1,15 @@
-import { ElTag, ElTagGroupItem, ElTagGroup } from './styles'
+import { elTag, ElTagGroup } from './styles'
 
 export interface TagProps extends React.HTMLAttributes<HTMLLIElement | HTMLSpanElement> {
   as?: 'span' | 'li'
 }
 
-export const Tag: React.FC<TagProps> = ({ children, as = 'li', ...props }) => {
-  return as == 'span' ? <ElTag {...props}>{children}</ElTag> : <ElTagGroupItem {...props}>{children}</ElTagGroupItem>
+export const Tag: React.FC<TagProps> = ({ children, as: Element = 'li', ...props }) => {
+  return (
+    <Element className={elTag} {...props}>
+      {children}
+    </Element>
+  )
 }
 
 export const TagGroup = ElTagGroup


### PR DESCRIPTION
following the discussion [here](https://github.com/reapit/elements/issues/241#issuecomment-2603753748), we decided to use `as="span"` patten instead of `isStandalone` props pattern

additionally as the term/props changed, I update the exported styles component name
- `ElStandaloneTag` -> `ElTag`
- `ElTag` -> `ElTagGroupItem`

note: react user can still use them as `<Tag />`

# Pull request checklist
- [x] refactor props
- [x] rename styles var name
- [x] update stories and test

**Detail as per issue below (required):**

fixes: #241 


