### PR TITLE
feat: #258 add new `ChipGroup` component

### DIFF
--- a/src/components/chip-group/__tests__/chip-group-item.tsx
+++ b/src/components/chip-group/__tests__/chip-group-item.tsx
@@ -1,0 +1,13 @@
+import { ChipGroupItem } from '../chip-group-item'
+import { expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+test('renders a chip with a list item ancestor', () => {
+  render(<ChipGroupItem variant="filter">Label</ChipGroupItem>)
+  const chip = screen.getByRole('button', { name: 'Label' })
+  const listItem = screen.getByRole('listitem')
+
+  expect(chip).toBeVisible()
+  expect(listItem).toBeVisible()
+  expect(chip.parentElement).toBe(listItem)
+})

--- a/src/components/chip-group/__tests__/chip-group.test.tsx
+++ b/src/components/chip-group/__tests__/chip-group.test.tsx
@@ -1,0 +1,21 @@
+import { ChipGroup } from '../chip-group'
+import { expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+test('renders its children in a list', () => {
+  render(<ChipGroup>Fake child</ChipGroup>)
+  const list = screen.getByRole('list')
+
+  expect(list).toBeVisible()
+  expect(list).toHaveTextContent('Fake child')
+})
+
+test('chip group list has `data-overflow="wrap"` attribute, by default', () => {
+  render(<ChipGroup>Fake child</ChipGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'wrap')
+})
+
+test('chip group list has `data-overflow="scroll"` attribute when specified', () => {
+  render(<ChipGroup overflow="scroll">Fake child</ChipGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'scroll')
+})

--- a/src/components/chip-group/chip-group-item.tsx
+++ b/src/components/chip-group/chip-group-item.tsx
@@ -1,0 +1,17 @@
+import { ElChipGroupListItem } from './styles'
+import { Chip } from '../chip/chip'
+
+import type { ComponentProps } from 'react'
+
+interface ChipGroupItemProps extends ComponentProps<typeof Chip> {}
+
+/**
+ * A thin wrapper around a chip to ensure it is rendered as a list item inside the chip group.
+ */
+export function ChipGroupItem(props: ChipGroupItemProps) {
+  return (
+    <ElChipGroupListItem>
+      <Chip {...props} />
+    </ElChipGroupListItem>
+  )
+}

--- a/src/components/chip-group/chip-group.stories.tsx
+++ b/src/components/chip-group/chip-group.stories.tsx
@@ -1,0 +1,114 @@
+import { ChipGroup } from './chip-group'
+import * as ChipStories from '../chip/chip.stories'
+
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/ChipGroup',
+  component: ChipGroup,
+  argTypes: {
+    children: {
+      control: 'radio',
+      defaultValue: 'Filter Chips',
+      options: ['Filter Chips', 'Selection Chips'],
+      mapping: {
+        'Filter Chips': (
+          <>
+            <ChipGroup.Item {...ChipStories.FilterChip.args}>Apples</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.FilterChip.args}>Bananas</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.FilterChip.args}>Oranges</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.FilterChip.args}>Peanuts</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.FilterChip.args}>Strawberries</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.FilterChip.args}>Watermelons</ChipGroup.Item>
+          </>
+        ),
+        'Selection Chips': (
+          <>
+            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Red</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Blue</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Yellow</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Pink</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Black</ChipGroup.Item>
+            <ChipGroup.Item {...ChipStories.SelectionChip.args}>White</ChipGroup.Item>
+          </>
+        ),
+      },
+    },
+    overflow: {
+      control: 'radio',
+      options: ['scroll', 'wrap'],
+    },
+  },
+} satisfies Meta<typeof ChipGroup>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const useNarrowParentDecorator: Decorator = (Story, args) => {
+  return (
+    <div style={{ border: '1px solid #FA00FF', width: '397px' }}>
+      <Story {...args} />
+    </div>
+  )
+}
+
+/**
+ * By default, a chip group will grow to whatever width it's parent allows.
+ */
+export const Default: Story = {
+  args: {
+    children: 'Filter Chips',
+    overflow: 'wrap',
+  },
+}
+
+/**
+ * By default, chips will wrap to other lines if they would otherwise overflow the group's bounding box.
+ */
+export const Wrapping: Story = {
+  args: {
+    ...Default.args,
+    overflow: 'wrap',
+  },
+  decorators: [useNarrowParentDecorator],
+}
+
+/**
+ * In some instances (e.g. small breakpoints), horizontal scrolling can be facilitated.
+ */
+export const Scrolling: Story = {
+  args: {
+    ...Wrapping.args,
+    overflow: 'scroll',
+  },
+  decorators: [useNarrowParentDecorator],
+}
+
+/**
+ * Whether wrapping or scrolling is used, chips will size themselves appropriately based on the
+ * length of their label.
+ */
+export const ChipLabels: Story = {
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  args: {
+    children: (
+      <>
+        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 1</ChipGroup.Item>
+        <ChipGroup.Item {...ChipStories.Disabled.args}>Chip 2</ChipGroup.Item>
+        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 3</ChipGroup.Item>
+        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 4</ChipGroup.Item>
+        <ChipGroup.Item {...ChipStories.Truncation.args} />
+        <ChipGroup.Item {...ChipStories.Disabled.args}>Chip 5</ChipGroup.Item>
+        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 6</ChipGroup.Item>
+        <ChipGroup.Item {...ChipStories.Wrapping.args} />
+      </>
+    ),
+    overflow: 'wrap',
+  },
+  decorators: [useNarrowParentDecorator],
+}

