### PR TITLE
feat: #314 add `maxWidth` prop to `Chip` and use new design tokens

### DIFF
--- a/src/components/chip/chip.stories.tsx
+++ b/src/components/chip/chip.stories.tsx
@@ -2,7 +2,7 @@ import { Chip } from './chip'
 import { Tooltip } from '../tooltip'
 import { useTooltip } from '../tooltip/use-tooltip'
 
-import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
   title: 'Components/Chip',
@@ -70,21 +70,13 @@ export const Disabled: Story = {
   },
 }
 
-const useNarrowParentDecorator: Decorator = (Story) => {
-  return (
-    <div style={{ width: '300px' }}>
-      <Story />
-    </div>
-  )
-}
-
 /** By default, long labels will wrap if there is not enough space is available. */
 export const Wrapping: Story = {
   args: {
     ...FilterChip.args,
     children: "This very long label will wrap because it's parent is not wide enough",
+    maxWidth: '--size-80',
   },
-  decorators: [useNarrowParentDecorator],
 }
 
 /**
@@ -95,7 +87,7 @@ export const Truncation: Story = {
   args: {
     ...FilterChip.args,
     children: 'Truncation can be applied when necessary',
+    maxWidth: '--size-80',
     willTruncateLabel: true,
   },
-  decorators: [useNarrowParentDecorator],
 }

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -13,14 +13,15 @@ type ElementAttributesToOmit = Extract<keyof ElementAttributes, 'disabled' | 'ty
 interface ChipProps extends Omit<ElementAttributes, ElementAttributesToOmit> {
   children: ReactNode
   isDisabled?: boolean
-  willTruncateLabel?: boolean
+  maxWidth?: `--size-${string}`
   variant: 'filter' | 'selection'
+  willTruncateLabel?: boolean
 }
 
 /**
  * An interactive chip that should be cleared (or removed) when clicked. Typically used within a `ChipGroup`.
  */
-export function Chip({ children, isDisabled, onClick, variant, willTruncateLabel, ...rest }: ChipProps) {
+export function Chip({ children, isDisabled, onClick, maxWidth, variant, willTruncateLabel, ...rest }: ChipProps) {
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (event) => {
       // We are not using <button>'s `disabled` attribute because disabled buttons are bad for a11y.
@@ -39,7 +40,16 @@ export function Chip({ children, isDisabled, onClick, variant, willTruncateLabel
   )
 
   return (
-    <ElChip {...rest} type="button" aria-disabled={isDisabled} data-variant={variant} onClick={handleClick}>
+    <ElChip
+      {...rest}
+      type="button"
+      aria-disabled={isDisabled}
+      data-variant={variant}
+      onClick={handleClick}
+      // NOTE: We'd prefer --chip-max-width to be a data attribute, but browsers do not support CSS' advanced
+      // attr() function syntax yet. Thus, we use a CSS variable instead.
+      style={maxWidth ? { '--chip-max-width': `var(${maxWidth})` } : undefined}
+    >
       <ElChipLabel data-will-truncate={willTruncateLabel}>{children}</ElChipLabel>
       <ElChipClearIcon icon="close" />
     </ElChip>

--- a/src/components/chip/styles.ts
+++ b/src/components/chip/styles.ts
@@ -1,14 +1,23 @@
 import { styled } from '@linaria/react'
 import { Icon } from '../icon'
+import type { CSSProperties } from 'react'
+
+interface ElChipCSSProperties extends CSSProperties {
+  /** Used to determine the maximum width of the chip because the browser does not support
+   * [CSS' advanced attr() syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/attr) */
+  '--chip-max-width'?: `var(--size-${string})`
+}
 
 interface ElChipProps {
   'data-variant': 'filter' | 'selection'
+  style?: ElChipCSSProperties
 }
 
 export const ElChip = styled.button<ElChipProps>`
   align-items: center;
   border: none;
-  border-radius: var(--corner-2xl);
+  border-radius: var(--comp-chip-border-radius);
+  color: var(--comp-chip-colour-text-active);
   cursor: pointer;
   display: grid;
   gap: var(--spacing-2);
@@ -17,29 +26,36 @@ export const ElChip = styled.button<ElChipProps>`
   padding-block: var(--spacing-1);
   padding-inline: var(--spacing-4) var(--spacing-2);
   width: fit-content;
+  max-width: var(--chip-max-width, auto);
+
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+    color: var(--comp-chip-colour-text-disabled);
+  }
 
   &[data-variant='filter'] {
-    background: var(--fill-action-lightest);
+    background: var(--comp-chip-colour-fill-filter-default);
 
     &:hover {
-      background: var(--fill-action-light);
+      background: var(--comp-chip-colour-fill-filter-hover);
+    }
+
+    &[aria-disabled='true'],
+    &[aria-disabled='true']:hover {
+      background: var(--comp-chip-colour-fill-filter-disabled);
     }
   }
 
   &[data-variant='selection'] {
-    background: var(--fill-default-lightest);
+    background: var(--comp-chip-colour-fill-selection-default);
 
     &:hover {
-      background: var(--fill-default-light);
+      background: var(--comp-chip-colour-fill-selection-hover);
     }
-  }
 
-  &[aria-disabled='true'] {
-    cursor: not-allowed;
-    background: var(--fill-default-lightest);
-
-    &:hover {
-      background: var(--fill-default-lightest);
+    &[aria-disabled='true'],
+    &[aria-disabled='true']:hover {
+      background: var(--comp-chip-colour-fill-selection-disabled);
     }
   }
 
@@ -81,12 +97,12 @@ export const ElChipLabel = styled.span<ElChipLabelProps>`
 export const ElChipClearIcon = styled(Icon)`
   /* NOTE: We only use !important here because the current Icon component
    * does not allow consumer-supplied styles to have a higher specificity */
-  color: var(--icon-secondary) !important;
+  color: var(--comp-chip-colour-icon-active) !important;
   font-size: 1rem;
   height: var(--size-icon-sm) !important;
   width: var(--size-icon-sm) !important;
 
   [aria-disabled='true'] & {
-    color: var(--icon-disabled) !important;
+    color: var(--comp-chip-colour-icon-disabled) !important;
   }
 `


### PR DESCRIPTION
fixes: #314

- Adds `maxWidth` prop to `Chip`
- Updates `Chip` to use the new design tokens

The image below shows chips with a max width applied. Originally, this was achieved by rendering them inside a parent element that had its own max width. That parent is no longer present and the Chip's are handling the max width themselves.

<img width="1032" alt="Screenshot 2025-03-21 at 10 06 36 AM" src="https://github.com/user-attachments/assets/2aea52f3-abe9-47b9-9595-4c86efccadef" />

Here, we can see the Chip's max width handling at work within a Chip group.

<img width="1032" alt="Screenshot 2025-03-21 at 10 08 46 AM" src="https://github.com/user-attachments/assets/09414140-fe78-4f90-8452-c89c3100798c" />