### PR TITLE
feat: #154 v5 new SideBar (Menu Group and Group Item)

### DIFF
--- a/src/components/side-bar-menu-group/__tests__/is-side-bar-menu-group-expanded-context.test.tsx
+++ b/src/components/side-bar-menu-group/__tests__/is-side-bar-menu-group-expanded-context.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  useIsSideBarMenuGroupExpandedContext,
+  IsSideBarMenuGroupExpandedContext,
+} from '../is-side-bar-menu-group-expanded-context'
+import { useState } from 'react'
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const [isExpanded, setIsExpanded] = useState(true)
+  return (
+    <IsSideBarMenuGroupExpandedContext.Provider value={{ isExpanded, setIsExpanded }}>
+      {children}
+    </IsSideBarMenuGroupExpandedContext.Provider>
+  )
+}
+
+describe('useIsSideBarMenuGroupExpandedContext', () => {
+  it('should return context value when used within a provider', () => {
+    const { result } = renderHook(() => useIsSideBarMenuGroupExpandedContext(), { wrapper: Wrapper })
+    expect(result.current).toHaveProperty('isExpanded', true)
+    expect(result.current).toHaveProperty('setIsExpanded')
+  })
+
+  it('should throw an error when used outside the provider', () => {
+    expect(() => renderHook(() => useIsSideBarMenuGroupExpandedContext())).toThrow(
+      'useIsSideBarMenuGroupExpandedContext must be used within a SideBarMenuGroupExpandedContext Provider',
+    )
+  })
+})

