### PR TITLE
refactor: #236 (mobile-nav-menu) add keyboard integration

### DIFF
--- a/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
+++ b/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
@@ -1,5 +1,6 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { MobileNavMenu } from '../mobile-nav-menu'
+import { Mobile } from '#src/components/top-bar/top-bar.stories'
 
 describe('MobileNavMenu', () => {
   it('should match a snapshot when isOpen state is true', () => {
@@ -25,5 +26,46 @@ describe('MobileNavMenu', () => {
         </MobileNavMenu>,
       ).asFragment(),
     ).toMatchSnapshot()
+  })
+
+  it('should handle the keyboard navigation properly', () => {
+    const mockOnButtonClick = vi.fn()
+    const mockOnKeyDown = vi.fn()
+
+    render(
+      <MobileNavMenu isOpen onKeyDown={mockOnKeyDown}>
+        <MobileNavMenu.Content>
+          <MobileNavMenu.ItemGroup>
+            <MobileNavMenu.Item isActive={false} label="Main Nav Item 1">
+              <MobileNavMenu.Item label="Label" href="#item-1.1" />
+              <MobileNavMenu.Item label="Label" href="#item-1.2" />
+            </MobileNavMenu.Item>
+            <MobileNavMenu.Item label="Main Nav Item 2" href="#item-2" />
+            <MobileNavMenu.Item label="Main Nav Item 3" onClick={mockOnButtonClick} />
+          </MobileNavMenu.ItemGroup>
+        </MobileNavMenu.Content>
+      </MobileNavMenu>,
+    )
+    const items = document?.querySelectorAll(
+      'ul:not([aria-hidden="true"]):not([aria-hidden="false"]) > li > a, ul[aria-hidden="false"] > li > a, button',
+    ) as NodeListOf<HTMLElement>
+
+    items[0].focus()
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(mockOnKeyDown).toHaveBeenCalled()
+    expect(document.activeElement).toBe(items[1])
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(items[2])
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(items[1])
+    fireEvent.keyDown(document.activeElement!, { key: ' ' })
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(items[2])
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
+    expect(mockOnButtonClick).toHaveBeenCalled()
   })
 })

--- a/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
+++ b/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render } from '@testing-library/react'
 import { MobileNavMenu } from '../mobile-nav-menu'
-import { Mobile } from '#src/components/top-bar/top-bar.stories'
 
 describe('MobileNavMenu', () => {
   it('should match a snapshot when isOpen state is true', () => {

--- a/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
+++ b/src/components/mobile-nav-menu/__tests__/mobile-nav-menu.test.tsx
@@ -36,35 +36,53 @@ describe('MobileNavMenu', () => {
         <MobileNavMenu.Content>
           <MobileNavMenu.ItemGroup>
             <MobileNavMenu.Item isActive={false} label="Main Nav Item 1">
-              <MobileNavMenu.Item label="Label" href="#item-1.1" />
-              <MobileNavMenu.Item label="Label" href="#item-1.2" />
+              <MobileNavMenu.Item label="Sub Nav Item 1" href="#item-1.1" />
+              <MobileNavMenu.Item label="Sub Nav Item 2" href="#item-1.2" />
             </MobileNavMenu.Item>
-            <MobileNavMenu.Item label="Main Nav Item 2" href="#item-2" />
-            <MobileNavMenu.Item label="Main Nav Item 3" onClick={mockOnButtonClick} />
+            <MobileNavMenu.Item label="Main Nav Item 2" onClick={mockOnButtonClick} />
           </MobileNavMenu.ItemGroup>
         </MobileNavMenu.Content>
       </MobileNavMenu>,
     )
-    const items = document?.querySelectorAll(
-      'ul:not([aria-hidden="true"]):not([aria-hidden="false"]) > li > a, ul[aria-hidden="false"] > li > a, button',
-    ) as NodeListOf<HTMLElement>
 
-    items[0].focus()
+    const getItems = () =>
+      document?.querySelectorAll(
+        'ul:not([aria-hidden="true"]):not([aria-hidden="false"]) > li > a, ul[aria-hidden="false"] > li > a, button',
+      ) as NodeListOf<HTMLElement>
 
+    const initialItems = getItems()
+    expect(initialItems).toHaveLength(2)
+
+    initialItems[0].focus()
+
+    // NOTE: proving the sub items are unaccessible while the parent item is collapsed
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
-    expect(mockOnKeyDown).toHaveBeenCalled()
-    expect(document.activeElement).toBe(items[1])
-
-    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
-    expect(document.activeElement).toBe(items[2])
-
+    expect(document.activeElement).toBe(initialItems[1])
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' })
-    expect(document.activeElement).toBe(items[1])
-    fireEvent.keyDown(document.activeElement!, { key: ' ' })
+    expect(document.activeElement).toBe(initialItems[0])
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(initialItems[0])
 
+    // NOTE: ensure the sub items are accessible while the parent item expanded
+    const expandedItems = getItems()
+    expect(expandedItems).toHaveLength(4)
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
-    expect(document.activeElement).toBe(items[2])
+    expect(document.activeElement).toBe(expandedItems[1])
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(expandedItems[2])
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(expandedItems[3])
+
+    // NOTE: move back to the first item
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(expandedItems[0])
+
+    // NOTE: asserting the expand and collapse functionality with across key strokes
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowLeft' })
+    expect(getItems()).toHaveLength(2)
     fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
-    expect(mockOnButtonClick).toHaveBeenCalled()
+    expect(getItems()).toHaveLength(4)
+    fireEvent.keyDown(document.activeElement!, { key: ' ' })
+    expect(getItems()).toHaveLength(2)
   })
 })

--- a/src/components/mobile-nav-menu/mobile-nav-menu.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.tsx
@@ -55,10 +55,22 @@ const MobileNavMenu: MobileNavMenuFC = ({ children, isOpen, onClose, ...rest }) 
         prevItem.focus()
         break
       }
