### PR TITLE
chore: Externalise peer dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
 import svgr from 'vite-plugin-svgr'
 import wyw from '@wyw-in-js/vite'
+import packageManifest from './package.json'
 
 export default defineConfig({
   build: {
@@ -16,6 +17,36 @@ export default defineConfig({
       formats: ['es', 'cjs'],
     },
     outDir: 'dist/js',
+    rollupOptions: {
+      // NOTE: This function ensures all peerDependencies defined in our package manifest are correctly externalised
+      // (i.e. not bundled into our build artefact/s)
+      external(id, _, isResolved) {
+        // A resolved id is an absolute file path to the module being imported and since the names of our package's
+        // peers do not correlate to the folder name thanks to the `@console` scope our package names typically
+        // include, we cannot have enough confidence to externalise a resolved id. Thus we always return false.
+        if (isResolved) {
+          return false
+        }
+
+        const peerDependencies = Object.keys(packageManifest.peerDependencies)
+
+        return peerDependencies.some((packageName) => {
+          // Imports from a peer dependency fall into one of two categories:
+          //  1. From the peer's root entry point, e.g. `import { Foo } from "my-peer-dependency"`; or,
+          //  2. From a peer's subpath/non-root entry point, e.g. `import Foo from "my-peer-dependency/foo".
+          //
+          // The `id` we have here will be `my-peer-dependency` and `my-peer-dependency/foo` respectively.
+          // Since `my-peer-dependency` is the name of a package declared as a peer, we want to externalise
+          // both imports. However, we do not want to externalise an `id` like `my-peer-dependency-alt`, so
+          // it is important we do not simply look for a substring match.
+          //
+          // So, for scenario (1), we check for an exact match, and for scenario (2), we check if the `id`
+          // starts with the peer's name AND a `/`. The inclusion of the trailing slash is to avoid partial
+          // matches against an `id` that happens to have our peer's name as a valid substring.
+          return id === packageName || id.startsWith(`${packageName}/`)
+        })
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
Ensure's all peer dependencies are externalised by Vite.

fixes: #317



