### PR TITLE
feat: #258 add new `Chip` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@storybook/react-dom-shim": "^8.0.7",
     "@storybook/react-vite": "^8.0.7",
     "@storybook/theming": "^8.0.7",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/babel__core": "^7",

--- a/src/components/chip/__tests__/chip.test.tsx
+++ b/src/components/chip/__tests__/chip.test.tsx
@@ -1,0 +1,74 @@
+import { Chip } from '../chip'
+import { expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+test('renders as a <button> element', () => {
+  render(<Chip variant="filter">Label</Chip>)
+  expect(screen.getByRole('button', { name: 'Label' })).toBeVisible()
+})
+
+test('filter chip has `data-variant="filter"` attribute', () => {
+  render(<Chip variant="filter">Label</Chip>)
+  expect(screen.getByRole('button', { name: 'Label' })).toHaveAttribute('data-variant', 'filter')
+})
+
+test('selection chip has `data-variant="selection"` attribute', () => {
+  render(<Chip variant="selection">Label</Chip>)
+  expect(screen.getByRole('button', { name: 'Label' })).toHaveAttribute('data-variant', 'selection')
+})
+
+test('chip has `type="button"` attribute', () => {
+  render(<Chip variant="selection">Label</Chip>)
+  expect(screen.getByRole('button', { name: 'Label' })).toHaveAttribute('type', 'button')
+})
+
+test('chip has no `aria-disabled` attribute when enabled', () => {
+  render(<Chip variant="selection">Label</Chip>)
+  expect(screen.getByRole('button', { name: 'Label' })).not.toHaveAttribute('aria-disabled')
+})
+
+test('chip label has `data-will-truncate="true"` attribute when `willTruncateLabel` is provided', () => {
+  render(
+    <Chip willTruncateLabel variant="selection">
+      Label
+    </Chip>,
+  )
+  expect(screen.getByText('Label')).toHaveAttribute('data-will-truncate', 'true')
+})
+
+test('disabled chip has `aria-disabled="true"` attribute', () => {
+  render(
+    <Chip isDisabled variant="filter">
+      Label
+    </Chip>,
+  )
+  expect(screen.getByRole('button', { name: 'Label' })).toHaveAttribute('aria-disabled', 'true')
+})
+
+test('disabled chip does not call `onClick`', () => {
+  const fakeClick = vi.fn()
+  render(
+    <Chip isDisabled onClick={fakeClick} variant="filter">
+      Label
+    </Chip>,
+  )
+  const chip = screen.getByRole('button', { name: 'Label' })
+  fireEvent.click(chip)
+
+  expect(fakeClick).not.toHaveBeenCalled()
+})
+
+test('disabled chip prevents click events from propagating', () => {
+  const parentClickHandler = vi.fn()
+  render(
+    <div onClick={parentClickHandler}>
+      <Chip isDisabled variant="filter">
+        Label
+      </Chip>
+    </div>,
+  )
+  const chip = screen.getByRole('button', { name: 'Label' })
+  fireEvent.click(chip)
+
+  expect(parentClickHandler).not.toHaveBeenCalled()
+})

--- a/src/components/chip/chip.stories.tsx
+++ b/src/components/chip/chip.stories.tsx
@@ -1,0 +1,101 @@
+import { Chip } from './chip'
+import { Tooltip } from '../tooltip'
+import { useTooltip } from '../tooltip/use-tooltip'
+
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/Chip',
+  component: Chip,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+    variant: {
+      control: 'radio',
+      options: ['filter', 'selection'],
+    },
+  },
+} satisfies Meta<typeof Chip>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * The filter chip variant is primarily used in a filter bar to indicate what
+ * filters have been applied to a table
+ */
+export const FilterChip: Story = {
+  args: {
+    children: 'Label',
+    isDisabled: false,
+    willTruncateLabel: false,
+    variant: 'filter',
+  },
+}
+
+/**
+ * The selection chip variant is used in select controls and other similar
+ * components to display what selections have been made
+ */
+export const SelectionChip: Story = {
+  args: {
+    ...FilterChip.args,
+    variant: 'selection',
+  },
+}
+
+/**
+ * Chips can be disabled in order to prevent their removal. Disabled chips should
+ * remain focusable in order to keep them in the accessibility tree. If it is
+ * important to communicate why the chip is disabled, a tooltip can be provided.
+ */
+export const Disabled: Story = {
+  args: {
+    ...FilterChip.args,
+    isDisabled: true,
+  },
+  render: function DisabledChipStory(args) {
+    const tooltip = useTooltip()
+    return (
+      <>
+        <Chip {...args} {...tooltip.getTriggerProps()} />
+        <Tooltip description="Because reasons" position="top" {...tooltip.getTooltipProps()} />
+      </>
+    )
+  },
+}
+
+const useNarrowParentDecorator: Decorator = (Story, args) => {
+  return (
+    <div style={{ width: '300px' }}>
+      <Story {...args} />
+    </div>
+  )
+}
+
+/** By default, long labels will wrap if there is not enough space is available. */
+export const Wrapping: Story = {
+  args: {
+    ...FilterChip.args,
+    children: "This very long label will wrap because it's parent is not wide enough",
+  },
+  decorators: [useNarrowParentDecorator],
+}
+
+/**
+ * Truncation is an optional behaviour that can be enabled to prevent the label from
+ * wrapping on multiple lines
+ */
+export const Truncation: Story = {
+  args: {
+    ...FilterChip.args,
+    children: 'Truncation can be applied when necessary',
+    willTruncateLabel: true,
+  },
+  decorators: [useNarrowParentDecorator],
+}

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -1,0 +1,47 @@
+import { ElChip, ElChipClearIcon, ElChipLabel } from './styles'
+import { useCallback } from 'react'
+
+import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+
+type ElementAttributes = ButtonHTMLAttributes<HTMLButtonElement>
+
+// We omit a few attributes from the base ElChip component (itself based on a <button>):
+// - `disabled`: we use `isDisabled` instead (which maps to `aria-disabled`).
+// - `type`: chips should never be used as form submit or reset buttons.
+type ElementAttributesToOmit = Extract<keyof ElementAttributes, 'disabled' | 'type'>
+
+interface ChipProps extends Omit<ElementAttributes, ElementAttributesToOmit> {
+  children: ReactNode
+  isDisabled?: boolean
+  willTruncateLabel?: boolean
+  variant: 'filter' | 'selection'
+}
+
+/**
+ * An interactive chip that should be cleared (or removed) when clicked. Typically used within a `ChipGroup`.
+ */
+export function Chip({ children, isDisabled, onClick, variant, willTruncateLabel, ...rest }: ChipProps) {
+  const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
+    (event) => {
+      // We are not using <button>'s `disabled` attribute because disabled buttons are bad for a11y.
+      // Rather, we keep the <button> enabled and available in the a11y tree, but mark it as disabled using
+      // `aria-disabled`. This means click events will still be fired, so we need to prevent any default action
+      // for the button from occuring, stop it propagating to ancestors and avoid calling the consumer-supplied
+      // `onClick` callback.
+      if (isDisabled) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+      onClick?.(event)
+    },
+    [isDisabled, onClick],
+  )
+
+  return (
+    <ElChip {...rest} type="button" aria-disabled={isDisabled} data-variant={variant} onClick={handleClick}>
+      <ElChipLabel data-will-truncate={willTruncateLabel}>{children}</ElChipLabel>
+      <ElChipClearIcon icon="close" />
+    </ElChip>
+  )
+}