--- a/src/components/chip-group/chip-group.stories.tsx
+++ b/src/components/chip-group/chip-group.stories.tsx
@@ -45,10 +45,10 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const useNarrowParentDecorator: Decorator = (Story, args) => {
+const useNarrowParentDecorator: Decorator = (Story) => {
   return (
     <div style={{ border: '1px solid #FA00FF', width: '397px' }}>
-      <Story {...args} />
+      <Story />
     </div>
   )
 }
@@ -89,7 +89,7 @@ export const Scrolling: Story = {
  * Whether wrapping or scrolling is used, chips will size themselves appropriately based on the
  * length of their label.
  */
-export const ChipLabels: Story = {
+export const ChipSizing: Story = {
   argTypes: {
     children: {
       control: false,
@@ -102,10 +102,14 @@ export const ChipLabels: Story = {
         <ChipGroup.Item {...ChipStories.Disabled.args}>Chip 2</ChipGroup.Item>
         <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 3</ChipGroup.Item>
         <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 4</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.Truncation.args} />
+        <ChipGroup.Item {...ChipStories.Truncation.args}>
+          Truncation can be applied to ensure a long chip label does not wrap to a second line
+        </ChipGroup.Item>
         <ChipGroup.Item {...ChipStories.Disabled.args}>Chip 5</ChipGroup.Item>
         <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 6</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.Wrapping.args} />
+        <ChipGroup.Item {...ChipStories.Wrapping.args}>
+          Or, you can avoid truncation and allow a long chip label to wrap to multiple lines
+        </ChipGroup.Item>
       </>
     ),
     overflow: 'wrap',

--- a/src/components/chip-group/chip-group.stories.tsx
+++ b/src/components/chip-group/chip-group.stories.tsx
@@ -12,26 +12,46 @@ const meta = {
       defaultValue: 'Filter Chips',
       options: ['Filter Chips', 'Selection Chips'],
       mapping: {
-        'Filter Chips': (
-          <>
-            <ChipGroup.Item {...ChipStories.FilterChip.args}>Apples</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.FilterChip.args}>Bananas</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.FilterChip.args}>Oranges</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.FilterChip.args}>Peanuts</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.FilterChip.args}>Strawberries</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.FilterChip.args}>Watermelons</ChipGroup.Item>
-          </>
-        ),
-        'Selection Chips': (
-          <>
-            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Red</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Blue</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Yellow</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Pink</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.SelectionChip.args}>Black</ChipGroup.Item>
-            <ChipGroup.Item {...ChipStories.SelectionChip.args}>White</ChipGroup.Item>
-          </>
-        ),
+        'Filter Chips': [
+          <ChipGroup.Item key="1" {...ChipStories.FilterChip.args}>
+            Apples
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="2" {...ChipStories.FilterChip.args}>
+            Bananas
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="3" {...ChipStories.FilterChip.args}>
+            Oranges
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="4" {...ChipStories.FilterChip.args}>
+            Peanuts
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="5" {...ChipStories.FilterChip.args}>
+            Strawberries
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="6" {...ChipStories.FilterChip.args}>
+            Watermelons
+          </ChipGroup.Item>,
+        ],
+        'Selection Chips': [
+          <ChipGroup.Item key="1" {...ChipStories.SelectionChip.args}>
+            Red
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="2" {...ChipStories.SelectionChip.args}>
+            Blue
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="3" {...ChipStories.SelectionChip.args}>
+            Yellow
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="4" {...ChipStories.SelectionChip.args}>
+            Pink
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="5" {...ChipStories.SelectionChip.args}>
+            Black
+          </ChipGroup.Item>,
+          <ChipGroup.Item key="6" {...ChipStories.SelectionChip.args}>
+            White
+          </ChipGroup.Item>,
+        ],
       },
     },
     overflow: {
@@ -96,22 +116,32 @@ export const ChipSizing: Story = {
     },
   },
   args: {
-    children: (
-      <>
-        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 1</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.Disabled.args}>Chip 2</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 3</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 4</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.Truncation.args}>
-          Truncation can be applied to ensure a long chip label does not wrap to a second line
-        </ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.Disabled.args}>Chip 5</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.FilterChip.args}>Chip 6</ChipGroup.Item>
-        <ChipGroup.Item {...ChipStories.Wrapping.args}>
-          Or, you can avoid truncation and allow a long chip label to wrap to multiple lines
-        </ChipGroup.Item>
-      </>
-    ),
+    children: [
+      <ChipGroup.Item key="1" {...ChipStories.FilterChip.args}>
+        Chip 1
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="2" {...ChipStories.Disabled.args}>
+        Chip 2
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="3" {...ChipStories.FilterChip.args}>
+        Chip 3
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="4" {...ChipStories.FilterChip.args}>
+        Chip 4
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="5" {...ChipStories.Truncation.args}>
+        Truncation can be applied to ensure a long chip label does not wrap to a second line
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="6" {...ChipStories.Disabled.args}>
+        Chip 5
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="7" {...ChipStories.FilterChip.args}>
+        Chip 6
+      </ChipGroup.Item>,
+      <ChipGroup.Item key="8" {...ChipStories.Wrapping.args}>
+        Or, you can avoid truncation and allow a long chip label to wrap to multiple lines
+      </ChipGroup.Item>,
+    ],
     overflow: 'wrap',
   },
   decorators: [useNarrowParentDecorator],

