### PR TITLE
feat: #154 SideBar Accessibility (a11y)

### DIFF
--- a/src/components/side-bar-collapse-button/styles.ts
+++ b/src/components/side-bar-collapse-button/styles.ts
@@ -34,6 +34,12 @@ export const ElSideBarCollapseButton = styled.button`
     background: var(--fill-default-lightest);
     font-weight: 500;
   }
+
+  &:focus-visible {
+    outline: none;
+    border: var(--border-width-double) solid var(--colour-border-focus);
+    background: var(--color-fill-neutral-light);
+  }
 `
 
 export const ElCollapseIcon = styled(CollapseIcon)`

--- a/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
+++ b/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
@@ -89,4 +89,18 @@ describe('SideBarMenuGroup', () => {
     fireEvent.click(screen.getByRole('button'))
     expect(screen.queryByText('Child Item')).not.toBeInTheDocument()
   })
+
+  it('should handle onKeyDown event properly', () => {
+    render(
+      <SideBar>
+        <SideBarMenuGroup isActive label="Group" icon={null}>
+          <button data-testid="item-1">Item 1</button>
+        </SideBarMenuGroup>
+      </SideBar>,
+    )
+    screen.getByTestId('item-1').focus()
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' })
+    expect(screen.queryByText('Item 1')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/side-bar-menu-group/side-bar-menu-group.molecules.tsx
+++ b/src/components/side-bar-menu-group/side-bar-menu-group.molecules.tsx
@@ -1,4 +1,11 @@
-import { useState, type FC, type ReactNode } from 'react'
+import {
+  useState,
+  type FC,
+  type HTMLAttributes,
+  type KeyboardEventHandler,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react'
 import { Icon } from '../icon'
 import { useIsSideBarExpandedContext } from '../side-bar/is-side-bar-expanded-context'
 import {
@@ -14,13 +21,13 @@ import {
   ElSideBarMenuGroupList,
 } from './styles'
 
-interface SideBarMenuGroupItemProps {
+interface SideBarMenuGroupItemProps extends HTMLAttributes<HTMLButtonElement> {
   icon: ReactNode
   isActive?: boolean
   children: ReactNode
 }
 
-export const SideBarMenuGroupItemTrigger: FC<SideBarMenuGroupItemProps> = ({ icon, isActive, children }) => {
+export const SideBarMenuGroupItemTrigger: FC<SideBarMenuGroupItemProps> = ({ icon, isActive, children, ...props }) => {
   const { isExpanded: isSideBarExpanded, setIsExpanded: setIsSideBarExpanded } = useIsSideBarExpandedContext()
   const { isExpanded, setIsExpanded } = useIsSideBarMenuGroupExpandedContext()
 
@@ -36,6 +43,7 @@ export const SideBarMenuGroupItemTrigger: FC<SideBarMenuGroupItemProps> = ({ ico
       data-expanded={isExpanded}
       onClick={handleClick}
       data-expandable="true"
+      {...props}
     >
       <ElSideBarMenuGroupTriggerIcon>{icon}</ElSideBarMenuGroupTriggerIcon>
       {isSideBarExpanded && (
@@ -61,15 +69,33 @@ export const SideBarMenuGroupContainer: FC<SideBarMenuGroupContainerProps> = ({ 
 
   return (
     <IsSideBarMenuGroupExpandedContext.Provider value={{ isExpanded, setIsExpanded }}>
-      <ElSideBarMenuGroup>{children}</ElSideBarMenuGroup>
+      <ElSideBarMenuGroup data-expanded={isExpanded}>{children}</ElSideBarMenuGroup>
     </IsSideBarMenuGroupExpandedContext.Provider>
   )
 }
 
-export const SideBarMenuGroupList: FC<{ children: ReactNode }> = ({ children }) => {
-  const { isExpanded } = useIsSideBarMenuGroupExpandedContext()
+export const SideBarMenuGroupList: FC<PropsWithChildren<HTMLAttributes<HTMLUListElement>>> = ({
+  children,
+  ...props
+}) => {
+  const { isExpanded, setIsExpanded } = useIsSideBarMenuGroupExpandedContext()
   const { isExpanded: isSideBarExpanded } = useIsSideBarExpandedContext()
 
   if (!isExpanded || !isSideBarExpanded) return null
-  return <ElSideBarMenuGroupList>{children}</ElSideBarMenuGroupList>
+
+  const handleOnKeyDown: KeyboardEventHandler<HTMLUListElement> = (e) => {
+    const menu = e.currentTarget
+    const menuButton = menu?.parentElement!.querySelector('button') as HTMLButtonElement
+
+    if (e.key === 'Escape') {
+      setIsExpanded(false)
+      menuButton.focus()
+    }
+  }
+
+  return (
+    <ElSideBarMenuGroupList {...props} onKeyDown={handleOnKeyDown}>
+      {children}
+    </ElSideBarMenuGroupList>
+  )
 }

--- a/src/components/side-bar-menu-group/side-bar-menu-group.molecules.tsx
+++ b/src/components/side-bar-menu-group/side-bar-menu-group.molecules.tsx
@@ -40,9 +40,8 @@ export const SideBarMenuGroupItemTrigger: FC<SideBarMenuGroupItemProps> = ({ ico
   return (
     <ElSideBarMenuGroupItemTrigger
       aria-current={isActive ? 'page' : undefined}
-      data-expanded={isExpanded}
       onClick={handleClick}
-      data-expandable="true"
+      aria-expanded={isExpanded}
       {...props}
     >
       <ElSideBarMenuGroupTriggerIcon>{icon}</ElSideBarMenuGroupTriggerIcon>
@@ -69,7 +68,7 @@ export const SideBarMenuGroupContainer: FC<SideBarMenuGroupContainerProps> = ({ 
 
   return (
     <IsSideBarMenuGroupExpandedContext.Provider value={{ isExpanded, setIsExpanded }}>
-      <ElSideBarMenuGroup data-expanded={isExpanded}>{children}</ElSideBarMenuGroup>
+      <ElSideBarMenuGroup data-is-expanded={isExpanded}>{children}</ElSideBarMenuGroup>
     </IsSideBarMenuGroupExpandedContext.Provider>
   )
 }

--- a/src/components/side-bar-menu-group/side-bar-menu-group.tsx
+++ b/src/components/side-bar-menu-group/side-bar-menu-group.tsx
@@ -1,4 +1,4 @@
-import type { FC, HTMLAttributes, ReactNode } from 'react'
+import { useId, type FC, type HTMLAttributes, type ReactNode } from 'react'
 import {
   SideBarMenuGroupContainer,
   SideBarMenuGroupItemTrigger,
@@ -44,12 +44,13 @@ export interface SideBarMenuGroupProps extends HTMLAttributes<HTMLLIElement> {
 }
 
 export const SideBarMenuGroup: FC<SideBarMenuGroupProps> = ({ label, icon, isActive, children, ...props }) => {
+  const groupId = useId()
   return (
     <SideBarMenuGroupContainer isActive={isActive} {...props}>
-      <SideBarMenuGroupItemTrigger isActive={isActive} icon={icon}>
+      <SideBarMenuGroupItemTrigger aria-controls={groupId} isActive={isActive} icon={icon}>
         {label}
       </SideBarMenuGroupItemTrigger>
-      <SideBarMenuGroupList>{children}</SideBarMenuGroupList>
+      <SideBarMenuGroupList id={groupId}>{children}</SideBarMenuGroupList>
     </SideBarMenuGroupContainer>
   )
 }

--- a/src/components/side-bar-menu-group/styles.ts
+++ b/src/components/side-bar-menu-group/styles.ts
@@ -45,7 +45,6 @@ export const ElSideBarMenuGroupItemTrigger = styled.button`
 
   display: flex;
   width: 100%;