--- a/src/components/chip/index.ts
+++ b/src/components/chip/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './chip'

--- a/src/components/chip/styles.ts
+++ b/src/components/chip/styles.ts
@@ -44,8 +44,10 @@ export const ElChip = styled.button<ElChipProps>`
   }
 
   &:focus-visible {
-    outline: 3px solid var(--purple-300);
-    outline-offset: var(--size-px);
+    box-shadow:
+      0px 0px 0px var(--size-px) var(--white),
+      0px 0px 0px var(--size-1) var(--purple-300);
+    outline: none;
   }
 `
 

--- a/src/components/chip/styles.ts
+++ b/src/components/chip/styles.ts
@@ -1,0 +1,90 @@
+import { styled } from '@linaria/react'
+import { Icon } from '../icon'
+
+interface ElChipProps {
+  'data-variant': 'filter' | 'selection'
+}
+
+export const ElChip = styled.button<ElChipProps>`
+  align-items: center;
+  border: none;
+  border-radius: var(--corner-2xl);
+  cursor: pointer;
+  display: grid;
+  gap: var(--spacing-2);
+  grid-template-columns: auto min-content;
+  height: min-content;
+  padding-block: var(--spacing-1);
+  padding-inline: var(--spacing-4) var(--spacing-2);
+  width: fit-content;
+
+  &[data-variant='filter'] {
+    background: var(--fill-action-lightest);
+
+    &:hover {
+      background: var(--fill-action-light);
+    }
+  }
+
+  &[data-variant='selection'] {
+    background: var(--fill-default-lightest);
+
+    &:hover {
+      background: var(--fill-default-light);
+    }
+  }
+
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+    background: var(--fill-default-lightest);
+
+    &:hover {
+      background: var(--fill-default-lightest);
+    }
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--purple-300);
+    outline-offset: var(--size-px);
+  }
+`
+
+interface ElChipLabelProps {
+  'data-will-truncate'?: boolean
+}
+
+export const ElChipLabel = styled.span<ElChipLabelProps>`
+  color: var(--text-primary);
+
+  /* text-sm/Regular */
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-style: normal;
+  font-weight: 400;
+  letter-spacing: var(--letter-spacing-sm);
+  line-height: var(--line-height-sm);
+  text-align: left;
+
+  &[data-will-truncate='true'] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [aria-disabled='true'] & {
+    color: var(--text-placeholder);
+  }
+`
+
+export const ElChipClearIcon = styled(Icon)`
+  /* NOTE: We only use !important here because the current Icon component
+   * does not allow consumer-supplied styles to have a higher specificity */
+  color: var(--icon-secondary) !important;
+  font-size: 1rem;
+  height: var(--size-icon-sm) !important;
+  width: var(--size-icon-sm) !important;
+
+  [aria-disabled='true'] & {
+    color: var(--icon-disabled) !important;
+  }
+`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "target": "ES2022",
     "declaration": true,
     "declarationMap": true,
