### PR TITLE
fix: #356 #386 Chip style updates

### DIFF
--- a/src/components/chip-group/chip-group.stories.tsx
+++ b/src/components/chip-group/chip-group.stories.tsx
@@ -141,6 +141,7 @@ export const ChipSizing: Story = {
       <ChipGroup.Item key="8" {...ChipStories.Wrapping.args}>
         Or, you can avoid truncation and allow a long chip label to wrap to multiple lines
       </ChipGroup.Item>,
+      <ChipGroup.Item key="9" {...ChipStories.LongWords.args} />,
     ],
     overflow: 'wrap',
   },

--- a/src/components/chip/chip.stories.tsx
+++ b/src/components/chip/chip.stories.tsx
@@ -79,6 +79,15 @@ export const Wrapping: Story = {
   },
 }
 
+/** Line breaks within an otherwise unbreakable string are also permitted to prevent text from overflowing the chip. */
+export const LongWords: Story = {
+  args: {
+    ...FilterChip.args,
+    children: 'Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu, NZ',
+    maxWidth: '--size-80',
+  },
+}
+
 /**
  * Truncation is an optional behaviour that can be enabled to prevent the label from
  * wrapping on multiple lines

--- a/src/components/chip/styles.ts
+++ b/src/components/chip/styles.ts
@@ -23,10 +23,10 @@ export const ElChip = styled.button<ElChipProps>`
   gap: var(--spacing-2);
   grid-template-columns: auto min-content;
   height: min-content;
+  max-width: var(--chip-max-width, auto);
   padding-block: var(--spacing-1);
   padding-inline: var(--spacing-4) var(--spacing-2);
   width: fit-content;
-  max-width: var(--chip-max-width, auto);
 
   &[aria-disabled='true'] {
     cursor: not-allowed;
@@ -74,6 +74,9 @@ interface ElChipLabelProps {
 export const ElChipLabel = styled.span<ElChipLabelProps>`
   color: var(--text-primary);
 
+  /* Allows long words to be broken and wrapped onto the next line. */
+  overflow-wrap: anywhere;
+
   /* text-sm/Regular */
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
@@ -99,8 +102,8 @@ export const ElChipClearIcon = styled(Icon)`
    * does not allow consumer-supplied styles to have a higher specificity */
   color: var(--comp-chip-colour-icon-active) !important;
   font-size: 1rem;
-  height: var(--size-icon-sm) !important;
-  width: var(--size-icon-sm) !important;
+  height: var(--icon_size-s) !important;
+  width: var(--icon_size-s) !important;
 
   [aria-disabled='true'] & {
     color: var(--comp-chip-colour-icon-disabled) !important;


### PR DESCRIPTION
fixes: #356 and #386 

- Replaces incorrect icon size CSS variables with the correct ones
- Updates the Chip label styles to allow line breaks mid-word
- Adds new stories for Chip and ChipGroup demonstrating correct wrapping behaviour for long words

<img width="231" alt="Screenshot 2025-05-08 at 12 19 15 pm" src="https://github.com/user-attachments/assets/642562c0-99e9-4d7a-bb76-83b75d89e946" />
<img width="756" alt="Screenshot 2025-05-08 at 12 18 48 pm" src="https://github.com/user-attachments/assets/7dfce59e-37b5-47ab-ad69-08d1b19b572a" />
<img width="739" alt="Screenshot 2025-05-08 at 12 18 54 pm" src="https://github.com/user-attachments/assets/6e1ce08b-91ce-4a72-92d6-314fbab80bc8" />