-  justify-content: flex-start;
   height: 40px;
   padding: var(--spacing-none) var(--spacing-2);
   align-items: center;
@@ -54,7 +53,7 @@ export const ElSideBarMenuGroupItemTrigger = styled.button`
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
 
-  &[data-expanded='false'] {
+  &[aria-expanded='false'] {
     border-radius: inherit;
   }
 
@@ -83,7 +82,7 @@ export const ElSideBarMenuGroupItemTrigger = styled.button`
 
 export const ElSideBarMenuGroup = styled.li`
   border-radius: var(--corner-lg);
-  &[data-expanded='true'] {
+  &[data-is-expanded='true'] {
     background: var(--colour-fill-neutral-lightest);
   }
 `

--- a/src/components/side-bar-menu-group/styles.ts
+++ b/src/components/side-bar-menu-group/styles.ts
@@ -18,6 +18,8 @@ export const ElSideBarMenuGroupItemText = styled.span`
   font-weight: var(--font-weight-regular);
   line-height: var(--line-height-sm);
   letter-spacing: var(--letter-spacing-sm);
+  flex: 1;
+  text-align: left;
 `
 
 export const ElSideBarMenuGroupTriggerIcon = styled.span`
@@ -42,6 +44,8 @@ export const ElSideBarMenuGroupItemTrigger = styled.button`
   border: none;
 
   display: flex;