+      case 'ArrowRight':
+      case 'ArrowLeft': {
+        e.preventDefault()
+        const currentItem = clickableItems[currentIndex]
+        if (!currentItem.hasAttribute('aria-expanded')) break
+
+        if (e.key === 'ArrowRight' && currentItem.getAttribute('aria-expanded') === 'true') break
+        else if (e.key === 'ArrowLeft' && currentItem.getAttribute('aria-expanded') === 'false') break
+
+        currentItem.click()
+        break
+      }
       case 'Enter':
       case ' ': {
         e.preventDefault()
-        const currentItem = clickableItems[currentIndex] as HTMLAnchorElement | HTMLButtonElement
+        const currentItem = clickableItems[currentIndex]
         currentItem.click()
         break
       }

--- a/src/components/mobile-nav-menu/mobile-nav-menu.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.tsx
@@ -1,10 +1,10 @@
-import { FC, KeyboardEventHandler, ReactNode, useRef } from 'react'
+import { FC, HTMLAttributes, KeyboardEventHandler, ReactNode, useRef } from 'react'
 import { MobileNavItem } from '../mobile-nav-item'
 import { MobileNavMenuHeader } from './mobile-nav-menu.atoms'
 import { ElMobileNavMenu, ElMobileNavMenuContent, ElMobileNavMenuItemGroup } from './styles'
 import { useToggleDialogVisibilityEffect } from '../dialog'
 
-export interface MobileNavMenuProps {
+export interface MobileNavMenuProps extends HTMLAttributes<HTMLDialogElement> {
   isOpen: boolean
   children: ReactNode
   onClose?: VoidFunction
@@ -17,7 +17,7 @@ export type MobileNavMenuFC = FC<MobileNavMenuProps> & {
   Header: typeof MobileNavMenuHeader
 }
 
-const MobileNavMenu: MobileNavMenuFC = ({ children, isOpen, onClose }) => {
+const MobileNavMenu: MobileNavMenuFC = ({ children, isOpen, onClose, ...rest }) => {
   const ref = useRef<HTMLDialogElement>(null)
 
   useToggleDialogVisibilityEffect({ isOpen, ref, onClose })
@@ -63,10 +63,12 @@ const MobileNavMenu: MobileNavMenuFC = ({ children, isOpen, onClose }) => {
         break
       }
     }
+
+    rest?.onKeyDown?.(e)
   }
 
   return (
-    <ElMobileNavMenu ref={ref} onKeyDown={handleOnKeyDown}>
+    <ElMobileNavMenu ref={ref} {...rest} onKeyDown={handleOnKeyDown}>
       {children}
     </ElMobileNavMenu>
   )

--- a/src/components/mobile-nav-menu/mobile-nav-menu.tsx
+++ b/src/components/mobile-nav-menu/mobile-nav-menu.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useRef } from 'react'
+import { FC, KeyboardEventHandler, ReactNode, useRef } from 'react'
 import { MobileNavItem } from '../mobile-nav-item'
 import { MobileNavMenuHeader } from './mobile-nav-menu.atoms'
 import { ElMobileNavMenu, ElMobileNavMenuContent, ElMobileNavMenuItemGroup } from './styles'
@@ -22,7 +22,54 @@ const MobileNavMenu: MobileNavMenuFC = ({ children, isOpen, onClose }) => {
 
   useToggleDialogVisibilityEffect({ isOpen, ref, onClose })
 
-  return <ElMobileNavMenu ref={ref}>{children}</ElMobileNavMenu>
+  const handleOnKeyDown: KeyboardEventHandler<HTMLDialogElement> = (e) => {
+    const container = e.currentTarget
+
+    /**
+     * NOTE:  handle the keyboard navigation for the mobile nav menu
+     *
+     * This will collect all the clickable items in the mobile nav menu, and
+     * will handle the keyboard navigation for the mobile nav menu
+     */
+    const clickableItems = container?.querySelectorAll(
+      'ul:not([aria-hidden="true"]):not([aria-hidden="false"]) > li > a, ul[aria-hidden="false"] > li > a, button',
+    ) as NodeListOf<HTMLElement>
+
+    let currentIndex = -1
+    clickableItems.forEach((item, index) => {
+      if (item === document.activeElement) {
+        currentIndex = index
+      }
+    })
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault()
+        const nextItem = clickableItems[(currentIndex + 1) % clickableItems.length]
+        nextItem.focus()
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const prevItem = clickableItems[(currentIndex - 1 + clickableItems.length) % clickableItems.length]
+        prevItem.focus()
+        break
+      }
+      case 'Enter':
+      case ' ': {
+        e.preventDefault()
+        const currentItem = clickableItems[currentIndex] as HTMLAnchorElement | HTMLButtonElement
+        currentItem.click()
+        break
+      }
+    }
+  }
+
+  return (
+    <ElMobileNavMenu ref={ref} onKeyDown={handleOnKeyDown}>
+      {children}
+    </ElMobileNavMenu>
+  )
 }
 
 MobileNavMenu.ItemGroup = ElMobileNavMenuItemGroup


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**

Part of #236 

Add a keyboard integration support when the document already focused on mobile nav menu area (built with dialog), the integration is similar with what we've done in SideBar component (arrow, space, enter, and escape keystrokes)

Please note, this PR requires #384 to be merged first

## Attachment

https://github.com/user-attachments/assets/c66d3966-3831-45a5-a2b1-b392e77e172b

https://github.com/user-attachments/assets/6e1a86fb-876c-4c79-9306-d8d1469c2927