--- a/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
+++ b/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SideBarMenuGroupItem, SideBarMenuGroup } from '..'
+import { SideBar } from '#src/components/side-bar/side-bar'
+import { SideBarCollapseButton } from '../../side-bar-collapse-button'
+
+describe('SideBarMenuGroupItem', () => {
+  it('renders with available props correctly', () => {
+    render(<SideBarMenuGroupItem href="/test">Test Child</SideBarMenuGroupItem>)
+    expect(screen.getByText('Test Child')).toBeInTheDocument()
+    expect(screen.getByText('Test Child')).toHaveAttribute('href', '/test')
+    expect(screen.getByText('Test Child')).not.toHaveAttribute('aria-current')
+  })
+
+  it('sets aria-current to page when isActive is true', () => {
+    render(<SideBarMenuGroupItem isActive>Active Item</SideBarMenuGroupItem>)
+    expect(screen.getByText('Active Item')).toHaveAttribute('aria-current', 'page')
+  })
+})
+
+describe('SideBarMenuGroup', () => {
+  it('renders label and icon correctly', () => {
+    render(
+      <SideBar>
+        <SideBarMenuGroup label="Trigger Label" icon={<span>mocked icon</span>}>
+          Child Item
+        </SideBarMenuGroup>
+      </SideBar>,
+    )
+    expect(screen.getByText('Trigger Label')).toBeInTheDocument()
+    expect(screen.getByText('mocked icon')).toBeInTheDocument()
+  })
+
+  it('renders active state properly', () => {
+    render(
+      <SideBar>
+        <SideBarMenuGroup label="Trigger Label" icon={null} isActive>
+          Child Item
+        </SideBarMenuGroup>
+      </SideBar>,
+    )
+    expect(screen.getByText('Trigger Label').parentElement).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('hide trigger label and show icon when SideBar is closed', () => {
+    render(
+      <SideBar>
+        <SideBarMenuGroup label="Trigger Label" icon={<span>mocked icon</span>}>
+          Child Item
+        </SideBarMenuGroup>
+        <SideBarCollapseButton data-testid="collapse-button-container" />
+      </SideBar>,
+    )
+    fireEvent.click(screen.getByTestId('collapse-button-container').children[0])
+    expect(screen.queryByText('Trigger Label')).not.toBeInTheDocument()
+    expect(screen.getByText('mocked icon')).toBeInTheDocument()
+  })
+
+  it('expand menu group and trigger click while SideBar is closed', () => {
+    render(
+      <SideBar>
+        <SideBarMenuGroup label="Trigger Label" icon={<span>mocked icon</span>}>
+          Child Item
+        </SideBarMenuGroup>
+        <SideBarCollapseButton data-testid="collapse-button-container" />
+      </SideBar>,
+    )
+    const collapseButton = screen.getByTestId('collapse-button-container').children[0]
+    fireEvent.click(collapseButton)
+    expect(screen.queryByText('Child Item')).not.toBeInTheDocument()
+
+    const triggerButton = screen.getByRole('button', { name: 'mocked icon' })
+    fireEvent.click(triggerButton)
+    expect(screen.getByText('Child Item')).toBeInTheDocument()
+  })
+
+  it('show and hide child item based on SideBar expanded state', () => {
+    render(
+      <SideBar>
+        <SideBarMenuGroup label="Group" icon={null}>
+          Child Item
+        </SideBarMenuGroup>
+      </SideBar>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('Child Item')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByText('Child Item')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
+++ b/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
@@ -41,7 +41,7 @@ describe('SideBarMenuGroup', () => {
     expect(screen.getByText('Trigger Label').parentElement).toHaveAttribute('aria-current', 'page')
   })
 
-  it('hide trigger label and show icon when SideBar is closed', () => {
+  it('hide trigger label and show only icon when SideBar is collapsed', () => {
     render(
       <SideBar>
         <SideBarMenuGroup label="Trigger Label" icon={<span>mocked icon</span>}>
@@ -55,7 +55,7 @@ describe('SideBarMenuGroup', () => {
     expect(screen.getByText('mocked icon')).toBeInTheDocument()
   })
 
-  it('expand menu group and trigger click while SideBar is closed', () => {
+  it('should expand SideBar and MenuGroup when trigger button is clicked while SideBar is collapsed ', () => {
     render(
       <SideBar>
         <SideBarMenuGroup label="Trigger Label" icon={<span>mocked icon</span>}>
@@ -70,6 +70,7 @@ describe('SideBarMenuGroup', () => {
 
     const triggerButton = screen.getByRole('button', { name: 'mocked icon' })
     fireEvent.click(triggerButton)
+    expect(screen.getByText('Trigger Label')).toBeInTheDocument()
     expect(screen.getByText('Child Item')).toBeInTheDocument()
   })
 

--- a/src/components/side-bar-menu-group/index.ts
+++ b/src/components/side-bar-menu-group/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './side-bar-menu-group'

--- a/src/components/side-bar-menu-group/is-side-bar-menu-group-expanded-context.tsx
+++ b/src/components/side-bar-menu-group/is-side-bar-menu-group-expanded-context.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, type Dispatch, type SetStateAction } from 'react'
+
+interface IsSideBarMenuGroupExpandedContextValue {
+  isExpanded: boolean
+  setIsExpanded: Dispatch<SetStateAction<boolean>>
+}
+export const IsSideBarMenuGroupExpandedContext = createContext<IsSideBarMenuGroupExpandedContextValue | null>(null)
+
+export const useIsSideBarMenuGroupExpandedContext = () => {
+  const context = useContext(IsSideBarMenuGroupExpandedContext)
+  if (!context) {
+    throw new Error(
+      'useIsSideBarMenuGroupExpandedContext must be used within a SideBarMenuGroupExpandedContext Provider',
+    )
+  }
+  return context
+}

--- a/src/components/side-bar-menu-group/side-bar-menu-group.molecules.tsx
+++ b/src/components/side-bar-menu-group/side-bar-menu-group.molecules.tsx
@@ -1,0 +1,75 @@
+import { useState, type FC, type ReactNode } from 'react'
+import { Icon } from '../icon'
+import { useIsSideBarExpandedContext } from '../side-bar/is-side-bar-expanded-context'
+import {
+  IsSideBarMenuGroupExpandedContext,
+  useIsSideBarMenuGroupExpandedContext,
+} from './is-side-bar-menu-group-expanded-context'
+import {
+  elDropdownIcon,
+  ElSideBarMenuGroupItemTrigger,
+  ElSideBarMenuGroup,
+  ElSideBarMenuGroupTriggerIcon,
+  ElSideBarMenuGroupItemText,
+  ElSideBarMenuGroupList,
+} from './styles'
+
+interface SideBarMenuGroupItemProps {
+  icon: ReactNode
+  isActive?: boolean
+  children: ReactNode
+}
+
+export const SideBarMenuGroupItemTrigger: FC<SideBarMenuGroupItemProps> = ({ icon, isActive, children }) => {
+  const { isExpanded: isSideBarExpanded, setIsExpanded: setIsSideBarExpanded } = useIsSideBarExpandedContext()
+  const { isExpanded, setIsExpanded } = useIsSideBarMenuGroupExpandedContext()
+
+  const handleClick = () => {
+    setIsSideBarExpanded(true)
+    // always open menu when SideBar is not expanded otherwise do toggle
+    setIsExpanded(!isSideBarExpanded ? true : !isExpanded)
+  }
+
+  return (
+    <ElSideBarMenuGroupItemTrigger
+      aria-current={isActive ? 'page' : undefined}
+      data-expanded={isExpanded}
+      onClick={handleClick}
+      data-expandable="true"
+    >
+      <ElSideBarMenuGroupTriggerIcon>{icon}</ElSideBarMenuGroupTriggerIcon>
+      {isSideBarExpanded && (
+        <>
+          <ElSideBarMenuGroupItemText>{children}</ElSideBarMenuGroupItemText>
+          {isExpanded ? (
+            <Icon className={elDropdownIcon} icon="chevronUp" />
+          ) : (
+            <Icon className={elDropdownIcon} icon="chevronDown" />
+          )}
+        </>
+      )}
+    </ElSideBarMenuGroupItemTrigger>
+  )
+}
+
+interface SideBarMenuGroupContainerProps {
+  children: ReactNode
+  isActive?: boolean
+}
+export const SideBarMenuGroupContainer: FC<SideBarMenuGroupContainerProps> = ({ children, isActive = false }) => {
+  const [isExpanded, setIsExpanded] = useState(isActive)
+
+  return (
+    <IsSideBarMenuGroupExpandedContext.Provider value={{ isExpanded, setIsExpanded }}>
+      <ElSideBarMenuGroup>{children}</ElSideBarMenuGroup>
+    </IsSideBarMenuGroupExpandedContext.Provider>
+  )
+}
+
+export const SideBarMenuGroupList: FC<{ children: ReactNode }> = ({ children }) => {
+  const { isExpanded } = useIsSideBarMenuGroupExpandedContext()
+  const { isExpanded: isSideBarExpanded } = useIsSideBarExpandedContext()
+
+  if (!isExpanded || !isSideBarExpanded) return null
+  return <ElSideBarMenuGroupList>{children}</ElSideBarMenuGroupList>
+}

--- a/src/components/side-bar-menu-group/side-bar-menu-group.tsx
+++ b/src/components/side-bar-menu-group/side-bar-menu-group.tsx
@@ -1,0 +1,54 @@
+import type { AnchorHTMLAttributes, FC, HTMLAttributes, ReactNode } from 'react'
+import {
+  SideBarMenuGroupContainer,
+  SideBarMenuGroupItemTrigger,
+  SideBarMenuGroupList,
+} from './side-bar-menu-group.molecules'
+import { elSideBarMenuGroupItemAnchor, ElSideBarMenuGroupItem, ElSideBarMenuGroupListItem } from './styles'
+
+export interface SideBarMenuGroupItemProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'> {
+  children?: ReactNode
+  /**
+   * Whether the page represented by this link is currently active.
+   *
+   * @default false
+   */
+  isActive?: boolean
+}
+
+export const SideBarMenuGroupItem: FC<SideBarMenuGroupItemProps> = ({ children, isActive, ...props }) => {
+  return (
+    <ElSideBarMenuGroupListItem>
+      <ElSideBarMenuGroupItem
+        className={elSideBarMenuGroupItemAnchor}
+        aria-current={isActive ? 'page' : undefined}
+        {...props}
+      >
+        {children}
+      </ElSideBarMenuGroupItem>
+    </ElSideBarMenuGroupListItem>
+  )
+}
+
+export interface SideBarMenuGroupProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'onClick'> {
+  children?: ReactNode
+  /**
+   * Whether the page represented by this group contain active link.
+   *
+   * @default false
+   */
+  isActive?: boolean
+  icon: ReactNode
+  label: string
+}
+
+export const SideBarMenuGroup: FC<SideBarMenuGroupProps> = ({ label, icon, isActive, children }) => {
+  return (
+    <SideBarMenuGroupContainer isActive={isActive}>
+      <SideBarMenuGroupItemTrigger isActive={isActive} icon={icon}>
+        {label}
+      </SideBarMenuGroupItemTrigger>
+      <SideBarMenuGroupList>{children}</SideBarMenuGroupList>
+    </SideBarMenuGroupContainer>
+  )
+}

--- a/src/components/side-bar-menu-group/styles.ts
+++ b/src/components/side-bar-menu-group/styles.ts
@@ -1,0 +1,120 @@
+import { css } from '@linaria/core'
+import { styled } from '@linaria/react'
+import { Icon } from '../icon'
+
+export const elDropdownIcon = css`
+  width: 24px;
+  height: 24px;
+  display: flex;
+  padding: var(--spacing-1);
+  justify-content: center;
+  align-items: center;
+  color: var(--neutral-400);
+`
+
+export const ElSideBarMenuGroupItemText = styled.span`
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-style: normal;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-sm);
+  letter-spacing: var(--letter-spacing-sm);
+`
+
+export const ElSideBarMenuGroupTriggerIcon = styled.span`
+  // override elIcon and custom icon
+  svg,
+  & {
+    width: var(--icon-md);
+    height: var(--icon-md);
+    color: var(--neutral-400);
+    box-sizing: content-box;
+  }
+
+  padding: var(--spacing-half);
+`
+
+export const ElSideBarMenuGroupListItem = styled.li``
+
+export const ElSideBarMenuGroupItemTrigger = styled.button`
+  // button override
+  cursor: pointer;
+  background: none;
+  border: none;
+
+  display: flex;
+  height: 40px;
+  padding: var(--spacing-none) var(--spacing-2);
+  align-items: center;
+  gap: var(--spacing-3);
+  align-self: stretch;
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+
+  &[data-expanded='false'] {
+    border-radius: inherit;
+  }
+
+  color: var(--component-text-colour-text-side-bar-menu-item-default, #506478);
+
+  &[aria-current='page'] {
+    & ${ElSideBarMenuGroupItemText}, ${ElSideBarMenuGroupTriggerIcon} svg {
+      color: var(--text-action);
+      font-weight: var(--font-weight-medium);
+    }
+  }
+
+  &:hover {
+    &,
+    ${ElSideBarMenuGroupTriggerIcon} svg {
+      background: var(--fill-default-light);
+    }
+  }
+`
+
+export const ElSideBarMenuGroup = styled.li`
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--corner-lg);
+  background: var(--fill-default-lightest);
+`
+
+export const ElSideBarMenuGroupList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-1);
+  padding-bottom: var(--spacing-2);
+  background: var(--fill-default-lightest);
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+`
+
+export const ElSideBarIcon = styled(Icon)``
+
+export const elSideBarMenuGroupItemAnchor = css`
+  display: flex;
+  align-items: center;
+  text-align: start;
+  color: var(--component-text-colour-text-side-bar-menu-item-default, #506478);
+
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-style: normal;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-sm);
+  letter-spacing: var(--letter-spacing-sm);
+  padding: var(--spacing-none) var(--spacing-3) var(--spacing-none) 44px;
+  height: var(--size-8);
+
+  &:hover {
+    background: var(--fill-default-light);
+  }
+
+  &[aria-current='page'] {
+    color: var(--text-action);
+    font-weight: var(--font-weight-medium);
+  }
+`
+
+export const ElSideBarMenuGroupItem = styled.a``

--- a/src/components/side-bar-menu-item/styles.ts
+++ b/src/components/side-bar-menu-item/styles.ts
@@ -5,9 +5,9 @@ export const ElSideBarMenuItemText = styled.span`
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
   font-style: normal;
-  font-weight: 400;
   line-height: var(--line-height-sm);
   letter-spacing: var(--letter-spacing-sm);
+  font-weight: var(--font-weight-regular);
 `
 
 export const ElSideBarMenuItemIcon = styled.span`
@@ -38,14 +38,12 @@ export const elSideBarMenuItemAnchor = css`
   &:hover,
   &[aria-current='page'] {
     background: var(--fill-default-lightest);
-    font-weight: 500;
   }
 
   &[aria-current='page'] {
-    &,
-    ${ElSideBarMenuItemIcon} svg {
+    & ${ElSideBarMenuItemText}, ${ElSideBarMenuItemIcon} svg {
       color: var(--text-action);
-      font-weight: 500;
+      font-weight: var(--font-weight-medium);
     }
   }
 `

--- a/src/components/side-bar/side-bar.stories.tsx
+++ b/src/components/side-bar/side-bar.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '../side-bar-menu-item'
 import { Icon } from '../icon'
 import { useIsSideBarExpandedContext } from './is-side-bar-expanded-context'
+import { SideBarMenuGroup, SideBarMenuGroupItem } from '../side-bar-menu-group'
 
 export default {
   title: 'Components/Side Bar',
@@ -58,8 +59,12 @@ export const Default: Story = {
         <SideBar>
           <SideBar.MenuList>
             <SideBarMenuItem isActive icon={<Icon icon="property" />} href="#">
-              SideBar Item (active)
+              SideBar Item (active) test
             </SideBarMenuItem>
+            <SideBarMenuGroup isActive label="Menu item Expandable" icon={<Icon icon="property" />}>
+              <SideBarMenuGroupItem isActive>Sub Menu Item 1</SideBarMenuGroupItem>
+              <SideBarMenuGroupItem>Sub Menu Item 2</SideBarMenuGroupItem>
+            </SideBarMenuGroup>
 
             <li>
               <CustomLink />

--- a/src/components/side-bar/side-bar.stories.tsx
+++ b/src/components/side-bar/side-bar.stories.tsx
@@ -59,7 +59,7 @@ export const Default: Story = {
         <SideBar>
           <SideBar.MenuList>
             <SideBarMenuItem isActive icon={<Icon icon="property" />} href="#">
-              SideBar Item (active) test
+              SideBar Item (active)
             </SideBarMenuItem>
             <SideBarMenuGroup isActive label="Menu item Expandable" icon={<Icon icon="property" />}>
               <SideBarMenuGroupItem isActive>Sub Menu Item 1</SideBarMenuGroupItem>


### PR DESCRIPTION
## Context
In order to create a new SideBar for the v5 release, this PR, as part of #154, initended to add the MenuGroup and MenuGroupItem component in SideBar.

![image](https://github.com/user-attachments/assets/dd2e4367-f1c2-45f7-ad77-636da7b16b5a)

## Pull request checklist
- [x] SideBarMenuGroup
- [x] SideBarMenuGroupItem
- [x] integration with SideBar's collapsed/expanded state

**Detail as per issue below (required):**

fixes: #

![side-bar-menu-group](https://github.com/user-attachments/assets/61a49411-9d87-49ba-9aac-99c77f57ed58)