+  width: 100%;
+  justify-content: flex-start;
   height: 40px;
   padding: var(--spacing-none) var(--spacing-2);
   align-items: center;
@@ -63,19 +67,25 @@ export const ElSideBarMenuGroupItemTrigger = styled.button`
     }
   }
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     &,
     ${ElSideBarMenuGroupTriggerIcon} svg {
-      background: var(--fill-default-light);
+      background: var(--colour-fill-neutral-light);
     }
+  }
+
+  &:focus-visible {
+    outline: none;
+    border: var(--border-width-double) solid var(--colour-border-focus);
   }
 `
 
 export const ElSideBarMenuGroup = styled.li`
-  display: flex;
-  flex-direction: column;
   border-radius: var(--corner-lg);
-  background: var(--fill-default-lightest);
+  &[data-expanded='true'] {
+    background: var(--colour-fill-neutral-lightest);
+  }
 `
 
 export const ElSideBarMenuGroupList = styled.ul`
@@ -84,7 +94,6 @@ export const ElSideBarMenuGroupList = styled.ul`
   align-items: flex-start;
   gap: var(--spacing-1);
   padding-bottom: var(--spacing-2);
-  background: var(--fill-default-lightest);
   border-bottom-left-radius: inherit;
   border-bottom-right-radius: inherit;
 `
@@ -104,13 +113,19 @@ export const elSideBarMenuGroupItemAnchor = css`
   padding: var(--spacing-none) var(--spacing-3) var(--spacing-none) 44px;
   height: var(--size-8);
 
