### PR TITLE
feat: #279 Introduce dynamic display of popover element

### DIFF
--- a/src/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Tooltip with createPortal > should render the tooltip when visible 1`] 
     data-position="top"
     id="tooltip-id-test-static-id"
     role="tooltip"
-    style="max-width: 400px; position: absolute; transform: translate(0px, -4px); margin: 0px;"
+    style="max-width: 400px; position: absolute; transform: translate(-4px, 4px); margin: 0px;"
   >
     <span
       class="mocked-styled-8 el-tooltip-label"

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -71,7 +71,7 @@ export default meta
  * `getTooltipProps()`: Applied to the Tooltip component to manage its visibility, positioning, and accessibility.
  *
  *
- * **Note**: The tooltip component ensures that the tooltip remains visible regardless of its 
+ * **Note**: The tooltip component ensures that the tooltip remains visible regardless of its
  * initially declared position.
  * If the tooltip overflows the viewport in any direction,
  * it automatically adjusts to stay visible inside the viewport.

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -4,6 +4,7 @@ import { useTooltip } from './use-tooltip'
 import { Tooltip, TooltipProps } from './tooltip'
 import { ElTooltip, ElTooltipLabel } from './styles'
 import { useId } from 'react'
+import { FlexContainer } from '../layout'
 
 const meta: Meta<typeof Tooltip> = {
   title: 'Components/Tooltip',
@@ -68,6 +69,12 @@ export default meta
  * to bind the necessary event handlers for displaying the tooltip.
  *
  * `getTooltipProps()`: Applied to the Tooltip component to manage its visibility, positioning, and accessibility.
+ *
+ *
+ * **Note**: The tooltip component ensures that the tooltip remains visible regardless of its initially declared position.
+ * If the tooltip overflows the viewport in any direction,
+ * it automatically adjusts to stay visible inside the viewport.
+ * This guarantees an optimal viewing experience without content being clipped or hidden.
  */
 export const BasicUsage = {
   args: {
@@ -268,6 +275,66 @@ export const DisplayTooltipWithoutTrigger = {
   render: (args) => {
     // Pass args to MockedTooltip to make it reactive
     return <MockedTooltip {...args} />
+  },
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: 'none',
+      },
+      story: {
+        inline: false,
+        iframeHeight: 60,
+      },
+    },
+  },
+}
+
+/**
+ * This tooltip component ensures that the tooltip remains visible regardless of its initially declared position.
+ * If the tooltip overflows the viewport in any direction,
+ * it automatically adjusts to stay visible inside the viewport.
+ * This guarantees an optimal viewing experience without content being clipped or hidden.
+ */
+export const DynamicDisplayTooltipExample = {
+  args: {
+    description: 'Tooltip text', // Default value for description
+    label: 'Label', // Default value for label
+    position: 'top',
+    maxWidth: '400px',
+  },
+  render: (args) => {
+    const tooltipTopLeft = useTooltip()
+    const tooltipTopRight = useTooltip()
+    const tooltipBottomRight = useTooltip()
+    const tooltipBottomLeft = useTooltip()
+    // Pass args to MockedTooltip to make it reactive
+    return (
+      <FlexContainer>
+        <FlexContainer
+          isFlexColumn
+          isFlexJustifyBetween
+          style={{
+            height: '100vh',
+            width: '100vw',
+            overflow: 'hidden',
+            minWidth: 'auto',
+          }}
+        >
+          <FlexContainer isFlexJustifyBetween>
+            <Button {...tooltipTopLeft.getTriggerProps()}>Hover me</Button>
+            <Tooltip {...tooltipTopLeft.getTooltipProps()} {...args} />
+            <Button {...tooltipTopRight.getTriggerProps()}>Hover me</Button>
+            <Tooltip {...tooltipTopRight.getTooltipProps()} {...args} />
+          </FlexContainer>
+          <FlexContainer isFlexJustifyBetween>
+            <Button {...tooltipBottomRight.getTriggerProps()}>Hover me</Button>
+            <Tooltip {...tooltipBottomRight.getTooltipProps()} {...args} />
+            <Button {...tooltipBottomLeft.getTriggerProps()}>Hover me</Button>
+            <Tooltip {...tooltipBottomLeft.getTooltipProps()} {...args} />
+          </FlexContainer>
+        </FlexContainer>
+      </FlexContainer>
+    )
   },
   parameters: {
     docs: {

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -71,7 +71,8 @@ export default meta
  * `getTooltipProps()`: Applied to the Tooltip component to manage its visibility, positioning, and accessibility.
  *
  *
- * **Note**: The tooltip component ensures that the tooltip remains visible regardless of its initially declared position.
+ * **Note**: The tooltip component ensures that the tooltip remains visible regardless of its 
+ * initially declared position.
  * If the tooltip overflows the viewport in any direction,
  * it automatically adjusts to stay visible inside the viewport.
  * This guarantees an optimal viewing experience without content being clipped or hidden.

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,25 +1,14 @@
-import React, { FC, HTMLAttributes } from 'react'
+import { FC, HTMLAttributes } from 'react'
 import { ElTooltip, ElTooltipLabel } from './styles'
 import { createPortal } from 'react-dom'
+import { PopoverPosition } from '../../helpers/calculatePopoverPosition'
 
 export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   label?: string
   description: string
   isVisible?: boolean
   maxWidth?: string
-  position?:
-    | 'top'
-    | 'bottom'
-    | 'right'
-    | 'left'
-    | 'top-start'
-    | 'top-end'
-    | 'bottom-start'
-    | 'bottom-end'
-    | 'right-start'
-    | 'right-end'
-    | 'left-start'
-    | 'left-end'
+  position?: PopoverPosition
 }
 
 export const Tooltip: FC<TooltipProps> = ({

--- a/src/components/tooltip/use-tooltip.ts
+++ b/src/components/tooltip/use-tooltip.ts
@@ -54,7 +54,7 @@ export const useTooltip = ({ truncationTargetId }: UseTooltipOptions = {}) => {
 
     // Default position to top
     const tooltipPosition = tooltip.getAttribute('data-position') || 'top'
-    calculatePopoverPosition({ triggerElement: trigger, popoverElement: tooltip, position: tooltipPosition})
+    calculatePopoverPosition({ triggerElement: trigger, popoverElement: tooltip, position: tooltipPosition })
   }
 
   // Update tooltip position on visibility change or window resize

--- a/src/components/tooltip/use-tooltip.ts
+++ b/src/components/tooltip/use-tooltip.ts
@@ -1,5 +1,6 @@
 import { HTMLAttributes, useEffect, useRef, useState } from 'react'
 import { useId } from '#src/storybook/random-id'
+import calculatePopoverPosition from '../../helpers/calculatePopoverPosition'
 
 type UseTooltipOptions = {
   truncationTargetId?: string
@@ -51,78 +52,9 @@ export const useTooltip = ({ truncationTargetId }: UseTooltipOptions = {}) => {
 
     if (!tooltip || !trigger) return
 
-    const triggerRect = trigger.getBoundingClientRect()
-    const tooltipRect = tooltip.getBoundingClientRect()
-
-    // Calculate scroll offsets
-    const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
-    const scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
-
-    // const viewportWidth = window.innerWidth
-    // const viewportHeight = window.innerHeight
-    const position = tooltip.getAttribute('data-position')
-
-    let top = 0
-    let left = 0
-
-    switch (position) {
-      case 'top':
-        top = triggerRect.top + scrollTop - tooltipRect.height - 4
-        left = triggerRect.left + scrollLeft + (triggerRect.width - tooltipRect.width) / 2
-        break
-      case 'top-start':
-        top = triggerRect.top + scrollTop - tooltipRect.height - 4
-        left = triggerRect.left + scrollLeft
-        break
-      case 'top-end':
-        top = triggerRect.top + scrollTop - tooltipRect.height - 4
-        left = triggerRect.right + scrollLeft - tooltipRect.width
-        break
-      case 'bottom':
-        top = triggerRect.bottom + scrollTop + 4
-        left = triggerRect.left + scrollLeft + (triggerRect.width - tooltipRect.width) / 2
-        break
-      case 'bottom-start':
-        top = triggerRect.bottom + scrollTop + 4
-        left = triggerRect.left + scrollLeft
-        break
-      case 'bottom-end':
-        top = triggerRect.bottom + scrollTop + 4
-        left = triggerRect.right + scrollLeft - tooltipRect.width
-        break
-      case 'left':
-        top = triggerRect.top + scrollTop + (triggerRect.height - tooltipRect.height) / 2
-        left = triggerRect.left + scrollLeft - tooltipRect.width - 4
-        break
-      case 'left-start':
-        top = triggerRect.top + scrollTop
-        left = triggerRect.left + scrollLeft - tooltipRect.width - 4
-        break
-      case 'left-end':
-        top = triggerRect.bottom + scrollTop - tooltipRect.height
-        left = triggerRect.left + scrollLeft - tooltipRect.width - 4
-        break
-      case 'right':
-        top = triggerRect.top + scrollTop + (triggerRect.height - tooltipRect.height) / 2
-        left = triggerRect.right + scrollLeft + 4
-        break
-      case 'right-start':
-        top = triggerRect.top + scrollTop
-        left = triggerRect.right + scrollLeft + 4
-        break
-      case 'right-end':
-        top = triggerRect.bottom + scrollTop - tooltipRect.height
-        left = triggerRect.right + scrollLeft + 4
-        break
-      default:
-        break
-    }
-
-    // Below are inline style applied to tooltip to position it relevant to respective trigger
-    tooltip.style.position = 'absolute'
-    tooltip.style.inset = '0px auto auto 0px'
-    tooltip.style.transform = `translate(${left}px, ${top}px)`
-    tooltip.style.margin = '0px'
+    // Default position to top
+    const tooltipPosition = tooltip.getAttribute('data-position') || 'top'
+    calculatePopoverPosition({ triggerElement: trigger, popoverElement: tooltip, position: tooltipPosition})
   }
 
   // Update tooltip position on visibility change or window resize
@@ -130,8 +62,12 @@ export const useTooltip = ({ truncationTargetId }: UseTooltipOptions = {}) => {
     if (isVisible) {
       positionTooltip()
       window.addEventListener('resize', positionTooltip)
+      window.addEventListener('scroll', positionTooltip, true)
     }
-    return () => window.removeEventListener('resize', positionTooltip)
+    return () => {
+      window.removeEventListener('resize', positionTooltip)
+      window.removeEventListener('scroll', positionTooltip)
+    }
   }, [isVisible])
 
   const getTriggerProps = (props?: HTMLAttributes<HTMLElement>) => ({

--- a/src/helpers/calculatePopoverPosition.ts
+++ b/src/helpers/calculatePopoverPosition.ts
@@ -136,32 +136,50 @@ const calculatePopoverPosition = ({
     }
   }
 
+  const adjustWhenOverflowTop = () => {
+    if (top - scrollTop < parentRect.top) {
+      top = triggerRect.bottom + scrollTop + popoverOffset
+    }
+  }
+
+  const adjustWhenOverflowBottom = () => {
+    if (top + popoverRect.height - scrollTop > parentRect.bottom) {
+      top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+    }
+  }
+
+  const adjustWhenOverflowLeft = () => {
+    if (left - scrollLeft < parentRect.left) {
+      left = triggerRect.right + scrollLeft + popoverOffset
+    }
+  }
+
+  const adjustWhenOverflowRight = () => {
+    if (left + popoverRect.width - scrollLeft > viewportWidth) {
+      left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
+    }
+  }
+
   switch (safePosition) {
     case 'top':
       top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
       left = triggerRect.left + scrollLeft + (triggerRect.width - popoverRect.width) / 2
 
-      if (top - scrollTop < parentRect.top) {
-        top = triggerRect.bottom + scrollTop + popoverOffset
-      }
+      adjustWhenOverflowTop()
       adjustLeft()
       break
     case 'top-start':
       top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
       left = triggerRect.left + scrollLeft
 
-      if (top - scrollTop < parentRect.top) {
-        top = triggerRect.bottom + scrollTop + popoverOffset
-      }
+      adjustWhenOverflowTop()
       adjustLeft()
       break
     case 'top-end':
       top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
       left = triggerRect.right + scrollLeft - popoverRect.width
 
-      if (top - scrollTop < parentRect.top) {
-        top = triggerRect.bottom + scrollTop + popoverOffset
-      }
+      adjustWhenOverflowTop()
       adjustLeft()
       break
 
@@ -169,27 +187,21 @@ const calculatePopoverPosition = ({
       top = triggerRect.bottom + scrollTop + popoverOffset
       left = triggerRect.left + scrollLeft + (triggerRect.width - popoverRect.width) / 2
 
-      if (top + popoverRect.height - scrollTop > parentRect.bottom) {
-        top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
-      }
+      adjustWhenOverflowBottom()
       adjustLeft()
       break
     case 'bottom-start':
       top = triggerRect.bottom + scrollTop + popoverOffset
       left = triggerRect.left + scrollLeft
 
-      if (top + popoverRect.height - scrollTop > parentRect.height) {
-        top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
-      }
+      adjustWhenOverflowBottom()
       adjustLeft()
       break
     case 'bottom-end':
       top = triggerRect.bottom + scrollTop + popoverOffset
       left = triggerRect.right + scrollLeft - popoverRect.width
 
-      if (top + popoverRect.height - scrollTop > parentRect.height) {
-        top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
-      }
+      adjustWhenOverflowBottom()
       adjustLeft()
       break
 
@@ -197,54 +209,42 @@ const calculatePopoverPosition = ({
       top = triggerRect.top + scrollTop + (triggerRect.height - popoverRect.height) / 2
       left = triggerRect.left + scrollLeft - popoverRect.width - popoverOffset
 
-      if (left - scrollLeft < parentRect.left) {
-        left = triggerRect.right + scrollLeft + popoverOffset
-      }
+      adjustWhenOverflowLeft()
       adjustTop()
       break
     case 'left-start':
       top = triggerRect.top + scrollTop
       left = triggerRect.left + scrollLeft - popoverRect.width - popoverOffset
 
-      if (left - scrollLeft < parentRect.left) {
-        left = triggerRect.right + scrollLeft + popoverOffset
-      }
+      adjustWhenOverflowLeft()
       adjustTop()
       break
     case 'left-end':
       top = triggerRect.bottom + scrollTop - popoverRect.height
       left = triggerRect.left + scrollLeft - popoverRect.width - popoverOffset
 
-      if (left - scrollLeft < parentRect.left) {
-        left = triggerRect.right + scrollLeft + popoverOffset
-      }
+      adjustWhenOverflowLeft()
       adjustTop()
       break
     case 'right':
       top = triggerRect.top + scrollTop + (triggerRect.height - popoverRect.height) / 2
       left = triggerRect.right + scrollLeft + popoverOffset
 
-      if (left + popoverRect.width - scrollLeft > viewportWidth) {
-        left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
-      }
+      adjustWhenOverflowRight()
       adjustTop()
       break
     case 'right-start':
       top = triggerRect.top + scrollTop
       left = triggerRect.right + scrollLeft + popoverOffset
 
-      if (left + popoverRect.width - scrollLeft > viewportWidth) {
-        left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
-      }
+      adjustWhenOverflowRight()
       adjustTop()
       break
     case 'right-end':
       top = triggerRect.bottom + scrollTop - popoverRect.height
       left = triggerRect.right + scrollLeft + popoverOffset
 
-      if (left + popoverRect.width - scrollLeft > viewportWidth) {
-        left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
-      }
+      adjustWhenOverflowRight()
       adjustTop()
       break
     default:

--- a/src/helpers/calculatePopoverPosition.ts
+++ b/src/helpers/calculatePopoverPosition.ts
@@ -1,0 +1,261 @@
+export type PopoverPosition =
+  | 'top'
+  | 'bottom'
+  | 'right'
+  | 'left'
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'right-start'
+  | 'right-end'
+  | 'left-start'
+  | 'left-end'
+
+const validPositions: PopoverPosition[] = [
+  'top',
+  'bottom',
+  'right',
+  'left',
+  'top-start',
+  'top-end',
+  'bottom-start',
+  'bottom-end',
+  'right-start',
+  'right-end',
+  'left-start',
+  'left-end',
+]
+
+export interface calculatePopoverPositionProps {
+  triggerElement: HTMLElement
+  popoverElement: HTMLElement
+  popoverOffset?: number
+  position?: string
+}
+
+/**
+ * Calculates and positions a popover element relative to a trigger element based on the specified direction.
+ *
+ * Supports 12 different placement positions (e.g., top-start, bottom-end, right, etc.).
+ * Automatically adjusts for screen boundaries, scroll positions, and scrollable parent containers to prevent overflow.
+ *
+ * Notes:
+ * - Fallbacks to `bottom-start` if an invalid position is provided.
+ * - Takes into account scrollbars and adjusts position accordingly.
+ * - Includes future TODO to use `useRef` once React 19 is adopted.
+ *
+ * @param {HTMLElement} triggerElement - The element that triggers the popover.
+ * @param {HTMLElement} popoverElement - The popover element to be positioned.
+ * @param {string} [position='bottom-start'] - Preferred position of the popover.
+ * @param {number} [popoverOffset=4] - The spacing between the trigger and popover.
+ */
+
+const calculatePopoverPosition = ({
+  triggerElement,
+  popoverElement,
+  position,
+  popoverOffset = 4,
+}: calculatePopoverPositionProps): void => {
+  const safePosition: PopoverPosition = validPositions.includes(position as PopoverPosition)
+    ? (position as PopoverPosition)
+    : 'bottom-start'
+  // To do (In Future): Popover/Trigger selector to use useRef once project upgraded to React 19
+  // See: https://react.dev/reference/react/forwardRef
+  // See: https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop
+
+  if (!popoverElement || !triggerElement) return
+
+  const triggerRect = triggerElement.getBoundingClientRect()
+  const popoverRect = popoverElement.getBoundingClientRect()
+
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  const clientWidth = document.body.clientWidth
+  const clientHeight = document.body.clientHeight
+
+  // This is a magic code to get nearest parent container which is scrollable
+  const getScrollableContainer = (element: HTMLElement): HTMLElement => {
+    while (element && element !== document.body) {
+      const { overflowX, overflowY } = getComputedStyle(element)
+      const isScrollableY =
+        (overflowY === 'auto' || overflowY === 'scroll') && element.scrollHeight > element.clientHeight
+      const isScrollableX =
+        (overflowX === 'auto' || overflowX === 'scroll') && element.scrollWidth > element.clientWidth
+
+      if (isScrollableY || isScrollableX) {
+        return element
+      }
+      element = element.parentElement as HTMLElement
+    }
+    return document.documentElement
+  }
+  const scrollableContainer = getScrollableContainer(triggerElement)
+  const parentRect = scrollableContainer?.getBoundingClientRect()
+
+  const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
+  const scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+
+  const hasVerticalScrollbar = viewportWidth > clientWidth
+  const hasHorizontalScrollbar = viewportHeight > clientHeight
+
+  let top = 0
+  let left = 0
+
+  // For vertical scrollbar
+  const verticalScrollbarOffset = hasVerticalScrollbar ? viewportWidth - clientWidth : 0
+  // For horizontal scrollbar
+  const horizontalScrollbarOffset = hasHorizontalScrollbar ? viewportHeight - clientHeight : 0
+
+  const parentReactLeft = parentRect.left > 0 ? parentRect.left : 0
+
+  const adjustLeft = () => {
+    // When overflowing in left view
+    if (left < scrollLeft + popoverOffset + parentReactLeft) {
+      left = scrollLeft + popoverOffset + parentReactLeft
+    }
+    // When overflowing in right view
+    if (left + popoverRect.width + popoverOffset + verticalScrollbarOffset > viewportWidth + scrollLeft) {
+      left = viewportWidth + scrollLeft - popoverRect.width - popoverOffset - verticalScrollbarOffset
+    }
+  }
+
+  const parentReactTop = parentRect.top > 0 ? parentRect.top : 0
+
+  const adjustTop = () => {
+    // When overflowing in bottom view
+    if (
+      top + popoverRect.height + popoverOffset + horizontalScrollbarOffset >
+      viewportHeight + scrollTop + parentRect.top
+    ) {
+      top = viewportHeight + scrollTop + parentRect.top - popoverRect.height - popoverOffset - horizontalScrollbarOffset
+    }
+    // When overflowing in top view
+    if (top < scrollTop + popoverOffset + parentReactTop) {
+      top = scrollTop + popoverOffset + parentReactTop
+    }
+  }
+
+  switch (safePosition) {
+    case 'top':
+      top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+      left = triggerRect.left + scrollLeft + (triggerRect.width - popoverRect.width) / 2
+
+      if (top - scrollTop < parentRect.top) {
+        top = triggerRect.bottom + scrollTop + popoverOffset
+      }
+      adjustLeft()
+      break
+    case 'top-start':
+      top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+      left = triggerRect.left + scrollLeft
+
+      if (top - scrollTop < parentRect.top) {
+        top = triggerRect.bottom + scrollTop + popoverOffset
+      }
+      adjustLeft()
+      break
+    case 'top-end':
+      top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+      left = triggerRect.right + scrollLeft - popoverRect.width
+
+      if (top - scrollTop < parentRect.top) {
+        top = triggerRect.bottom + scrollTop + popoverOffset
+      }
+      adjustLeft()
+      break
+
+    case 'bottom':
+      top = triggerRect.bottom + scrollTop + popoverOffset
+      left = triggerRect.left + scrollLeft + (triggerRect.width - popoverRect.width) / 2
+
+      if (top + popoverRect.height - scrollTop > parentRect.bottom) {
+        top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+      }
+      adjustLeft()
+      break
+    case 'bottom-start':
+      top = triggerRect.bottom + scrollTop + popoverOffset
+      left = triggerRect.left + scrollLeft
+
+      if (top + popoverRect.height - scrollTop > parentRect.height) {
+        top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+      }
+      adjustLeft()
+      break
+    case 'bottom-end':
+      top = triggerRect.bottom + scrollTop + popoverOffset
+      left = triggerRect.right + scrollLeft - popoverRect.width
+
+      if (top + popoverRect.height - scrollTop > parentRect.height) {
+        top = triggerRect.top + scrollTop - popoverRect.height - popoverOffset
+      }
+      adjustLeft()
+      break
+
+    case 'left':
+      top = triggerRect.top + scrollTop + (triggerRect.height - popoverRect.height) / 2
+      left = triggerRect.left + scrollLeft - popoverRect.width - popoverOffset
+
+      if (left - scrollLeft < parentRect.left) {
+        left = triggerRect.right + scrollLeft + popoverOffset
+      }
+      adjustTop()
+      break
+    case 'left-start':
+      top = triggerRect.top + scrollTop
+      left = triggerRect.left + scrollLeft - popoverRect.width - popoverOffset
+
+      if (left - scrollLeft < parentRect.left) {
+        left = triggerRect.right + scrollLeft + popoverOffset
+      }
+      adjustTop()
+      break
+    case 'left-end':
+      top = triggerRect.bottom + scrollTop - popoverRect.height
+      left = triggerRect.left + scrollLeft - popoverRect.width - popoverOffset
+
+      if (left - scrollLeft < parentRect.left) {
+        left = triggerRect.right + scrollLeft + popoverOffset
+      }
+      adjustTop()
+      break
+    case 'right':
+      top = triggerRect.top + scrollTop + (triggerRect.height - popoverRect.height) / 2
+      left = triggerRect.right + scrollLeft + popoverOffset
+
+      if (left + popoverRect.width - scrollLeft > viewportWidth) {
+        left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
+      }
+      adjustTop()
+      break
+    case 'right-start':
+      top = triggerRect.top + scrollTop
+      left = triggerRect.right + scrollLeft + popoverOffset
+
+      if (left + popoverRect.width - scrollLeft > viewportWidth) {
+        left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
+      }
+      adjustTop()
+      break
+    case 'right-end':
+      top = triggerRect.bottom + scrollTop - popoverRect.height
+      left = triggerRect.right + scrollLeft + popoverOffset
+
+      if (left + popoverRect.width - scrollLeft > viewportWidth) {
+        left = triggerRect.left - popoverRect.width - popoverOffset + scrollLeft
+      }
+      adjustTop()
+      break
+    default:
+      break
+  }
+
+  // Below are inline style applied to popoverElement to position it relevant to respective triggerElement
+  popoverElement.style.position = 'absolute'
+  popoverElement.style.inset = '0px auto auto 0px'
+  popoverElement.style.transform = `translate(${left}px, ${top}px)`
+  popoverElement.style.margin = '0px'
+}
+
+export default calculatePopoverPosition


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**

fixes: #279 Added helper function to calculate the position of the popover element relative to the trigger.

**Note:**

- The initial usage of this popover is done in the Tooltip component, which uses `createPortal` to position the popover element at the bottom of the body. 

**To do:**

- The current calculation only supports the positioning of the popover element for the 1 level of scrollable element, i.e., window scroll.
- Still need to provide a fix for nested scrollable elements, i.e., Usage of trigger in a scrollable container within a scrollable container. A good example would be a scrollable Table within a scrollable Page.


