### PR TITLE
feat: #236 (mobile-nav-menu) initialize mobile-nav-menu component

### DIFF
--- a/src/components/mobile-nav-menu/__tests__/__snapshots__/mobile-nav-menu.test.tsx.snap
+++ b/src/components/mobile-nav-menu/__tests__/__snapshots__/mobile-nav-menu.test.tsx.snap
@@ -1,0 +1,204 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MobileNavMenu > should match a snapshot when isOpen state is true 1`] = `
+<DocumentFragment>
+  <dialog
+    class="mocked-styled-14 el-mobile-nav-menu"
+    open=""
+  >
+    <div
+      class="mocked-styled-11 el-mobile-nav-menu-header"
+    >
+      <button
+        aria-label="Close"
+        class="mocked-styled-9 el-button-nav-icon-item"
+      >
+        <span
+          class="mocked-styled-0 el-icon"
+          style="font-size: 24px;"
+        >
+          <svg
+            fill="none"
+            height="1em"
+            role="img"
+            style="font-size: 24px;"
+            title="Icon image with name close"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.3608 13.8296L18.0208 19.4896C18.2652 19.775 18.6489 19.8993 19.0142 19.8114C19.3795 19.7235 19.6647 19.4383 19.7526 19.073C19.8405 18.7077 19.7162 18.324 19.4308 18.0796L13.7708 12.4196L19.4308 6.75958C19.7162 6.51519 19.8405 6.13146 19.7526 5.76616C19.6647 5.40086 19.3795 5.11564 19.0142 5.02777C18.6489 4.93989 18.2652 5.0642 18.0208 5.34958L12.3608 11.0096L6.70079 5.34958C6.31076 4.96185 5.68083 4.96185 5.29079 5.34958C4.90307 5.73961 4.90307 6.36954 5.29079 6.75958L10.9508 12.4196L5.29079 18.0796C4.90307 18.4696 4.90307 19.0995 5.29079 19.4896C5.68083 19.8773 6.31076 19.8773 6.70079 19.4896L12.3608 13.8296Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <nav
+      class="mocked-styled-12 el-mobile-nav-menu-content"
+    >
+      <ul
+        class="mocked-styled-13 el-mobile-nav-menu-item-group"
+      >
+        <li
+          aria-label="Main Nav Item 1"
+          class="mocked-styled-7 el-mobile-nav-item-list-item"
+          data-is-expanded="false"
+        >
+          <button
+            aria-controls="test-static-id"
+            aria-expanded="false"
+            class="mocked-styled-3 el-mobile-nav-item-expander-button"
+            type="button"
+          >
+            <span
+              class="mocked-styled-4 el-mobile-nav-item-content"
+            >
+              Main Nav Item 1
+              <span
+                class="mocked-styled-5 el-mobile-nav-item-badge"
+              />
+            </span>
+            <span
+              class="mocked-styled-0 el-icon"
+              style="font-size: 16px;"
+            >
+              <svg
+                fill="none"
+                height="1em"
+                role="img"
+                style="font-size: 16px;"
+                title="Icon image with name chevronDown"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 16.5041C11.7343 16.5057 11.479 16.4013 11.2904 16.2141L4.29396 9.21411C4.04044 8.96046 3.94142 8.59074 4.03422 8.24424C4.12702 7.89773 4.39753 7.62708 4.74385 7.53424C5.09018 7.44139 5.45971 7.54046 5.71324 7.79411L12 14.0941L18.2868 7.79411C18.6787 7.40199 19.3141 7.40199 19.7061 7.79411C20.098 8.18624 20.098 8.82199 19.7061 9.21411L12.7096 16.2141C12.521 16.4013 12.2657 16.5057 12 16.5041Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </button>
+          <ul
+            aria-hidden="true"
+            class="mocked-styled-6 el-mobile-nav-sub-item-unordered-list"
+            id="test-static-id"
+          >
+            <li
+              aria-label="Label"
+              class="mocked-styled-7 el-mobile-nav-item-list-item"
+            >
+              <a
+                class="mocked-styled-1 el-mobile-nav-item-anchor"
+                href="#item-1.1"
+              >
+                <span
+                  class="mocked-styled-4 el-mobile-nav-item-content"
+                >
+                  Label
+                </span>
+              </a>
+            </li>
+            <li
+              aria-label="Label"
+              class="mocked-styled-7 el-mobile-nav-item-list-item"
+            >
+              <a
+                class="mocked-styled-1 el-mobile-nav-item-anchor"
+                href="#item-1.2"
+              >
+                <span
+                  class="mocked-styled-4 el-mobile-nav-item-content"
+                >
+                  Label
+                </span>
+              </a>
+            </li>
+            <li
+              aria-label="Label"
+              class="mocked-styled-7 el-mobile-nav-item-list-item"
+            >
+              <a
+                class="mocked-styled-1 el-mobile-nav-item-anchor"
+                href="#item-1.3"
+              >
+                <span
+                  class="mocked-styled-4 el-mobile-nav-item-content"
+                >
+                  Label
+                </span>
+              </a>
+            </li>
+            <li
+              aria-label="Label"
+              class="mocked-styled-7 el-mobile-nav-item-list-item"
+            >
+              <a
+                class="mocked-styled-1 el-mobile-nav-item-anchor"
+                href="#item-1.4"
+              >
+                <span
+                  class="mocked-styled-4 el-mobile-nav-item-content"
+                >
+                  Label
+                </span>
+              </a>
+            </li>
+            <li
+              aria-label="Label"
+              class="mocked-styled-7 el-mobile-nav-item-list-item"
+            >
+              <a
+                class="mocked-styled-1 el-mobile-nav-item-anchor"
+                href="#item-1.5"
+              >
+                <span
+                  class="mocked-styled-4 el-mobile-nav-item-content"
+                >
+                  Label
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <ul
+        class="mocked-styled-13 el-mobile-nav-menu-item-group"
+      >
+        <li
+          aria-label="User Item 1"
+          class="mocked-styled-7 el-mobile-nav-item-list-item"
+        >
+          <a
+            class="mocked-styled-1 el-mobile-nav-item-anchor"
+            href="#item-1.1"
+          >
+            <span
+              class="mocked-styled-4 el-mobile-nav-item-content"
+            >
+              User Item 1
+            </span>
+          </a>
+        </li>
+        <li
+          aria-label="User Item 2"
+          class="mocked-styled-7 el-mobile-nav-item-list-item"
+        >
+          <a
+            class="mocked-styled-1 el-mobile-nav-item-anchor"
+            href="#item-1.1"
+          >
+            <span
+              class="mocked-styled-4 el-mobile-nav-item-content"
+            >
+              User Item 2
+            </span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </dialog>
+</DocumentFragment>
+`;

--- a/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
+++ b/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { MobileNavMenu } from '../mobile-nav-menu'
+
+describe('MobileNavMenu', () => {
+  it('should match a snapshot when isOpen state is true', () => {
+    expect(
+      render(
+        <MobileNavMenu isOpen onClose={vi.fn()}>
+          <MobileNavMenu.Header onClose={vi.fn()} />
+          <MobileNavMenu.Content>
+            <MobileNavMenu.ItemGroup>
+              <MobileNavMenu.Item label="Main Nav Item 1" hasBadge>
+                <MobileNavMenu.Item label="Label" href="#item-1.1" />
+                <MobileNavMenu.Item label="Label" href="#item-1.2" />
+                <MobileNavMenu.Item label="Label" href="#item-1.3" />
+                <MobileNavMenu.Item label="Label" href="#item-1.4" />
+                <MobileNavMenu.Item label="Label" href="#item-1.5" />
+              </MobileNavMenu.Item>
+            </MobileNavMenu.ItemGroup>
+            <MobileNavMenu.ItemGroup>
+              <MobileNavMenu.Item label="User Item 1" href="#item-1.1" />
+              <MobileNavMenu.Item label="User Item 2" href="#item-1.1" />
+            </MobileNavMenu.ItemGroup>
+          </MobileNavMenu.Content>
+        </MobileNavMenu>,
+      ).asFragment(),
+    ).toMatchSnapshot()
+  })
+})

--- a/src/components/mobile-nav-menu/index.ts
+++ b/src/components/mobile-nav-menu/index.ts
@@ -1,0 +1,3 @@
+export * from './mobile-nav-menu'
+export * from './mobile-nav-menu.atoms'
+export * from './styles'

--- a/src/components/mobile-nav-menu/mobile-nav-menu.atoms.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.atoms.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react'
+import { NavIconItem } from '../nav-icon-item'
+import { ElMobileNavMenuHeader } from './styles'
+import { Icon } from '../icon'
+
+export interface MobileNavMenuHeaderProps {
+  onClose: VoidFunction
+}
+
+export const MobileNavMenuHeader: FC<MobileNavMenuHeaderProps> = ({ onClose }) => {
+  return (
+    <ElMobileNavMenuHeader>
+      <NavIconItem aria-label="Close" icon={<Icon icon="close" fontSize="24px" />} onClick={onClose} />
+    </ElMobileNavMenuHeader>
+  )
+}

--- a/src/components/mobile-nav-menu/mobile-nav-menu.mdx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.mdx
@@ -1,0 +1,12 @@
+import { Meta, Source, Title, Subtitle, Description, Canvas, ArgTypes } from '@storybook/blocks';
+import * as MobileNavMenu from './mobile-nav-menu.stories';
+
+<Meta of={MobileNavMenu} />
+
+<Title of={MobileNavMenu.Desktop} />
+
+<Description of={MobileNavMenu.Desktop} />
+
+<Canvas of={MobileNavMenu.Desktop} />
+
+<ArgTypes of={MobileNavMenu} />

--- a/src/components/mobile-nav-menu/mobile-nav-menu.stories.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from '../button'
+
 import { MobileNavMenu, MobileNavMenuProps } from './mobile-nav-menu'
 
 const meta = {

--- a/src/components/mobile-nav-menu/mobile-nav-menu.stories.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.stories.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from '../button'
+import { MobileNavMenu, MobileNavMenuProps } from './mobile-nav-menu'
+
+const meta = {
+  title: 'Components/Mobile Nav Menu',
+  component: MobileNavMenu,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    isOpen: true,
+    children: null,
+  },
+  render: ({}) => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    const handleOnClose = () => {
+      setIsOpen(false)
+    }
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>{isOpen ? 'Close' : 'Open'} Mobile Nav Menu</Button>
+        <MobileNavMenu isOpen={isOpen} onClose={handleOnClose}>
+          <MobileNavMenu.Header onClose={handleOnClose} />
+          <MobileNavMenu.Content>
+            <MobileNavMenu.ItemGroup>
+              <MobileNavMenu.Item label="Main Nav Item 1" hasBadge>
+                <MobileNavMenu.Item label="Label" href="#item-1.1" />
+                <MobileNavMenu.Item label="Label" href="#item-1.2" />
+                <MobileNavMenu.Item label="Label" href="#item-1.3" />
+                <MobileNavMenu.Item label="Label" href="#item-1.4" />
+                <MobileNavMenu.Item label="Label" href="#item-1.5" />
+              </MobileNavMenu.Item>
+              <MobileNavMenu.Item label="Main Nav Item 2" href="#item-2" />
+              <MobileNavMenu.Item label="Main Nav Item 3" href="#item-3" />
+              <MobileNavMenu.Item label="Main Nav Item 4" href="#item-4" />
+              <MobileNavMenu.Item label="Main Nav Item 5" href="#item-5" />
+            </MobileNavMenu.ItemGroup>
+            <MobileNavMenu.ItemGroup>
+              <MobileNavMenu.Item label="Secondary Nav Item 1" hasBadge isActive>
+                <MobileNavMenu.Item label="Label" href="#item-1.1" />
+                <MobileNavMenu.Item label="Label" href="#item-1.2" />
+                <MobileNavMenu.Item label="Label" href="#item-1.3" isActive />
+                <MobileNavMenu.Item label="Label" href="#item-1.4" hasBadge />
+                <MobileNavMenu.Item label="Label" href="#item-1.5" />
+              </MobileNavMenu.Item>
+              <MobileNavMenu.Item label="Secondary Nav Item 2" href="#item-2" />
+              <MobileNavMenu.Item label="Secondary Nav Item 3" href="#item-3" />
+              <MobileNavMenu.Item label="Secondary Nav Item 4" href="#item-4" />
+              <MobileNavMenu.Item label="Secondary Nav Item 5" href="#item-5" />
+            </MobileNavMenu.ItemGroup>
+            <MobileNavMenu.ItemGroup>
+              <MobileNavMenu.Item label="User Item 1" href="#item-1.1" />
+              <MobileNavMenu.Item label="User Item 2" href="#item-1.1" />
+              <MobileNavMenu.Item label="User Item 3" href="#item-1.1" />
+              <MobileNavMenu.Item label="User Item 4" href="#item-1.1" />
+              <MobileNavMenu.Item label="User Item 5" href="#item-1.1" />
+            </MobileNavMenu.ItemGroup>
+          </MobileNavMenu.Content>
+        </MobileNavMenu>
+      </>
+    )
+  },
+} satisfies Meta<MobileNavMenuProps>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+}
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile2',
+    },
+  },
+}

--- a/src/components/mobile-nav-menu/mobile-nav-menu.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode, useRef } from 'react'
+import { MobileNavItem } from '../mobile-nav-item'
+import { MobileNavMenuHeader } from './mobile-nav-menu.atoms'
+import { ElMobileNavMenu, ElMobileNavMenuContent, ElMobileNavMenuItemGroup } from './styles'
+import { useToggleDialogVisibilityEffect } from '../dialog'
+
+export interface MobileNavMenuProps {
+  isOpen: boolean
+  children: ReactNode
+  onClose?: VoidFunction
+}
+
+export type MobileNavMenuFC = FC<MobileNavMenuProps> & {
+  ItemGroup: typeof ElMobileNavMenuItemGroup
+  Item: typeof MobileNavItem
+  Content: typeof ElMobileNavMenuContent
+  Header: typeof MobileNavMenuHeader
+}
+
+const MobileNavMenu: MobileNavMenuFC = ({ children, isOpen, onClose }) => {
+  const ref = useRef<HTMLDialogElement>(null)
+
+  useToggleDialogVisibilityEffect({ isOpen, ref, onClose })
+
+  return <ElMobileNavMenu ref={ref}>{children}</ElMobileNavMenu>
+}
+
+MobileNavMenu.ItemGroup = ElMobileNavMenuItemGroup
+MobileNavMenu.Item = MobileNavItem
+MobileNavMenu.Header = MobileNavMenuHeader
+MobileNavMenu.Content = ElMobileNavMenuContent
+
+export { MobileNavMenu }

--- a/src/components/mobile-nav-menu/styles.ts
+++ b/src/components/mobile-nav-menu/styles.ts
@@ -1,0 +1,127 @@
+import { styled } from '@linaria/react'
+import { isMobile } from '#src/styles/media'
+
+export const ElMobileNavMenuHeader = styled.div`
+  display: flex;
+  padding: var(--spacing-2) var(--spacing-4);
+  justify-content: flex-end;
+  align-items: center;
+  align-self: stretch;
+
+  border-bottom: var(--border-width-default) solid var(--comp-navigation-colour-border-mobile_nav);
+  background: var(--comp-navigation-colour-fill-top_bar);
+`
+
+export const ElMobileNavMenuContent = styled.nav`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  padding: var(--spacing-3) var(--spacing-none);
+  background: var(--comp-navigation-colour-fill-mobile_nav-default);
+`
+
+export const ElMobileNavMenuItemGroup = styled.ul`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  padding: var(--spacing-3);
+  gap: var(--spacing-1);
+`
+
+export const ElMobileNavMenu = styled.dialog`
+  // NOTE: overrides default browser styles for 'dialog'
+  max-width: 100%;
+  max-height: 100%;
+  width: 375px;
+  height: 100%;
+  z-index: 99;
+  display: none;
+  overflow: auto;
+  border: none;
+  scrollbar-gutter: stable;
+  padding: var(--spacing-none);
+  animation: mobileNavMenuSlideRight 0.2s ease-out;
+
+  ${isMobile} {
+    width: 100%;
+    margin: var(--spacing-none);
+    scrollbar-gutter: unset;
+    animation: mobileNavMenuFadeOut 0.2s ease-out;
+  }
+
+  &[open] {
+    animation: mobileNavMenuSlideLeft 0.2s ease-out forwards;
+    display: block;
+
+    ${isMobile} {
+      animation: mobileNavMenuFadeIn 0.2s ease-out forwards;
+    }
+
+    &::backdrop {
+      background-color: var(--black);
+      opacity: 0.5;
+      animation: backdropFadeIn 0.2s ease-out;
+    }
+  }
+
+  ${ElMobileNavMenuItemGroup}:not(:first-child) {
+    border-top: var(--border-width-border-default) solid var(--outline-colour-outline-default);
+  }
+
+  @keyframes mobileNavMenuFadeIn {
+    from {
+      opacity: 0;
+      display: none;
+    }
+    to {
+      opacity: 1;
+      display: block;
+    }
+  }
+
+  @keyframes mobileNavMenuFadeOut {
+    from {
+      opacity: 1;
+      display: block;
+    }
+    to {
+      opacity: 0;
+      display: none;
+    }
+  }
+
+  @keyframes mobileNavMenuSlideLeft {
+    from {
+      margin-right: -375px;
+      display: none;
+    }
+    to {
+      margin-right: 0px;
+      display: block;
+    }
+  }
+
+  @keyframes mobileNavMenuSlideRight {
+    from {
+      margin-right: 0px;
+      display: block;
+    }
+    to {
+      margin-right: -375px;
+      display: none;
+    }
+  }
+
+  @keyframes backdropFadeIn {
+    from {
+      background-color: var(--black);
+      opacity: 0;
+    }
+    to {
+      background-color: var(--black);
+      opacity: 0.5;
+    }
+  }
+`

--- a/src/components/mobile-nav-menu/styles.ts
+++ b/src/components/mobile-nav-menu/styles.ts
@@ -7,7 +7,6 @@ export const ElMobileNavMenuHeader = styled.div`
   justify-content: flex-end;
   align-items: center;
   align-self: stretch;
