### PR TITLE
chore: #340 Updated Prerelease test script to vitest

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Test
         run: |
-          yarn test --watch=false --ci --forceExit --detectOpenHandles --runInBand --passWithNoTests
+          yarn vitest run --watch=false --passWithNoTests
 
       - name: Package Version Bump
         run: |

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Test
         run: |
-          yarn vitest run --watch=false --passWithNoTests
+          yarn test run --passWithNoTests
 
       - name: Package Version Bump
         run: |


### PR DESCRIPTION
**Background:**

We recently replaced Jest with Vitest and missed updating the prerelease GitHub workflow to use Vitest.

**Detail as per issue below (required):**

fixes: #340 `5.0.0-beta.18` release - Replaced jest test script with vitest


