### PR TITLE
feat: 281 v5 Icon colour inheritance

### DIFF
--- a/src/components/avatar/styles.ts
+++ b/src/components/avatar/styles.ts
@@ -15,11 +15,6 @@ const baseMediumSizeStyle = `
 const baseColourDefaultStyle = `
   background: var(--fill-default-medium);
   color: var(--text-white);
-
-  /* override Icon element colour  */
-  svg {
-    color: var(--text-white);
-  }
 `
 
 export const ElAvatar = styled.span`
@@ -43,10 +38,6 @@ export const ElAvatar = styled.span`
   &[data-colour='purple'] {
     background: var(--fill-action-lightest);
     color: var(--text-action);
-    /* override Icon element colour  */
-    svg {
-      color: var(--text-action);
-    }
   }
 
   &[data-size='small'] {

--- a/src/components/badge/styles.ts
+++ b/src/components/badge/styles.ts
@@ -19,7 +19,6 @@ export const ElBadge = styled.div`
     ${ElIcon} {
       width: var(--icon-xs);
       height: var(--icon-xs);
-      color: inherit;
     }
   }
 

--- a/src/components/bottom-bar-item/styles.ts
+++ b/src/components/bottom-bar-item/styles.ts
@@ -1,11 +1,9 @@
 import { styled } from '@linaria/react'
 import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
-import { ElIcon } from '../icon'
 
 export const ElBottomBarItemIcon = styled.div`
   width: var(--icon-default);
   height: var(--icon-default);
-  color: inherit;
 `
 
 export const ElBottomBarItemLabel = styled.span`
@@ -55,16 +53,8 @@ export const ElBottomBarItemBadge = styled.span`
 
 export const ElAnchorBottomBarItemContainer = styled.a<AnchorHTMLAttributes<HTMLAnchorElement>>`
   ${baseStyles}
-
-  ${ElIcon} {
-    color: inherit;
-  }
 `
 
 export const ElButtonBottomBarItemContainer = styled.button<ButtonHTMLAttributes<HTMLButtonElement>>`
   ${baseStyles}
-
-  ${ElIcon} {
-    color: inherit;
-  }
 `

--- a/src/components/features/styles.ts
+++ b/src/components/features/styles.ts
@@ -22,7 +22,6 @@ export const ElFeaturesItem = styled.li`
   letter-spacing: var(--letter-spacing-2xs);
 
   ${ElIcon} {
-    color: inherit;
     font-size: inherit;
   }
 `

--- a/src/components/icon/__styles__/index.ts
+++ b/src/components/icon/__styles__/index.ts
@@ -11,7 +11,6 @@ import {
 
 export const ElIcon = styled.span`
   display: flex;
-  color: var(--black);
   font-size: 1.5rem;
 
   &.${elIntentPrimary} {

--- a/src/components/icon/icon.mdx
+++ b/src/components/icon/icon.mdx
@@ -784,7 +784,9 @@ By setting a custom height and width prop, you can scale the icon to custom requ
 
 <RenderHtmlMarkup of={IconStories.IconCustomSizes} />
 
-## Icon Intent
+## Icon Colors
+
+In v5, icons inherit their color by default. This differs from v4 where they were `--black` by default. This change also applies to DeprecatedIcon.
 
 Set the `intent` prop to enable Icons to be used in different contexts by assigning colors. Note for legacy icons below, this only applies to icons in the System Icons set.
 

--- a/src/components/nav-icon-item/styles.ts
+++ b/src/components/nav-icon-item/styles.ts
@@ -1,6 +1,5 @@
 import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
 import { styled } from '@linaria/react'
-import { ElIcon } from '../icon'
 
 // TODO: add tooltip integration on hover state
 const baseStyles = `
@@ -49,16 +48,8 @@ export const ElNavIconItemBadge = styled.span`
 
 export const ElButtonNavIconItem = styled.button<ButtonHTMLAttributes<HTMLButtonElement>>`
   ${baseStyles}
-
-  ${ElIcon} {
-    color: inherit;
-  }
 `
 
 export const ElAnchorNavIconItem = styled.a<AnchorHTMLAttributes<HTMLAnchorElement>>`
   ${baseStyles}
-
-  ${ElIcon} {
-    color: inherit;
-  }
 `


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**
* Icons now inherit colour by default
* unnecessary styling removed now that colour is inherited

fixes (partially): [#281](https://github.com/reapit/elements/issues/281)