-  &:hover {
-    background: var(--fill-default-light);
+  &:hover,
+  &:focus-visible {
+    background: var(--colour-fill-neutral-light);
   }
 
   &[aria-current='page'] {
     color: var(--text-action);
     font-weight: var(--font-weight-medium);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border: var(--border-width-double) solid var(--colour-border-focus);
   }
 `
 

--- a/src/components/side-bar-menu-item/styles.ts
+++ b/src/components/side-bar-menu-item/styles.ts
@@ -36,6 +36,10 @@ export const elSideBarMenuItemAnchor = css`
   border-radius: var(--corner-lg);
 
   &:hover,
+  &:focus-visible {
+    background: var(--colour-fill-neutral-light);
+  }
+
   &[aria-current='page'] {
     background: var(--fill-default-lightest);
   }
@@ -45,6 +49,11 @@ export const elSideBarMenuItemAnchor = css`
       color: var(--text-action);
       font-weight: var(--font-weight-medium);
     }
+  }
+
+  &:focus-visible {
+    outline: none;
+    border: var(--border-width-double) solid var(--colour-border-focus);
   }
 `
 

--- a/src/components/side-bar/__test__/side-bar.test.tsx
+++ b/src/components/side-bar/__test__/side-bar.test.tsx
@@ -29,4 +29,38 @@ describe('SideBar', () => {
     expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false')
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('should handle onKeyDown event properly', () => {
+    const mockOnAnchorClick = vi.fn()
+    const mockOnButtonClick = vi.fn()
+    const mockOnKeyDown = vi.fn()
+    render(
+      <SideBar onKeyDown={mockOnKeyDown}>
+        <SideBar.MenuList>
+          <button>Item 1</button>
+          <a onClick={mockOnAnchorClick}>Item 2</a>
+        </SideBar.MenuList>
+        <button onClick={mockOnButtonClick}>Item 3</button>
+      </SideBar>,
+    )
+    const items = document.querySelectorAll('a,button') as NodeListOf<HTMLAnchorElement | HTMLButtonElement>
+    items[0].focus()
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(mockOnKeyDown).toHaveBeenCalled()
+    expect(document.activeElement).toBe(items[1])
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(items[2])
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(items[1])
+    fireEvent.keyDown(document.activeElement!, { key: ' ' })
+    expect(mockOnAnchorClick).toHaveBeenCalled()
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(items[2])
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
+    expect(mockOnButtonClick).toHaveBeenCalled()
+  })
 })

--- a/src/components/side-bar/side-bar.stories.tsx
+++ b/src/components/side-bar/side-bar.stories.tsx
@@ -61,9 +61,16 @@ export const Default: Story = {
             <SideBarMenuItem isActive icon={<Icon icon="property" />} href="#">
               SideBar Item (active)
             </SideBarMenuItem>
-            <SideBarMenuGroup isActive label="Menu item Expandable" icon={<Icon icon="property" />}>
-              <SideBarMenuGroupItem isActive>Sub Menu Item 1</SideBarMenuGroupItem>
-              <SideBarMenuGroupItem>Sub Menu Item 2</SideBarMenuGroupItem>
+            <SideBarMenuGroup isActive label="Menu Group 1" icon={<Icon icon="property" />}>
+              <SideBarMenuGroupItem isActive href="#">
+                Sub Menu Item 1
+              </SideBarMenuGroupItem>
+              <SideBarMenuGroupItem href="#">Sub Menu Item 2</SideBarMenuGroupItem>
+            </SideBarMenuGroup>
+
+            <SideBarMenuGroup label="Menu Group 2" icon={<Icon icon="property" />}>
+              <SideBarMenuGroupItem href="#">Sub Menu Item 3</SideBarMenuGroupItem>
+              <SideBarMenuGroupItem href="#">Sub Menu Item 4</SideBarMenuGroupItem>
             </SideBarMenuGroup>
 
             <li>
@@ -73,7 +80,7 @@ export const Default: Story = {
               External Icon
             </SideBarMenuItem>
 
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].map((i) => {
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => {
               return (
                 <SideBarMenuItem key={i} icon={<Icon icon="property" />} href="/#">
                   SideBar Item

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC, type HTMLAttributes } from 'react'
+import { useState, type FC, type HTMLAttributes, type KeyboardEventHandler } from 'react'
 import { SideBarCollapseButton } from '../side-bar-collapse-button'
 import { IsSideBarExpandedContext, useIsSideBarExpandedContext } from './is-side-bar-expanded-context'
 import { ElSideBar, ELSideBarMenuList } from './styles'
@@ -10,9 +10,45 @@ type SideBarFC = FC<HTMLAttributes<HTMLElement>> & {
 
 const SideBar: SideBarFC = ({ children, ...props }) => {
   const [isExpanded, setIsExpanded] = useState(true)
+
+  const handleOnKeyDown: KeyboardEventHandler<HTMLUListElement> = (e) => {
+    const container = e.currentTarget
+    const clickableItems = container?.querySelectorAll('a,button') as NodeListOf<HTMLElement>
+
+    let currentIndex = -1
+    clickableItems.forEach((item, index) => {
+      if (item === document.activeElement) {
+        currentIndex = index
+      }
+    })
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault()
+        const nextItem = clickableItems[(currentIndex + 1) % clickableItems.length]
+        nextItem.focus()
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const prevItem = clickableItems[(currentIndex - 1 + clickableItems.length) % clickableItems.length]
+        prevItem.focus()
+        break
+      }
+      case 'Enter':
+      case ' ': {
+        e.preventDefault()
+        const currentItem = clickableItems[currentIndex] as HTMLAnchorElement | HTMLButtonElement
+        currentItem.click()
+        break
+      }
+    }
+
+    props.onKeyDown?.(e)
+  }
   return (
     <IsSideBarExpandedContext.Provider value={{ isExpanded, setIsExpanded }}>
-      <ElSideBar aria-label="Sidebar Navigation" {...props}>
+      <ElSideBar aria-label="Sidebar Navigation" {...props} onKeyDown={handleOnKeyDown}>
         {children}
       </ElSideBar>
     </IsSideBarExpandedContext.Provider>


### PR DESCRIPTION
## Context
In order to create a new SideBar for the v5 release, this PR, as part of #154, initended to add the accessibility support and keyboard interaction in SideBar.

for this work I referring to https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation following the pattern in MobileNav ticket previously.

## Pull request checklist
- [x] support `arrowUp` and `arrowDown` keys to navigate between items
- [x] support `Enter` or `Space` key to click item
- [x] support `Escape` key to unexpand the group and move focus to the trigger
- [x] ensure the correct style applied

**Detail as per issue below (required):**

fixes: #

![sidebar-a11y](https://github.com/user-attachments/assets/0dee3bc3-3927-4ac8-a89d-351a23d4c549)