-    "types": ["vite/client", "vitest/globals", "vite-plugin-svgr/client"],
+    "types": ["vite/client", "vitest/globals", "vite-plugin-svgr/client", "@testing-library/jest-dom/vitest"],
     "lib": ["ES2022", "dom"],
     "outDir": "dist/types",
     "rootDir": "src",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,3 @@
+import '@testing-library/jest-dom/vitest'
+
 process.env.TZ = 'UTC'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.4.1
+  resolution: "@adobe/css-tools@npm:4.4.1"
+  checksum: 10/a0ea05517308593a52728936a833b1075c4cf1a6b68baaea817063f34e75faa1dba1209dd285003c4f8072804227dfa563e7e903f72ae2d39cb520aaee3f4bcc
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.2.1
   resolution: "@ampproject/remapping@npm:2.2.1"
@@ -2844,6 +2851,7 @@ __metadata:
     "@storybook/react-dom-shim": "npm:^8.0.7"
     "@storybook/react-vite": "npm:^8.0.7"
     "@storybook/theming": "npm:^8.0.7"
+    "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^12.1.5"
     "@testing-library/react-hooks": "npm:^8.0.1"
     "@types/babel__core": "npm:^7"
@@ -4146,6 +4154,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:^6.6.3":
+  version: 6.6.3
+  resolution: "@testing-library/jest-dom@npm:6.6.3"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    chalk: "npm:^3.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    lodash: "npm:^4.17.21"
+    redent: "npm:^3.0.0"
+  checksum: 10/1f3427e45870eab9dcc59d6504b780d4a595062fe1687762ae6e67d06a70bf439b40ab64cf58cbace6293a99e3764d4647fdc8300a633b721764f5ce39dade18
+  languageName: node
+  linkType: hard
+
 "@testing-library/react-hooks@npm:^8.0.1":
   version: 8.0.1
   resolution: "@testing-library/react-hooks@npm:8.0.1"
@@ -5331,6 +5354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "aria-query@npm:5.3.2"
+  checksum: 10/b2fe9bc98bd401bc322ccb99717c1ae2aaf53ea0d468d6e7aebdc02fac736e4a99b46971ee05b783b08ade23c675b2d8b60e4a1222a95f6e27bc4d2a0bfdcc03
+  languageName: node
+  linkType: hard
+
 "array-buffer-byte-length@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-buffer-byte-length@npm:1.0.0"
@@ -6027,6 +6057,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chalk@npm:3.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/37f90b31fd655fb49c2bd8e2a68aebefddd64522655d001ef417e6f955def0ed9110a867ffc878a533f2dafea5f2032433a37c8a7614969baa7f8a1cd424ddfc
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -6448,6 +6488,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10/f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.0.2":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
@@ -6795,6 +6842,13 @@ __metadata:
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 10/377b4a7f9eae0a5d72e1068c369c99e0e4ca17fdfd5219f3abd32a73a590749a267475a59d7b03a891f9b673c27429133a818c44b2e47e32fec024b34274e2ca
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10/83d3371f8226487fbad36e160d44f1d9017fb26d46faba6a06fcad15f34633fc827b8c3e99d49f71d5f3253d866e2131826866fd0a3c86626f8eccfc361881ff
   languageName: node
   linkType: hard
 
@@ -10154,7 +10208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"min-indent@npm:^1.0.1":
+"min-indent@npm:^1.0.0, min-indent@npm:^1.0.1":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: 10/bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
@@ -11672,6 +11726,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10/fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
+  languageName: node
+  linkType: hard
+
 "redent@npm:^4.0.0":
   version: 4.0.0
   resolution: "redent@npm:4.0.0"
@@ -12884,6 +12948,15 @@ __metadata:
   version: 3.0.0
   resolution: "strip-final-newline@npm:3.0.0"
   checksum: 10/23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10/18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context

- #258 is introducing a new Chip component
- Elements has an existing Chip component that is considerably different regarding it's intended usage/semantics (it acts as a checkbox)
- #303 deprecated this existing Chip (and Chip Group) component to make room for a new <button>-based version

### This PR

- Adds the new Chip component (a new ChipGroup component will be added in a separate PR).

<img width="1139" alt="Screenshot 2025-02-07 at 2 39 39 PM" src="https://github.com/user-attachments/assets/7d6160b7-90a3-45aa-8a49-5a43eb39316f" />

**note:** The "Simple Chip" detailed in the Figma designs is currently marked as out-of-scope, so only the "Clearable Chip" has been implemented.