--- a/src/components/chip-group/chip-group.tsx
+++ b/src/components/chip-group/chip-group.tsx
@@ -1,0 +1,23 @@
+import { ElChipGroup, ElChipGroupList } from './styles'
+import { ChipGroupItem } from './chip-group-item'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface ChipGroupProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode
+  overflow?: 'scroll' | 'wrap'
+}
+
+/**
+ * Groups multiple chips together. Should only be used to group chips of the same variant. By default,
+ * chips will wrap within the group, though horizontal scrolling can be permitted when required.
+ */
+export function ChipGroup({ children, overflow = 'wrap', ...rest }: ChipGroupProps) {
+  return (
+    <ElChipGroup {...rest}>
+      <ElChipGroupList data-overflow={overflow}>{children}</ElChipGroupList>
+    </ElChipGroup>
+  )
+}
+
+ChipGroup.Item = ChipGroupItem

--- a/src/components/chip-group/styles.ts
+++ b/src/components/chip-group/styles.ts
@@ -14,7 +14,7 @@ interface ElChipGroupListProps {
 
 export const ElChipGroupList = styled.ul<ElChipGroupListProps>`
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   list-style: none;
 
   &[data-overflow='scroll'] {

--- a/src/components/chip-group/styles.ts
+++ b/src/components/chip-group/styles.ts
@@ -1,0 +1,32 @@
+import { styled } from '@linaria/react'
+
+export const ElChipGroup = styled.div`
+  display: block;
+
+  :has(& > [data-overflow='scroll']) {
+    overflow-x: auto;
+  }
+`
+
+interface ElChipGroupListProps {
+  'data-overflow': 'scroll' | 'wrap'
+}
+
+export const ElChipGroupList = styled.ul<ElChipGroupListProps>`
+  display: flex;
+  gap: 8px;
+  list-style: none;
+
+  &[data-overflow='scroll'] {
+    flex-wrap: nowrap;
+    width: max-content;
+  }
+
+  &[data-overflow='wrap'] {
+    flex-wrap: wrap;
+  }
+`
+
+export const ElChipGroupListItem = styled.li`
+  display: block;
+`

--- a/src/components/chip/chip.stories.tsx
+++ b/src/components/chip/chip.stories.tsx
@@ -70,10 +70,10 @@ export const Disabled: Story = {
   },
 }
 
-const useNarrowParentDecorator: Decorator = (Story, args) => {
+const useNarrowParentDecorator: Decorator = (Story) => {
   return (
     <div style={{ width: '300px' }}>
-      <Story {...args} />
+      <Story />
     </div>
   )
 }


### PR DESCRIPTION
### Context

- #258 is introducing a new Chip component
- Elements has an existing Chip component that is considerably different regarding it's intended usage/semantics (it acts as a checkbox)
- #303 deprecated this existing Chip (and Chip Group) component to make room for a new <button>-based version
- #304 adds a new Chip component

### This PR

- Adds a new ChipGroup component.

<img width="1141" alt="Screenshot 2025-02-10 at 10 05 47 AM" src="https://github.com/user-attachments/assets/4c28e073-80e7-44f9-8125-2a4ed68aa031" />

<img width="1142" alt="Screenshot 2025-02-11 at 12 33 36 PM" src="https://github.com/user-attachments/assets/a6770c8d-eb83-4954-831a-9da3f0c73bf7" />