### PR TITLE
refactor: #316 new Menu to use props pattern, and new design

### DIFF
--- a/src/components/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
+++ b/src/components/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
@@ -140,43 +140,6 @@ exports[`BottomBar > can render 4 items and an overflow menu 1`] = `
           More
         </span>
       </button>
-      <div
-        class="mocked-styled-7 el-menu-popover"
-        data-open="false"
-        style="position: absolute;"
-      >
-        <div
-          class="mocked-styled-9 el-menu-list"
-          role="menu"
-        >
-          <button
-            class="mocked-styled-12 el-menu-item-button"
-            data-close-menu="true"
-            role="menuitem"
-          >
-            <div
-              class="mocked-styled-10 el-menu-item-content"
-            >
-              <span
-                class="mocked-styled-11 el-menu-item-label"
-              />
-            </div>
-          </button>
-          <button
-            class="mocked-styled-12 el-menu-item-button"
-            data-close-menu="true"
-            role="menuitem"
-          >
-            <div
-              class="mocked-styled-10 el-menu-item-content"
-            >
-              <span
-                class="mocked-styled-11 el-menu-item-label"
-              />
-            </div>
-          </button>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
+++ b/src/components/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BottomBar > can render 4 items and an overflow menu 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-14 el-bottom-bar"
+    class="mocked-styled-16 el-bottom-bar"
   >
     <button
       class="mocked-styled-5 el-button-bottom-bar-item-container"
@@ -90,7 +90,7 @@ exports[`BottomBar > can render 4 items and an overflow menu 1`] = `
       </span>
     </button>
     <div
-      class="mocked-styled-15 el-bottom-bar-more-menu el-menu"
+      class="mocked-styled-17 el-bottom-bar-more-menu el-menu"
       data-alignment="right"
     >
       <button
