### PR TITLE
chore: #432 Bump up beta version to 5.0.0-beta.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reapit/elements",
-  "version": "5.0.0-beta.27",
+  "version": "5.0.0-beta.28",
   "description": "A collection of React components and utilities for building apps for Reapit Marketplace",
   "homepage": "https://github.com/reapit/elements#readme",
   "bugs": {

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,6 +16,9 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
+### **5.0.0-beta.28 - **/**/25**
+- TBC
+
 ### **5.0.0-beta.27 - 16/05/25**
 - Support added for Payprop theme
 - Minor bug fixes and css token variable updates


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**

fixes: #432 

- Bumpup `main` branch to new version 5.0.0-beta.28 for whenever we are ready for the next release.
- Added changelog section for new releases, devs to update this with all ongoing ticket that gets merged back to `main`

**Note:** I am adding all developers here so that you stay aware of the updated change log for every change you make.