-
   border-bottom: var(--border-width-default) solid var(--outline-default);
   background: var(--comp-navigation-colour-fill-top_bar);
 `
@@ -17,6 +16,8 @@ export const ElMobileNavMenuContent = styled.nav`
   flex-direction: column;
   align-items: flex-start;
   align-self: stretch;
+  scrollbar-gutter: stable;
+  overflow-y: auto;
   padding: var(--spacing-3) var(--spacing-none);
   background: var(--comp-navigation-colour-fill-mobile_nav-default);
 `
@@ -38,9 +39,7 @@ export const ElMobileNavMenu = styled.dialog`
   height: 100%;
   z-index: 99;
   display: none;
-  overflow: auto;
   border: none;
-  scrollbar-gutter: stable;
   padding: var(--spacing-none);
   animation: mobileNavMenuSlideRight 0.2s ease-out;
 
@@ -53,7 +52,8 @@ export const ElMobileNavMenu = styled.dialog`
 
   &[open] {
     animation: mobileNavMenuSlideLeft 0.2s ease-out forwards;
-    display: block;
+    display: flex;
+    flex-direction: column;
 
     ${isMobile} {
       animation: mobileNavMenuFadeIn 0.2s ease-out forwards;
@@ -77,14 +77,14 @@ export const ElMobileNavMenu = styled.dialog`
     }
     to {
       opacity: 1;
-      display: block;
+      display: flex;
     }
   }
 
   @keyframes mobileNavMenuFadeOut {
     from {
       opacity: 1;
-      display: block;
+      display: flex;
     }
     to {
       opacity: 0;
@@ -99,14 +99,14 @@ export const ElMobileNavMenu = styled.dialog`
     }
     to {
       margin-right: 0px;
-      display: block;
+      display: flex;
     }
   }
 
   @keyframes mobileNavMenuSlideRight {
     from {
       margin-right: 0px;
-      display: block;
+      display: flex;
     }
     to {
       margin-right: -375px;

--- a/src/components/mobile-nav-menu/styles.ts
+++ b/src/components/mobile-nav-menu/styles.ts
@@ -8,7 +8,7 @@ export const ElMobileNavMenuHeader = styled.div`
   align-items: center;
   align-self: stretch;
 
-  border-bottom: var(--border-width-default) solid var(--comp-navigation-colour-border-mobile_nav);
+  border-bottom: var(--border-width-default) solid var(--outline-default);
   background: var(--comp-navigation-colour-fill-top_bar);
 `
 
@@ -67,7 +67,7 @@ export const ElMobileNavMenu = styled.dialog`
   }
 
   ${ElMobileNavMenuItemGroup}:not(:first-child) {
-    border-top: var(--border-width-border-default) solid var(--outline-colour-outline-default);
+    border-top: var(--border-width-default) solid var(--outline-default);
   }
 
   @keyframes mobileNavMenuFadeIn {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export * from './components/empty-data'
 export * from './components/label-text'
 export * from './components/features'
 export * from './components/badge'
+export * from './components/mobile-nav-menu'
 
 export * from './hooks/use-portal'
 export * from './hooks/use-snack'


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**

Part of #236 
To continue the development for MobileNavMenu after we've settle an approach in SideBar component

This PR is deliberately to ship the MobileNavMenu based on [last agreement](https://github.com/reapit/elements/issues/236#issuecomment-2550558575) with @kurtdoherty  and also already use the latest token from the Design

There would be another PR that focusing on a11y and keyboard interaction based on @ksolanki7  [suggestion](https://github.com/reapit/elements/issues/236#issuecomment-2635465523)

Please to note, this PR rely on #264 , would be better if we also look at that first

## Attachment

https://github.com/user-attachments/assets/9e3fab54-4e9b-48d8-a29a-9ff3925f2cd0