@@ -140,6 +140,43 @@ exports[`BottomBar > can render 4 items and an overflow menu 1`] = `
           More
         </span>
       </button>
+      <div
+        class="mocked-styled-7 el-menu-popover"
+        data-open="false"
+        style="position: absolute;"
+      >
+        <div
+          class="mocked-styled-9 el-menu-list"
+          role="menu"
+        >
+          <button
+            class="mocked-styled-12 el-menu-item-button"
+            data-close-menu="true"
+            role="menuitem"
+          >
+            <div
+              class="mocked-styled-10 el-menu-item-content"
+            >
+              <span
+                class="mocked-styled-11 el-menu-item-label"
+              />
+            </div>
+          </button>
+          <button
+            class="mocked-styled-12 el-menu-item-button"
+            data-close-menu="true"
+            role="menuitem"
+          >
+            <div
+              class="mocked-styled-10 el-menu-item-content"
+            >
+              <span
+                class="mocked-styled-11 el-menu-item-label"
+              />
+            </div>
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -148,7 +185,7 @@ exports[`BottomBar > can render 4 items and an overflow menu 1`] = `
 exports[`BottomBar > can render 5 items 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-14 el-bottom-bar"
+    class="mocked-styled-16 el-bottom-bar"
   >
     <button
       class="mocked-styled-5 el-button-bottom-bar-item-container"

--- a/src/components/bottom-bar/__tests__/bottom-bar.test.tsx
+++ b/src/components/bottom-bar/__tests__/bottom-bar.test.tsx
@@ -25,8 +25,8 @@ describe('BottomBar', () => {
           <BottomBar.Item icon={<span>mock icon</span>}>Menu 3</BottomBar.Item>
           <BottomBar.Item icon={<span>mock icon</span>}>Menu 4</BottomBar.Item>
           <BottomBar.MoreMenu>
-            <BottomBar.MoreMenuItem>Menu 5</BottomBar.MoreMenuItem>
-            <BottomBar.MoreMenuItem>Menu 6</BottomBar.MoreMenuItem>
+            <BottomBar.MoreMenuItem label="Menu 5" />
+            <BottomBar.MoreMenuItem label="Menu 6" />
           </BottomBar.MoreMenu>
         </BottomBar>,
       ).asFragment(),

--- a/src/components/bottom-bar/bottom-bar.atoms.tsx
+++ b/src/components/bottom-bar/bottom-bar.atoms.tsx
@@ -2,7 +2,7 @@ import type { FC, ReactNode } from 'react'
 
 import { BottomBarItem } from '../bottom-bar-item'
 import { Icon } from '../icon'
-import { Menu, MenuItemContainerProps } from '../menu'
+import { Menu, type MenuItemProps } from '../menu'
 import { ElBottomBarMoreMenu } from './styles'
 
 export interface BottomBarMoreMenuProps {
@@ -26,7 +26,7 @@ export const BottomBarMoreMenu: FC<BottomBarMoreMenuProps> = ({ children }) => {
   )
 }
 
-export type BottomBarMoreMenuItemProps = MenuItemContainerProps
+export type BottomBarMoreMenuItemProps = MenuItemProps
 export const BottomBarMoreMenuItem: FC<BottomBarMoreMenuItemProps> = (args) => {
   return <Menu.Item {...args} />
 }

--- a/src/components/bottom-bar/bottom-bar.atoms.tsx
+++ b/src/components/bottom-bar/bottom-bar.atoms.tsx
@@ -2,7 +2,7 @@ import type { FC, ReactNode } from 'react'
 
 import { BottomBarItem } from '../bottom-bar-item'
 import { Icon } from '../icon'
-import { Menu, MenuItemProps } from '../menu'
+import { Menu, MenuItemContainerProps } from '../menu'
 import { ElBottomBarMoreMenu } from './styles'
 
 export interface BottomBarMoreMenuProps {
@@ -26,7 +26,7 @@ export const BottomBarMoreMenu: FC<BottomBarMoreMenuProps> = ({ children }) => {
   )
 }
 
-export type BottomBarMoreMenuItemProps = MenuItemProps
+export type BottomBarMoreMenuItemProps = MenuItemContainerProps
 export const BottomBarMoreMenuItem: FC<BottomBarMoreMenuItemProps> = (args) => {
   return <Menu.Item {...args} />
 }

--- a/src/components/bottom-bar/bottom-bar.stories.tsx
+++ b/src/components/bottom-bar/bottom-bar.stories.tsx
@@ -74,8 +74,8 @@ export const WithOverflowMenu: Story = {
               Menu 4
             </BottomBar.Item>
             <BottomBar.MoreMenu>
-              <BottomBar.MoreMenuItem>Menu 5</BottomBar.MoreMenuItem>
-              <BottomBar.MoreMenuItem>Menu 6</BottomBar.MoreMenuItem>
+              <BottomBar.MoreMenuItem label="Menu 5" />
+              <BottomBar.MoreMenuItem label="Menu 6" />
             </BottomBar.MoreMenu>
           </BottomBar>
         </section>

--- a/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
@@ -22,18 +22,34 @@ exports[`Menu Popover component > should render and close Popover based on any e
         role="menu"
       >
         <button
-          class="mocked-styled-3 el-menu-item-button"
+          class="mocked-styled-5 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
         >
-          Menu Item
+          <div
+            class="mocked-styled-3 el-menu-item-content"
+          >
+            <span
+              class="mocked-styled-4 el-menu-item-label"
+            >
+              Menu Item
+            </span>
+          </div>
         </button>
         <button
-          class="mocked-styled-3 el-menu-item-button"
+          class="mocked-styled-5 el-menu-item-button"
           data-close-menu="false"
           role="menuitem"
         >
-          Non closing Menu Item
+          <div
+            class="mocked-styled-3 el-menu-item-content"
+          >
+            <span
+              class="mocked-styled-4 el-menu-item-label"
+            >
+              Non closing Menu Item
+            </span>
+          </div>
         </button>
       </div>
     </div>
@@ -53,6 +69,47 @@ exports[`Menu Popover component > should render and close Popover based on any e
     >
       Trigger
     </button>
+    <div
+      class="mocked-styled-0 el-menu-popover"
+      data-open="false"
+      style="top: 4px;"
+    >
+      <div
+        class="mocked-styled-2 el-menu-list"
+        role="menu"
+      >
+        <button
+          class="mocked-styled-5 el-menu-item-button"
+          data-close-menu="true"
+          role="menuitem"
+        >
+          <div
+            class="mocked-styled-3 el-menu-item-content"
+          >
+            <span
+              class="mocked-styled-4 el-menu-item-label"
+            >
+              Menu Item
+            </span>
+          </div>
+        </button>
+        <button
+          class="mocked-styled-5 el-menu-item-button"
+          data-close-menu="false"
+          role="menuitem"
+        >
+          <div
+            class="mocked-styled-3 el-menu-item-content"
+          >
+            <span
+              class="mocked-styled-4 el-menu-item-label"
+            >
+              Non closing Menu Item
+            </span>
+          </div>
+        </button>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Menu Popover component > should render and close Popover based on any e
           class="mocked-styled-5 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
+          tabindex="0"
         >
           <div
             class="mocked-styled-3 el-menu-item-content"
@@ -40,6 +41,7 @@ exports[`Menu Popover component > should render and close Popover based on any e
           class="mocked-styled-5 el-menu-item-button"
           data-close-menu="false"
           role="menuitem"
+          tabindex="0"
         >
           <div
             class="mocked-styled-3 el-menu-item-content"
@@ -69,47 +71,6 @@ exports[`Menu Popover component > should render and close Popover based on any e
     >
       Trigger
     </button>
-    <div
-      class="mocked-styled-0 el-menu-popover"
-      data-open="false"
-      style="top: 4px;"
-    >
-      <div
-        class="mocked-styled-2 el-menu-list"
-        role="menu"
-      >
-        <button
-          class="mocked-styled-5 el-menu-item-button"
-          data-close-menu="true"
-          role="menuitem"
-        >
-          <div
-            class="mocked-styled-3 el-menu-item-content"
-          >
-            <span
-              class="mocked-styled-4 el-menu-item-label"
-            >
-              Menu Item
-            </span>
-          </div>
-        </button>
-        <button
-          class="mocked-styled-5 el-menu-item-button"
-          data-close-menu="false"
-          role="menuitem"
-        >
-          <div
-            class="mocked-styled-3 el-menu-item-content"
-          >
-            <span
-              class="mocked-styled-4 el-menu-item-label"
-            >
-              Non closing Menu Item
-            </span>
-          </div>
-        </button>
-      </div>
-    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/menu/__tests__/__snapshots__/menu.molecules.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.molecules.test.tsx.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MenuItem component > should render with required props and match snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="mocked-styled-5 el-menu-item-button"
+    data-close-menu="true"
+    role="menuitem"
+    tabindex="0"
+  >
+    <div
+      class="mocked-styled-3 el-menu-item-content"
+    >
+      <span
+        class="mocked-styled-4 el-menu-item-label"
+      >
+        Test Menu Item
+      </span>
+    </div>
+  </button>
+</DocumentFragment>
+`;

--- a/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`Menu list component > should render menu with list components and match
           class="mocked-styled-5 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
+          tabindex="0"
         >
           <div
             class="mocked-styled-3 el-menu-item-content"

--- a/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
@@ -10,28 +10,45 @@ exports[`Menu list component > should render menu with list components and match
       role="menu"
     >
       <div
-        class="mocked-styled-6 el-menu-item-group"
+        class="mocked-styled-8 el-menu-item-group"
         role="group"
       >
         <div
-          class="mocked-styled-5 el-menu-item-group-title"
+          class="mocked-styled-7 el-menu-item-group-title"
         >
           Group Title
         </div>
         <a
-          class="mocked-styled-4 el-menu-item-anchor"
+          class="mocked-styled-6 el-menu-item-anchor"
           data-close-menu="true"
           href="/#"
           role="menuitem"
+          tabindex="0"
         >
-          Menu item as anchor
+          <div
+            class="mocked-styled-3 el-menu-item-content"
+          >
+            <span
+              class="mocked-styled-4 el-menu-item-label"
+            >
+              Menu item as anchor
+            </span>
+          </div>
         </a>
         <button
-          class="mocked-styled-3 el-menu-item-button"
+          class="mocked-styled-5 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
         >
-          Menu item as button
+          <div
+            class="mocked-styled-3 el-menu-item-content"
+          >
+            <span
+              class="mocked-styled-4 el-menu-item-label"
+            >
+              Menu item as button
+            </span>
+          </div>
         </button>
       </div>
     </div>

--- a/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`Menu list component > should render menu with list components and match
           data-close-menu="true"
           href="/#"
           role="menuitem"
-          tabindex="0"
         >
           <div
             class="mocked-styled-3 el-menu-item-content"

--- a/src/components/menu/__tests__/menu-popover.test.tsx
+++ b/src/components/menu/__tests__/menu-popover.test.tsx
@@ -9,8 +9,8 @@ describe('Menu Popover component', () => {
         <Menu.Trigger>{({ getTriggerProps }) => <button {...getTriggerProps()}>Trigger</button>}</Menu.Trigger>
         <Menu.Popover>
           <Menu.List>
-            <Menu.Item>Menu Item</Menu.Item>
-            <Menu.Item closeMenu={false}>Non closing Menu Item</Menu.Item>
+            <Menu.Item label="Menu Item" />
+            <Menu.Item closeMenu={false} label="Non closing Menu Item" />
           </Menu.List>
         </Menu.Popover>
       </Menu>

--- a/src/components/menu/__tests__/menu.atoms.tests.tsx
+++ b/src/components/menu/__tests__/menu.atoms.tests.tsx
@@ -26,6 +26,7 @@ describe('MenuItemContainer', () => {
       render(<MenuItemContainer disabled>Disabled Button</MenuItemContainer>)
 
       const button = screen.getByRole('menuitem')
+      expect(button).toHaveAttribute('disabled', 'true')
       expect(button).toHaveAttribute('aria-disabled', 'true')
       expect(button).toHaveAttribute('tabIndex', '-1')
     })
@@ -68,18 +69,6 @@ describe('MenuItemContainer', () => {
 
       const link = screen.getByRole('menuitem')
       expect(link).toHaveAttribute('aria-current', 'page')
-    })
-
-    it('should apply disabled state correctly', () => {
-      render(
-        <MenuItemContainer href="/test" disabled>
-          Disabled Link
-        </MenuItemContainer>,
-      )
-
-      const link = screen.getByRole('menuitem')
-      expect(link).toHaveAttribute('aria-disabled', 'true')
-      expect(link).toHaveAttribute('tabIndex', '-1')
     })
 
     it('should set data-close-menu attribute correctly', () => {

--- a/src/components/menu/__tests__/menu.atoms.tests.tsx
+++ b/src/components/menu/__tests__/menu.atoms.tests.tsx
@@ -27,6 +27,7 @@ describe('MenuItemContainer', () => {
 
       const button = screen.getByRole('menuitem')
       expect(button).toHaveAttribute('disabled', 'true')
+      expect(button).toHaveAttribute('data-close-menu', 'false')
       expect(button).toHaveAttribute('aria-disabled', 'true')
       expect(button).toHaveAttribute('tabIndex', '-1')
     })

--- a/src/components/menu/__tests__/menu.atoms.tests.tsx
+++ b/src/components/menu/__tests__/menu.atoms.tests.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { MenuItemContainer, MenuItemGroup, MenuList } from '../menu.atoms'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MenuItemContainer, MenuList } from '../menu.atoms'
 
 describe.todo('MenuItemGroup', () => {
   // TODO: Add tests for MenuItemGroup in separate pr
@@ -9,7 +9,7 @@ describe('MenuItemContainer', () => {
   describe('as button', () => {
     it('should render as button when no href is provided', () => {
       render(<MenuItemContainer>Test Button</MenuItemContainer>)
-      
+
       const button = screen.getByRole('menuitem')
       expect(button.tagName).toBe('BUTTON')
       expect(button).toHaveTextContent('Test Button')
@@ -17,14 +17,14 @@ describe('MenuItemContainer', () => {
 
     it('should apply active state correctly', () => {
       render(<MenuItemContainer isActive>Active Button</MenuItemContainer>)
-      
+
       const button = screen.getByRole('menuitem')
       expect(button).toHaveAttribute('aria-current', 'true')
     })
 
     it('should apply disabled state correctly', () => {
       render(<MenuItemContainer disabled>Disabled Button</MenuItemContainer>)
-      
+
       const button = screen.getByRole('menuitem')
       expect(button).toHaveAttribute('aria-disabled', 'true')
       expect(button).toHaveAttribute('tabIndex', '-1')
@@ -32,18 +32,18 @@ describe('MenuItemContainer', () => {
 
     it('should call onClick handler when clicked', () => {
       const handleClick = vi.fn()
-      
+
       render(<MenuItemContainer onClick={handleClick}>Clickable Button</MenuItemContainer>)
-      
+
       const button = screen.getByRole('menuitem')
       fireEvent.click(button)
-      
+
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
     it('should set data-close-menu attribute correctly', () => {
       render(<MenuItemContainer closeMenu={false}>Non-closing Button</MenuItemContainer>)
-      
+
       const button = screen.getByRole('menuitem')
       expect(button).toHaveAttribute('data-close-menu', 'false')
     })
@@ -52,7 +52,7 @@ describe('MenuItemContainer', () => {
   describe('as anchor', () => {
     it('should render as anchor when href is provided', () => {
       render(<MenuItemContainer href="/test">Test Link</MenuItemContainer>)
-      
+
       const link = screen.getByRole('menuitem')
       expect(link.tagName).toBe('A')
       expect(link).toHaveTextContent('Test Link')
@@ -60,23 +60,35 @@ describe('MenuItemContainer', () => {
     })
 
     it('should apply active state correctly', () => {
-      render(<MenuItemContainer href="/test" isActive>Active Link</MenuItemContainer>)
-      
+      render(
+        <MenuItemContainer href="/test" isActive>
+          Active Link
+        </MenuItemContainer>,
+      )
+
       const link = screen.getByRole('menuitem')
       expect(link).toHaveAttribute('aria-current', 'page')
     })
 
     it('should apply disabled state correctly', () => {
-      render(<MenuItemContainer href="/test" disabled>Disabled Link</MenuItemContainer>)
-      
+      render(
+        <MenuItemContainer href="/test" disabled>
+          Disabled Link
+        </MenuItemContainer>,
+      )
+
       const link = screen.getByRole('menuitem')
       expect(link).toHaveAttribute('aria-disabled', 'true')
       expect(link).toHaveAttribute('tabIndex', '-1')
     })
 
     it('should set data-close-menu attribute correctly', () => {
-      render(<MenuItemContainer href="/test" closeMenu={false}>Non-closing Link</MenuItemContainer>)
-      
+      render(
+        <MenuItemContainer href="/test" closeMenu={false}>
+          Non-closing Link
+        </MenuItemContainer>,
+      )
+
       const link = screen.getByRole('menuitem')
       expect(link).toHaveAttribute('data-close-menu', 'false')
     })
@@ -90,7 +102,7 @@ describe('MenuList', () => {
         <div data-testid="menu-child">Menu Child</div>
       </MenuList>,
     )
-    
+
     expect(screen.getByRole('menu')).toBeInTheDocument()
     expect(screen.getByTestId('menu-child')).toBeInTheDocument()
     expect(screen.getByTestId('custom-menu-list')).toBeInTheDocument()

--- a/src/components/menu/__tests__/menu.atoms.tests.tsx
+++ b/src/components/menu/__tests__/menu.atoms.tests.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MenuItemContainer, MenuItemGroup, MenuList } from '../menu.atoms'
+
+describe.todo('MenuItemGroup', () => {
+  // TODO: Add tests for MenuItemGroup in separate pr
+})
+
+describe('MenuItemContainer', () => {
+  describe('as button', () => {
+    it('should render as button when no href is provided', () => {
+      render(<MenuItemContainer>Test Button</MenuItemContainer>)
+      
+      const button = screen.getByRole('menuitem')
+      expect(button.tagName).toBe('BUTTON')
+      expect(button).toHaveTextContent('Test Button')
+    })
+
+    it('should apply active state correctly', () => {
+      render(<MenuItemContainer isActive>Active Button</MenuItemContainer>)
+      
+      const button = screen.getByRole('menuitem')
+      expect(button).toHaveAttribute('aria-current', 'true')
+    })
+
+    it('should apply disabled state correctly', () => {
+      render(<MenuItemContainer disabled>Disabled Button</MenuItemContainer>)
+      
+      const button = screen.getByRole('menuitem')
+      expect(button).toHaveAttribute('aria-disabled', 'true')
+      expect(button).toHaveAttribute('tabIndex', '-1')
+    })
+
+    it('should call onClick handler when clicked', () => {
+      const handleClick = vi.fn()
+      
+      render(<MenuItemContainer onClick={handleClick}>Clickable Button</MenuItemContainer>)
+      
+      const button = screen.getByRole('menuitem')
+      fireEvent.click(button)
+      
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should set data-close-menu attribute correctly', () => {
+      render(<MenuItemContainer closeMenu={false}>Non-closing Button</MenuItemContainer>)
+      
+      const button = screen.getByRole('menuitem')
+      expect(button).toHaveAttribute('data-close-menu', 'false')
+    })
+  })
+
+  describe('as anchor', () => {
+    it('should render as anchor when href is provided', () => {
+      render(<MenuItemContainer href="/test">Test Link</MenuItemContainer>)
+      
+      const link = screen.getByRole('menuitem')
+      expect(link.tagName).toBe('A')
+      expect(link).toHaveTextContent('Test Link')
+      expect(link).toHaveAttribute('href', '/test')
+    })
+
+    it('should apply active state correctly', () => {
+      render(<MenuItemContainer href="/test" isActive>Active Link</MenuItemContainer>)
+      
+      const link = screen.getByRole('menuitem')
+      expect(link).toHaveAttribute('aria-current', 'page')
+    })
+
+    it('should apply disabled state correctly', () => {
+      render(<MenuItemContainer href="/test" disabled>Disabled Link</MenuItemContainer>)
+      
+      const link = screen.getByRole('menuitem')
+      expect(link).toHaveAttribute('aria-disabled', 'true')
+      expect(link).toHaveAttribute('tabIndex', '-1')
+    })
+
+    it('should set data-close-menu attribute correctly', () => {
+      render(<MenuItemContainer href="/test" closeMenu={false}>Non-closing Link</MenuItemContainer>)
+      
+      const link = screen.getByRole('menuitem')
+      expect(link).toHaveAttribute('data-close-menu', 'false')
+    })
+  })
+})
+
+describe('MenuList', () => {
+  it('should render as expected', () => {
+    render(
+      <MenuList>
+        <div data-testid="menu-child">Menu Child</div>
+      </MenuList>,
+    )
+    
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByTestId('menu-child')).toBeInTheDocument()
+    expect(screen.getByTestId('custom-menu-list')).toBeInTheDocument()
+  })
+})

--- a/src/components/menu/__tests__/menu.molecules.test.tsx
+++ b/src/components/menu/__tests__/menu.molecules.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import { MenuItem } from '../menu.molecules'
+
+describe('MenuItem component', () => {
+  it('should render with required props and match snapshot', () => {
+    const { asFragment } = render(<MenuItem label="Test Menu Item" />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/menu/__tests__/menu.test.tsx
+++ b/src/components/menu/__tests__/menu.test.tsx
@@ -7,8 +7,8 @@ describe('Menu list component', () => {
       <Menu>
         <Menu.List>
           <Menu.Group label="Group Title">
-            <Menu.Item href="/#">Menu item as anchor</Menu.Item>
-            <Menu.Item>Menu item as button</Menu.Item>
+            <Menu.Item href="/#" label="Menu item as anchor" />
+            <Menu.Item label="Menu item as button" />
           </Menu.Group>
         </Menu.List>
       </Menu>,

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -1,3 +1,4 @@
 export * from './menu'
 export * from './menu.atoms'
+export * from './menu.molecules'
 export * from './styles'

--- a/src/components/menu/menu-popover.tsx
+++ b/src/components/menu/menu-popover.tsx
@@ -48,7 +48,7 @@ export const MenuPopover: FC<
     }
   }, [isOpen])
 
-  // if (!isOpen) return null
+  if (!isOpen) return null
 
   const handleClick = (event) => {
     // close menu if clicked target has parent with below selector

--- a/src/components/menu/menu-popover.tsx
+++ b/src/components/menu/menu-popover.tsx
@@ -48,7 +48,7 @@ export const MenuPopover: FC<
     }
   }, [isOpen])
 
-  if (!isOpen) return null
+  // if (!isOpen) return null
 
   const handleClick = (event) => {
     // close menu if clicked target has parent with below selector

--- a/src/components/menu/menu.atoms.tsx
+++ b/src/components/menu/menu.atoms.tsx
@@ -34,8 +34,8 @@ interface MenuItemAsButtonElementProps extends CommonMenuItemProps, ButtonHTMLAt
 }
 
 interface MenuItemAsAnchorElementProps extends CommonMenuItemProps, AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** MenuItemAsAnchor currently doesn't support disabled state */
-  disabled?: boolean
+  /** MenuItemAsAnchor currently doesn't support disabled state, use MenuItemButton instead */
+  disabled?: never
 }
 
 export type MenuItemContainerProps = MenuItemAsButtonElementProps | MenuItemAsAnchorElementProps
@@ -71,8 +71,7 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
         role="menuitem"
         data-close-menu={closeMenu}
         aria-current={isActive ? 'page' : undefined}
-        aria-disabled={disabled}
-        tabIndex={disabled ? -1 : 0}
+        datat-test={disabled}
       >
         {children}
       </ElMenuItemAnchor>
@@ -84,6 +83,7 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
       {...rest}
       role="menuitem"
       data-close-menu={closeMenu}
+      disabled={disabled}
       aria-disabled={disabled}
       aria-current={isActive ? 'true' : undefined}
       tabIndex={disabled ? -1 : 0}

--- a/src/components/menu/menu.atoms.tsx
+++ b/src/components/menu/menu.atoms.tsx
@@ -19,6 +19,12 @@ interface CommonMenuItemProps {
    * @default true
    */
   closeMenu?: boolean
+  /**
+   * Whether the Menu item is active
+   *
+   * @default false
+   **/
+  isActive?: boolean
 }
 
 interface MenuItemAsButtonElementProps extends CommonMenuItemProps, ButtonHTMLAttributes<HTMLButtonElement> {
@@ -29,10 +35,10 @@ interface MenuItemAsButtonElementProps extends CommonMenuItemProps, ButtonHTMLAt
 
 interface MenuItemAsAnchorElementProps extends CommonMenuItemProps, AnchorHTMLAttributes<HTMLAnchorElement> {
   /** MenuItemAsAnchor currently doesn't support disabled state */
-  disabled?: never
+  disabled?: boolean
 }
 
-export type MenuItemProps = MenuItemAsButtonElementProps | MenuItemAsAnchorElementProps
+export type MenuItemContainerProps = MenuItemAsButtonElementProps | MenuItemAsAnchorElementProps
 
 /**
  * The `MenuItemGroup` component is a wrapper for `MenuItem` which has optional label
@@ -51,17 +57,36 @@ export const MenuItemGroup: FC<
   )
 }
 
-export const MenuItem: FC<MenuItemProps> = ({ children, disabled, closeMenu = true, ...rest }) => {
+export const MenuItemContainer: FC<MenuItemContainerProps> = ({
+  children,
+  disabled,
+  isActive,
+  closeMenu = true,
+  ...rest
+}) => {
   if (!isItemAsButtonElement(rest)) {
     return (
-      <ElMenuItemAnchor role="menuitem" data-close-menu={closeMenu} {...(rest as MenuItemAsAnchorElementProps)}>
+      <ElMenuItemAnchor
+        role="menuitem"
+        data-close-menu={closeMenu}
+        {...(rest as MenuItemAsAnchorElementProps)}
+        aria-current={isActive ? 'page' : undefined}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+      >
         {children}
       </ElMenuItemAnchor>
     )
   }
 
   return (
-    <ElMenuItemButton role="menuitem" data-close-menu={closeMenu} aria-disabled={disabled} {...rest}>
+    <ElMenuItemButton
+      role="menuitem"
+      data-close-menu={closeMenu}
+      aria-disabled={disabled}
+      {...rest}
+      aria-current={isActive ? 'true' : undefined}
+    >
       {children}
     </ElMenuItemButton>
   )
@@ -73,6 +98,6 @@ export const MenuList: FC<HTMLAttributes<HTMLDivElement>> = ({ children, ...rest
   </ElMenuList>
 )
 
-function isItemAsButtonElement(props: MenuItemProps): props is MenuItemAsButtonElementProps {
+function isItemAsButtonElement(props: MenuItemContainerProps): props is MenuItemAsButtonElementProps {
   return !props.href
 }

--- a/src/components/menu/menu.atoms.tsx
+++ b/src/components/menu/menu.atoms.tsx
@@ -50,7 +50,7 @@ export const MenuItemGroup: FC<
   }
 > = ({ children, label, ...rest }) => {
   return (
-    <ElMenuItemGroup role="group" {...rest}>
+    <ElMenuItemGroup {...rest} role="group">
       {!!label && <ElMenuItemGroupTitle>{label}</ElMenuItemGroupTitle>}
       {children}
     </ElMenuItemGroup>
@@ -67,9 +67,9 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
   if (!isItemAsButtonElement(rest)) {
     return (
       <ElMenuItemAnchor
+        {...(rest as MenuItemAsAnchorElementProps)}
         role="menuitem"
         data-close-menu={closeMenu}
-        {...(rest as MenuItemAsAnchorElementProps)}
         aria-current={isActive ? 'page' : undefined}
         aria-disabled={disabled}
         tabIndex={disabled ? -1 : 0}
@@ -81,10 +81,10 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
 
   return (
     <ElMenuItemButton
+      {...rest}
       role="menuitem"
       data-close-menu={closeMenu}
       aria-disabled={disabled}
-      {...rest}
       aria-current={isActive ? 'true' : undefined}
       tabIndex={disabled ? -1 : 0}
     >
@@ -94,7 +94,7 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
 }
 
 export const MenuList: FC<HTMLAttributes<HTMLDivElement>> = ({ children, ...rest }) => (
-  <ElMenuList role="menu" {...rest}>
+  <ElMenuList {...rest} role="menu">
     {children}
   </ElMenuList>
 )

--- a/src/components/menu/menu.atoms.tsx
+++ b/src/components/menu/menu.atoms.tsx
@@ -59,8 +59,8 @@ export const MenuItemGroup: FC<
 
 export const MenuItemContainer: FC<MenuItemContainerProps> = ({
   children,
-  disabled,
   isActive,
+  disabled,
   closeMenu = true,
   ...rest
 }) => {
@@ -69,7 +69,7 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
       <ElMenuItemAnchor
         {...(rest as MenuItemAsAnchorElementProps)}
         role="menuitem"
-        data-close-menu={closeMenu}
+        data-close-menu={closeMenu || !!disabled}
         aria-current={isActive ? 'page' : undefined}
         datat-test={disabled}
       >

--- a/src/components/menu/menu.atoms.tsx
+++ b/src/components/menu/menu.atoms.tsx
@@ -86,6 +86,7 @@ export const MenuItemContainer: FC<MenuItemContainerProps> = ({
       aria-disabled={disabled}
       {...rest}
       aria-current={isActive ? 'true' : undefined}
+      tabIndex={disabled ? -1 : 0}
     >
       {children}
     </ElMenuItemButton>

--- a/src/components/menu/menu.molecules.tsx
+++ b/src/components/menu/menu.molecules.tsx
@@ -1,0 +1,17 @@
+import type { FC } from 'react'
+import { MenuItemContainer, type MenuItemContainerProps } from './menu.atoms'
+import { ElMenuItemContent, ElMenuItemLabel } from './styles'
+
+interface MenuItemProps extends Omit<MenuItemContainerProps, 'children'> {
+  label?: string
+}
+
+export const MenuItem: FC<MenuItemProps> = ({ label, ...props }) => {
+  return (
+    <MenuItemContainer {...(props as MenuItemContainerProps)}>
+      <ElMenuItemContent>
+        <ElMenuItemLabel>{label}</ElMenuItemLabel>
+      </ElMenuItemContent>
+    </MenuItemContainer>
+  )
+}

--- a/src/components/menu/menu.molecules.tsx
+++ b/src/components/menu/menu.molecules.tsx
@@ -3,7 +3,7 @@ import { MenuItemContainer, type MenuItemContainerProps } from './menu.atoms'
 import { ElMenuItemContent, ElMenuItemLabel } from './styles'
 
 export interface MenuItemProps extends Omit<MenuItemContainerProps, 'children'> {
-  label?: string
+  label: string
 }
 
 export const MenuItem: FC<MenuItemProps> = ({ label, ...props }) => {

--- a/src/components/menu/menu.molecules.tsx
+++ b/src/components/menu/menu.molecules.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import { MenuItemContainer, type MenuItemContainerProps } from './menu.atoms'
 import { ElMenuItemContent, ElMenuItemLabel } from './styles'
 
-interface MenuItemProps extends Omit<MenuItemContainerProps, 'children'> {
+export interface MenuItemProps extends Omit<MenuItemContainerProps, 'children'> {
   label?: string
 }
 

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -25,7 +25,7 @@ export const Default: StoryObj = {
               <Menu.Item label="Menu Item" onClick={console.log} />
               <Menu.Item label="Menu Item as anchor" href="/#" />
               <Menu.Item label="Menu Item (keep open)" closeMenu={false} isActive />
-              <Menu.Item label="Menu Item (disabled)" href="/#" disabled />
+              <Menu.Item label="Menu Item (disabled)" onClick={console.log} disabled />
             </Menu.Group>
           </Menu.List>
         </Menu.Popover>

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -22,9 +22,10 @@ export const Default: StoryObj = {
         <Menu.Popover>
           <Menu.List>
             <Menu.Group label="Group Title">
-              <Menu.Item onClick={console.log}>Menu Item</Menu.Item>
-              <Menu.Item href="/#">Menu Item as anchor</Menu.Item>
-              <Menu.Item closeMenu={false}>Menu Item (keep open)</Menu.Item>
+              <Menu.Item label="Menu Item" onClick={console.log} />
+              <Menu.Item label="Menu Item as anchor" href="/#" />
+              <Menu.Item label="Menu Item (keep open)" closeMenu={false} isActive />
+              <Menu.Item label="Menu Item (disabled)" href="/#" disabled />
             </Menu.Group>
           </Menu.List>
         </Menu.Popover>
@@ -44,9 +45,9 @@ export const WithCustomAlignment: Story = {
           <Menu.Popover yOffset={10}>
             <Menu.List>
               <Menu.Group label="Group Title">
-                <Menu.Item onClick={console.log}>Menu Item</Menu.Item>
-                <Menu.Item href="/#">Menu Item as anchor</Menu.Item>
-                <Menu.Item closeMenu={false}>Menu Item (keep open)</Menu.Item>
+                <Menu.Item label="Menu Item" onClick={console.log} />
+                <Menu.Item label="Menu Item as anchor" href="/#" />
+                <Menu.Item label="Menu Item (keep open)" closeMenu={false} />
               </Menu.Group>
             </Menu.List>
           </Menu.Popover>
@@ -75,9 +76,9 @@ export const MoreComplexUsageExample: Story = {
           <Menu.Popover yOffset={yOffset}>
             <Menu.List>
               <Menu.Group label={title ?? 'Group Title'}>
-                <Menu.Item onClick={console.log}>Menu Item</Menu.Item>
-                <Menu.Item href="/#">Menu Item as anchor</Menu.Item>
-                <Menu.Item closeMenu={false}>Menu Item (keep open)</Menu.Item>
+                <Menu.Item label="Menu Item" onClick={console.log} />
+                <Menu.Item label="Menu Item as anchor" href="/#" />
+                <Menu.Item label="Menu Item (keep open)" closeMenu={false} />
               </Menu.Group>
             </Menu.List>
           </Menu.Popover>

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -1,8 +1,9 @@
 import React, { type HTMLAttributes } from 'react'
 import { MenuProvider } from './menu-context'
 import { MenuPopover, MenuTrigger } from './menu-popover'
-import { MenuItem, MenuItemGroup, MenuList } from './menu.atoms'
+import { MenuItemGroup, MenuList } from './menu.atoms'
 import { ElMenu } from './styles'
+import { MenuItem } from './menu.molecules'
 
 type MenuFC = React.FC<HTMLAttributes<HTMLDivElement> & { 'data-alignment'?: 'left' | 'right' }> & {
   Item: typeof MenuItem

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -32,8 +32,8 @@ export const ElMenuList = styled.div`
 
 export const ElMenuItemContent = styled.div`
   display: flex;
+  align-items: flex-start;
   flex-direction: column;
-  justify-content: center;
   gap: var(--spacing-1);
   flex: 1 0 0;
 `
@@ -44,10 +44,10 @@ export const ElMenuItemLabel = styled.span`
   font-weight: var(--font-sm-regular-weight);
   line-height: var(--font-sm-regular-line_height);
   letter-spacing: var(--font-sm-regular-letter_spacing);
-  text-align: left;
 `
 
 const baseMenuItemStyles = `
+  width: 100%;
   cursor: pointer;
   display: flex;
   align-items: flex-start;
@@ -55,7 +55,6 @@ const baseMenuItemStyles = `
   gap: var(--spacing-3);
   border-radius: var(--comp-menu-border-radius);
   background: var(--comp-menu-colour-fill-default);
-  width: 100%;
   color: var(--comp-menu-colour-text-default-primary);
 
   &:hover {
@@ -90,6 +89,12 @@ export const ElMenuItemButton = styled.button`
   &[aria-current="true"], &[aria-current="page"] {
     ${ElMenuItemLabel} {
       color: var(--comp-menu-colour-text-default-action) !important;
+    }
+  }
+
+  &[aria-disabled='true'] {
+    ${ElMenuItemLabel} {
+      color: var(--comp-menu-colour-text-disabled-primary);
     }
   }
 

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -110,11 +110,6 @@ export const ElMenuItemAnchor = styled.a`
       color: var(--comp-menu-colour-text-default-action) !important;
     }
   }
-  &[aria-disabled='true'] {
-    ${ElMenuItemLabel} {
-      color: var(--comp-menu-colour-text-disabled-primary);
-    }
-  }
 `
 
 export const ElMenuItemGroupTitle = styled.div`

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -24,48 +24,92 @@ export const ElMenu = styled.div`
 export const ElMenuList = styled.div`
   min-width: 200px;
   width: fit-content;
-  padding: var(--spacing-2) var(--spacing-none);
+  padding: var(--spacing-2) var(--spacing-2);
   border-radius: var(--corner-default);
   background-color: var(--fill-white);
   box-shadow: 0px 4px 16px 0px #222b3329;
 `
 
+export const ElMenuItemContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--spacing-1);
+  flex: 1 0 0;
+`
+
+export const ElMenuItemLabel = styled.span`
+  font-family: var(--font-sm-regular-family);
+  font-size: var(--font-sm-regular-size);
+  font-weight: var(--font-sm-regular-weight);
+  line-height: var(--font-sm-regular-line_height);
+  letter-spacing: var(--font-sm-regular-letter_spacing);
+  text-align: left;
+`
+
 const baseMenuItemStyles = `
   cursor: pointer;
   display: flex;
-  align-items: center;
-  justify-content: start;
-  height: var(--size-7);
-  padding: var(--spacing-none) var(--spacing-4);
-  gap: var(--spacing-4);
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-sm);
-  letter-spacing: var(--letter-spacing-sm);
-  color: var(--text-primary);
-  &:hover,
-  &:focus {
-    color: var(--text-white);
-    background: var(--fill-action-dark);
+  align-items: flex-start;
+  padding: var(--spacing-3);
+  gap: var(--spacing-3);
+  border-radius: var(--comp-menu-border-radius);
+  background: var(--comp-menu-colour-fill-default);
+  width: 100%;
+  color: var(--comp-menu-colour-text-default-primary);
+
+  &:hover {
+    background: var(--comp-menu-colour-fill-hover);
   }
+
   &:focus-visible {
     outline: none;
+  }
+
+  &:focus {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+
+    /* prevent the outline to be hidden behind next item */
+    position: relative;
+    z-index: 1;
+  }
+
+  &[aria-current="true"], &[aria-current="page"] {
+    background: var(--comp-menu-colour-fill-highlighted);
+  }
+
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+    background: var(--comp-menu-colour-fill-default);
+    color: var(--comp-menu-colour-text-disabled);
   }
 `
 
 export const ElMenuItemButton = styled.button`
   ${baseMenuItemStyles}
+  &[aria-current="true"], &[aria-current="page"] {
+    ${ElMenuItemLabel} {
+      color: var(--comp-menu-colour-text-default-action) !important;
+    }
+  }
 
   /* customize html button */
-  width: 100%;
   background-color: transparent;
   border: none;
-  border-radius: 0;
 `
 
 export const ElMenuItemAnchor = styled.a`
   ${baseMenuItemStyles}
+  &[aria-current="true"], &[aria-current="page"] {
+    ${ElMenuItemLabel} {
+      color: var(--comp-menu-colour-text-default-action) !important;
+    }
+  }
+  &[aria-disabled='true'] {
+    ${ElMenuItemLabel} {
+      color: var(--comp-menu-colour-text-disabled-primary);
+    }
+  }
 `
 
 export const ElMenuItemGroupTitle = styled.div`
@@ -83,4 +127,8 @@ export const ElMenuItemGroupTitle = styled.div`
   align-items: center;
   align-self: stretch;
 `
-export const ElMenuItemGroup = styled.div``
+export const ElMenuItemGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`

--- a/src/components/nav-dropdown-button/nav-dropdown-button.stories.tsx
+++ b/src/components/nav-dropdown-button/nav-dropdown-button.stories.tsx
@@ -6,8 +6,10 @@ import {
   ElMenu,
   ElMenuItemAnchor,
   ElMenuItemButton,
+  ElMenuItemContent,
   ElMenuItemGroup,
   ElMenuItemGroupTitle,
+  ElMenuItemLabel,
   ElMenuList,
   ElMenuPopover,
   Menu,
@@ -33,10 +35,20 @@ export const StylesOnlyUsage: Story = {
           <ElMenuList>
             <ElMenuItemGroup role="group">
               <ElMenuItemGroupTitle>Group Title</ElMenuItemGroupTitle>
-              <ElMenuItemButton role="menuitem">Menu Item</ElMenuItemButton>
-              <ElMenuItemButton role="menuitem">Menu Item</ElMenuItemButton>
+              <ElMenuItemButton role="menuitem">
+                <ElMenuItemContent>
+                  <ElMenuItemLabel>Menu Item</ElMenuItemLabel>
+                </ElMenuItemContent>
+              </ElMenuItemButton>
+              <ElMenuItemButton role="menuitem">
+                <ElMenuItemContent>
+                  <ElMenuItemLabel>Menu Item</ElMenuItemLabel>
+                </ElMenuItemContent>
+              </ElMenuItemButton>
               <ElMenuItemAnchor href="/#" role="menuitem">
-                Menu Item as anchor
+                <ElMenuItemContent>
+                  <ElMenuItemLabel>Menu Item as anchor</ElMenuItemLabel>
+                </ElMenuItemContent>
               </ElMenuItemAnchor>
             </ElMenuItemGroup>
           </ElMenuList>
@@ -66,9 +78,9 @@ export const ReactUsage: Story = {
           <Menu.Popover>
             <Menu.List>
               <Menu.Group label="Group Title">
-                <Menu.Item onClick={console.log}>Menu Item</Menu.Item>
-                <Menu.Item href="/#">Menu Item as anchor</Menu.Item>
-                <Menu.Item closeMenu={false}>Menu Item (keep open)</Menu.Item>
+                <Menu.Item label="Menu Item" onClick={console.log} />
+                <Menu.Item label="Menu Item as anchor" href="/#" />
+                <Menu.Item label="Menu Item (keep open)" closeMenu={false} />
               </Menu.Group>
             </Menu.List>
           </Menu.Popover>

--- a/src/components/split-button/split-button.stories.tsx
+++ b/src/components/split-button/split-button.stories.tsx
@@ -47,8 +47,8 @@ export const SplitButtonWithMenu = {
         <Menu.Trigger>{({ getTriggerProps }) => <SplitButton.Menu {...getTriggerProps()} />}</Menu.Trigger>
         <Menu.Popover>
           <Menu.List>
-            <Menu.Item onClick={console.log}>Save & Download</Menu.Item>
-            <Menu.Item disabled>Save & Send</Menu.Item>
+            <Menu.Item onClick={console.log} label="Save & Download" />
+            <Menu.Item disabled label="Save & Send" />
           </Menu.List>
         </Menu.Popover>
       </Menu>
@@ -120,10 +120,8 @@ export const SplitButtonDisabledWithMenu = {
         <Menu.Trigger>{({ getTriggerProps }) => <SplitButton.Menu {...getTriggerProps()} />}</Menu.Trigger>
         <Menu.Popover>
           <Menu.List>
-            <Menu.Item disabled onClick={console.log}>
-              Save & Download
-            </Menu.Item>
-            <Menu.Item disabled>Save & Send</Menu.Item>
+            <Menu.Item disabled onClick={console.log} label="Save & Download" />
+            <Menu.Item disabled label="Save & Send" />
           </Menu.List>
         </Menu.Popover>
       </Menu>

--- a/src/components/table/table-container/table-container.stories.tsx
+++ b/src/components/table/table-container/table-container.stories.tsx
@@ -37,9 +37,9 @@ export const BasicUsage = {
             <MenuPopover>
               <MenuList>
                 <MenuItemGroup>
-                  <MenuItem>25</MenuItem>
-                  <MenuItem>50</MenuItem>
-                  <MenuItem>100</MenuItem>
+                  <MenuItem label="25" />
+                  <MenuItem label="50" />
+                  <MenuItem label="100" />
                 </MenuItemGroup>
               </MenuList>
             </MenuPopover>

--- a/src/components/table/table-toolbar/table-toolbar.stories.tsx
+++ b/src/components/table/table-toolbar/table-toolbar.stories.tsx
@@ -5,9 +5,10 @@ import { Button } from '#src/components/button/button'
 import { Icon } from '#src/components/icon/icon-component'
 import { Menu } from '#src/components/menu/menu'
 import { MenuPopover, MenuTrigger } from '#src/components/menu/menu-popover'
-import { MenuItem, MenuItemGroup, MenuList } from '#src/components/menu/menu.atoms'
+import { MenuItemGroup, MenuList } from '#src/components/menu/menu.atoms'
 import { ButtonGroup } from '#src/components/button-group/button-group'
 import { Skeleton } from '#src/components/skeleton/skeleton'
+import { MenuItem } from '../../menu/menu.molecules.js'
 
 const meta: Meta<typeof TableToolbar> = {
   title: 'Components/TableToolbar',
@@ -42,9 +43,9 @@ export const BasicUsage = {
           <MenuPopover>
             <MenuList>
               <MenuItemGroup>
-                <MenuItem>25</MenuItem>
-                <MenuItem>50</MenuItem>
-                <MenuItem>100</MenuItem>
+                <MenuItem label="25" />
+                <MenuItem label="50" />
+                <MenuItem label="100" />
               </MenuItemGroup>
             </MenuList>
           </MenuPopover>
@@ -76,9 +77,9 @@ export const WithBulkActions = {
             <MenuPopover>
               <MenuList>
                 <MenuItemGroup>
-                  <MenuItem>25</MenuItem>
-                  <MenuItem>50</MenuItem>
-                  <MenuItem>100</MenuItem>
+                  <MenuItem label="25" />
+                  <MenuItem label="50" />
+                  <MenuItem label="100" />
                 </MenuItemGroup>
               </MenuList>
             </MenuPopover>
@@ -115,9 +116,9 @@ export const ToolbarSkeleton = {
           <MenuPopover>
             <MenuList>
               <MenuItemGroup>
-                <MenuItem>25</MenuItem>
-                <MenuItem>50</MenuItem>
-                <MenuItem>100</MenuItem>
+                <MenuItem label="25" />
+                <MenuItem label="50" />
+                <MenuItem label="100" />
               </MenuItemGroup>
             </MenuList>
           </MenuPopover>

--- a/src/components/top-bar/top-bar.stories.tsx
+++ b/src/components/top-bar/top-bar.stories.tsx
@@ -91,9 +91,12 @@ export const Default: Story = {
             </Menu.Trigger>
             <Menu.Popover className={elTopBarMenuPopover}>
               <Menu.List>
-                <Menu.Item href="/">Button 3</Menu.Item>
-                <Menu.Item href="/">Button 4</Menu.Item>
-                <Menu.Item href="/">Button 5</Menu.Item>
+                <Menu.Item label="Button 3" href="/" />
+                <Menu.Item label="Button 4" href="/" />
+                <Menu.Item label="Button 5" href="/" />
+                <Menu.Item label="Menu Item" onClick={console.log} />
+                <Menu.Item label="Menu Item as anchor" href="/#" />
+                <Menu.Item label="Menu Item (keep open)" closeMenu={false} isActive />
               </Menu.List>
             </Menu.Popover>
           </Menu>
@@ -118,9 +121,9 @@ export const Default: Story = {
             </Menu.Trigger>
             <Menu.Popover className={elTopBarMenuPopover}>
               <Menu.List>
-                <Menu.Item href="/">User menu 1</Menu.Item>
-                <Menu.Item href="/">User menu 2</Menu.Item>
-                <Menu.Item href="/">User menu 3</Menu.Item>
+                <Menu.Item label="User menu 1" href="/" />
+                <Menu.Item label="User menu 2" href="/" />
+                <Menu.Item label="User menu 3" href="/" />
               </Menu.List>
             </Menu.Popover>
           </Menu>
@@ -178,9 +181,12 @@ export const ResponsiveMainNav: Story = {
               </Menu.Trigger>
               <Menu.Popover className={elTopBarMenuPopover}>
                 <Menu.List>
-                  <Menu.Item href="/">Button 3</Menu.Item>
-                  <Menu.Item href="/">Button 4</Menu.Item>
-                  <Menu.Item href="/">Button 5</Menu.Item>
+                  <Menu.Item label="Button 3" href="/" />
+                  <Menu.Item label="Button 4" href="/" />
+                  <Menu.Item label="Button 5" href="/" />
+                  <Menu.Item label="Menu Item" onClick={console.log} />
+                  <Menu.Item label="Menu Item as anchor" href="/#" />
+                  <Menu.Item label="Menu Item (keep open)" closeMenu={false} isActive />
                 </Menu.List>
               </Menu.Popover>
             </Menu>
@@ -206,9 +212,9 @@ export const ResponsiveMainNav: Story = {
             </Menu.Trigger>
             <Menu.Popover className={elTopBarMenuPopover}>
               <Menu.List>
-                <Menu.Item href="/">User menu 1</Menu.Item>
-                <Menu.Item href="/">User menu 2</Menu.Item>
-                <Menu.Item href="/">User menu 3</Menu.Item>
+                <Menu.Item label="User menu 1" href="/" />
+                <Menu.Item label="User menu 2" href="/" />
+                <Menu.Item label="User menu 3" href="/" />
               </Menu.List>
             </Menu.Popover>
           </Menu>


### PR DESCRIPTION
## Context

As there is redesign in new v5 Menu #316 . this pr is to refactor existing meu based on a POC that has been discussed [here](https://github.com/reapit/elements/issues/316#issuecomment-2853782912)

note: I've noticed the new behavour regarding the menu group title, I'll address this in a separate PR.

# Pull request checklist
- [x] Refactor Menu component
- [x] Update Menu consumer
 
**Detail as per issue below (required):**

![new menu 1](https://github.com/user-attachments/assets/9800a89a-3d72-41b6-9c1c-97db64fb5f27)
