### PR TITLE
fix: #383 v5 update SideBar default expanded state

### DIFF
--- a/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
+++ b/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
@@ -2,8 +2,27 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { SideBarMenuGroupItem, SideBarMenuGroup } from '..'
 import { SideBar } from '#src/components/side-bar/side-bar'
 import { SideBarCollapseButton } from '../../side-bar-collapse-button'
+import { useMediaQuery } from '#src/hooks/use-media-query/index'
+
+vi.mock('#src/hooks/use-media-query/index', () => ({
+  useMediaQuery: vi.fn(),
+}))
+
+const mockUseMediaQuery = vi.mocked(useMediaQuery)
 
 describe('SideBarMenuGroupItem', () => {
+  beforeAll(() => {
+    // default expanded side-bar
+    mockUseMediaQuery.mockReturnValue({
+      isDesktop: false,
+      isWideScreen: true,
+      isSuperWideScreen: false,
+      is4KScreen: false,
+      isMobile: false,
+      isTablet: false,
+    })
+  })
+
   it('renders with available props correctly', () => {
     render(<SideBarMenuGroupItem href="/test">Test Child</SideBarMenuGroupItem>)
     expect(screen.getByText('Test Child')).toBeInTheDocument()

--- a/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
+++ b/src/components/side-bar-menu-group/__tests__/side-bar-menu-group.test.tsx
@@ -2,9 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { SideBarMenuGroupItem, SideBarMenuGroup } from '..'
 import { SideBar } from '#src/components/side-bar/side-bar'
 import { SideBarCollapseButton } from '../../side-bar-collapse-button'
-import { useMediaQuery } from '#src/hooks/use-media-query/index'
+import { useMediaQuery } from '#src/hooks/use-media-query'
 
-vi.mock('#src/hooks/use-media-query/index', () => ({
+vi.mock('#src/hooks/use-media-query', () => ({
   useMediaQuery: vi.fn(),
 }))
 

--- a/src/components/side-bar/__test__/side-bar.test.tsx
+++ b/src/components/side-bar/__test__/side-bar.test.tsx
@@ -1,11 +1,30 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useMediaQuery } from '#src/hooks/use-media-query/index'
+import { fireEvent, render } from '@testing-library/react'
 import { SideBar } from '..'
 
 vi.mock('../../side-bar-collapse-button/icons/collapse.svg?react', () => ({
   default: vi.fn(() => <span data-testid="collapse-icon" />),
 }))
 
+vi.mock('#src/hooks/use-media-query/index', () => ({
+  useMediaQuery: vi.fn(),
+}))
+
+const mockUseMediaQuery = vi.mocked(useMediaQuery)
+
 describe('SideBar', () => {
+  beforeAll(() => {
+    // default expanded side-bar
+    mockUseMediaQuery.mockReturnValue({
+      isDesktop: false,
+      isWideScreen: true,
+      isSuperWideScreen: false,
+      is4KScreen: false,
+      isMobile: false,
+      isTablet: false,
+    })
+  })
+
   it('should match snapshot with expanded state', () => {
     const { asFragment } = render(
       <SideBar>
@@ -17,16 +36,15 @@ describe('SideBar', () => {
   })
 
   it('should match snapshot with collapsed state', () => {
+    mockUseMediaQuery.mockReturnValue({
+      isDesktop: true,
+    } as any)
     const { asFragment } = render(
       <SideBar>
         <SideBar.MenuList>SideBar list content</SideBar.MenuList>
         <SideBar.CollapseButon />
       </SideBar>,
     )
-    act(() => {
-      fireEvent.click(screen.getByRole('button'))
-    })
-    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false')
     expect(asFragment()).toMatchSnapshot()
   })
 

--- a/src/components/side-bar/__test__/side-bar.test.tsx
+++ b/src/components/side-bar/__test__/side-bar.test.tsx
@@ -1,4 +1,4 @@
-import { useMediaQuery } from '#src/hooks/use-media-query/index'
+import { useMediaQuery } from '#src/hooks/use-media-query'
 import { fireEvent, render } from '@testing-library/react'
 import { SideBar } from '..'
 
@@ -6,7 +6,7 @@ vi.mock('../../side-bar-collapse-button/icons/collapse.svg?react', () => ({
   default: vi.fn(() => <span data-testid="collapse-icon" />),
 }))
 
-vi.mock('#src/hooks/use-media-query/index', () => ({
+vi.mock('#src/hooks/use-media-query', () => ({
   useMediaQuery: vi.fn(),
 }))
 

--- a/src/components/side-bar/side-bar.mdx
+++ b/src/components/side-bar/side-bar.mdx
@@ -9,6 +9,8 @@ import * as SideBarStories from './side-bar.stories'
 
 SideBar component is part of the element's navigation, It is composed of several components to easily create a left-side-vertical navigation structure.
 
+Note: The SideBar component needs to be wrapped in a `MediaStateProvider` component to make the default expanded state set properly.
+
 ## Default
 
 <Canvas of={SideBarStories.Default} />

--- a/src/components/side-bar/side-bar.stories.tsx
+++ b/src/components/side-bar/side-bar.stories.tsx
@@ -1,15 +1,16 @@
+import { MediaStateProvider } from '#src/hooks/use-media-query/index'
 import { figmaDesignUrls } from '#src/storybook/figma/index'
 import type { Meta, StoryObj } from '@storybook/react'
-import { SideBar } from './side-bar'
+import { Icon } from '../icon'
+import { SideBarMenuGroup, SideBarMenuGroupItem } from '../side-bar-menu-group'
 import {
   elSideBarMenuItemAnchor,
   ElSideBarMenuItemIcon,
   ElSideBarMenuItemText,
   SideBarMenuItem,
 } from '../side-bar-menu-item'
-import { Icon } from '../icon'
 import { useIsSideBarExpandedContext } from './is-side-bar-expanded-context'
-import { SideBarMenuGroup, SideBarMenuGroupItem } from '../side-bar-menu-group'
+import { SideBar } from './side-bar'
 
 export default {
   title: 'Components/Side Bar',
@@ -40,75 +41,77 @@ export const Default: Story = {
       )
     }
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          height: '100%',
-          overflow: 'hidden',
-        }}
-      >
-        <style>
-          {`
+      <MediaStateProvider>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            height: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <style>
+            {`
             #storybook-root {
               height: 100%;
             }
           `}
-        </style>
+          </style>
 
-        <SideBar>
-          <SideBar.MenuList>
-            <SideBarMenuItem isActive icon={<Icon icon="property" />} href="#">
-              SideBar Item (active)
-            </SideBarMenuItem>
-            <SideBarMenuGroup isActive label="Menu Group 1" icon={<Icon icon="property" />}>
-              <SideBarMenuGroupItem isActive href="#">
-                Sub Menu Item 1
-              </SideBarMenuGroupItem>
-              <SideBarMenuGroupItem href="#">Sub Menu Item 2</SideBarMenuGroupItem>
-            </SideBarMenuGroup>
+          <SideBar>
+            <SideBar.MenuList>
+              <SideBarMenuItem isActive icon={<Icon icon="property" />} href="#">
+                SideBar Item (active)
+              </SideBarMenuItem>
+              <SideBarMenuGroup isActive label="Menu Group 1" icon={<Icon icon="property" />}>
+                <SideBarMenuGroupItem isActive href="#">
+                  Sub Menu Item 1
+                </SideBarMenuGroupItem>
+                <SideBarMenuGroupItem href="#">Sub Menu Item 2</SideBarMenuGroupItem>
+              </SideBarMenuGroup>
 
-            <SideBarMenuGroup label="Menu Group 2" icon={<Icon icon="property" />}>
-              <SideBarMenuGroupItem href="#">Sub Menu Item 3</SideBarMenuGroupItem>
-              <SideBarMenuGroupItem href="#">Sub Menu Item 4</SideBarMenuGroupItem>
-            </SideBarMenuGroup>
+              <SideBarMenuGroup label="Menu Group 2" icon={<Icon icon="property" />}>
+                <SideBarMenuGroupItem href="#">Sub Menu Item 3</SideBarMenuGroupItem>
+                <SideBarMenuGroupItem href="#">Sub Menu Item 4</SideBarMenuGroupItem>
+              </SideBarMenuGroup>
 
-            <li>
-              <CustomLink />
-            </li>
-            <SideBarMenuItem icon={<Customicon />} href="#">
-              External Icon
-            </SideBarMenuItem>
+              <li>
+                <CustomLink />
+              </li>
+              <SideBarMenuItem icon={<Customicon />} href="#">
+                External Icon
+              </SideBarMenuItem>
 
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => {
-              return (
-                <SideBarMenuItem key={i} icon={<Icon icon="property" />} href="/#">
-                  SideBar Item
-                </SideBarMenuItem>
-              )
-            })}
-          </SideBar.MenuList>
-          <SideBar.CollapseButon />
-        </SideBar>
-        <main
-          style={{
-            width: '100%',
-            overflow: 'auto',
-          }}
-        >
-          <div
+              {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => {
+                return (
+                  <SideBarMenuItem key={i} icon={<Icon icon="property" />} href="/#">
+                    SideBar Item
+                  </SideBarMenuItem>
+                )
+              })}
+            </SideBar.MenuList>
+            <SideBar.CollapseButon />
+          </SideBar>
+          <main
             style={{
-              background: '#ffdaf5',
-              paddingTop: '13rem',
-              paddingLeft: '3rem',
-              fontSize: '1.25rem',
-              height: '115vh',
+              width: '100%',
+              overflow: 'auto',
             }}
           >
-            Placeholder main content
-          </div>
-        </main>
-      </div>
+            <div
+              style={{
+                background: '#ffdaf5',
+                paddingTop: '13rem',
+                paddingLeft: '3rem',
+                fontSize: '1.25rem',
+                height: '115vh',
+              }}
+            >
+              Placeholder main content
+            </div>
+          </main>
+        </div>
+      </MediaStateProvider>
     )
   },
   parameters: {

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -2,6 +2,7 @@ import { useState, type FC, type HTMLAttributes, type KeyboardEventHandler } fro
 import { SideBarCollapseButton } from '../side-bar-collapse-button'
 import { IsSideBarExpandedContext, useIsSideBarExpandedContext } from './is-side-bar-expanded-context'
 import { ElSideBar, ELSideBarMenuList } from './styles'
+import { useMediaQuery } from '#src/hooks/use-media-query/index'
 
 type SideBarFC = FC<HTMLAttributes<HTMLElement>> & {
   CollapseButon: typeof SideBarCollapseButton
@@ -9,7 +10,8 @@ type SideBarFC = FC<HTMLAttributes<HTMLElement>> & {
 }
 
 const SideBar: SideBarFC = ({ children, ...props }) => {
-  const [isExpanded, setIsExpanded] = useState(true)
+  const { isWideScreen, isSuperWideScreen, is4KScreen } = useMediaQuery()
+  const [isExpanded, setIsExpanded] = useState(!!(isWideScreen || isSuperWideScreen || is4KScreen))
 
   const handleOnKeyDown: KeyboardEventHandler<HTMLUListElement> = (e) => {
     const container = e.currentTarget

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -2,7 +2,7 @@ import { useState, type FC, type HTMLAttributes, type KeyboardEventHandler } fro
 import { SideBarCollapseButton } from '../side-bar-collapse-button'
 import { IsSideBarExpandedContext, useIsSideBarExpandedContext } from './is-side-bar-expanded-context'
 import { ElSideBar, ELSideBarMenuList } from './styles'
-import { useMediaQuery } from '#src/hooks/use-media-query/index'
+import { useMediaQuery } from '#src/hooks/use-media-query'
 
 type SideBarFC = FC<HTMLAttributes<HTMLElement>> & {
   CollapseButon: typeof SideBarCollapseButton


### PR DESCRIPTION
## Context
_QA reported several issues in #371. This PR fixes all the mentioned issues to ensure expected functionality._

to fix this issue, I utilize existing `useMediaQuery` hook, so the user have to wrap the `SideBar` with the `MediaStateProvider` to make it work (I also have add a note in the documentation for it).

# Pull request checklist
- [x] On breakpoints <1440 px -> default state is collapsed
- [x] On breakpoints >=1440 px -> default state is expanded

**Detail as per issue below (required):**

fixes: #

![sidebar default expanded state](https://github.com/user-attachments/assets/7da969a2-76f8-40a5-a0f9-526f37cc841d)

