### PR TITLE
feat: #316 new Menu - support leftIcon and rightIcon

### DIFF
--- a/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Menu Popover component > should render and close Popover based on any e
         role="menu"
       >
         <button
-          class="mocked-styled-5 el-menu-item-button"
+          class="mocked-styled-6 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
           tabindex="0"
@@ -38,7 +38,7 @@ exports[`Menu Popover component > should render and close Popover based on any e
           </div>
         </button>
         <button
-          class="mocked-styled-5 el-menu-item-button"
+          class="mocked-styled-6 el-menu-item-button"
           data-close-menu="false"
           role="menuitem"
           tabindex="0"

--- a/src/components/menu/__tests__/__snapshots__/menu.molecules.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.molecules.test.tsx.snap
@@ -1,9 +1,44 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`MenuItem component > should render with complete features enabled and match snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="mocked-styled-6 el-menu-item-button"
+    data-close-menu="false"
+    role="menuitem"
+    tabindex="0"
+  >
+    <div
+      class="el-menu-item-left-icon el-menu-item-icon"
+    >
+      <span>
+        Left Icon
+      </span>
+    </div>
+    <div
+      class="mocked-styled-3 el-menu-item-content"
+    >
+      <span
+        class="mocked-styled-4 el-menu-item-label"
+      >
+        Test Menu Item
+      </span>
+    </div>
+    <div
+      class="mocked-styled-5 el-menu-item-icon"
+    >
+      <span>
+        Right Icon
+      </span>
+    </div>
+  </button>
+</DocumentFragment>
+`;
+
 exports[`MenuItem component > should render with required props and match snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="mocked-styled-5 el-menu-item-button"
+    class="mocked-styled-6 el-menu-item-button"
     data-close-menu="true"
     role="menuitem"
     tabindex="0"

--- a/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
@@ -10,16 +10,16 @@ exports[`Menu list component > should render menu with list components and match
       role="menu"
     >
       <div
-        class="mocked-styled-8 el-menu-item-group"
+        class="mocked-styled-9 el-menu-item-group"
         role="group"
       >
         <div
-          class="mocked-styled-7 el-menu-item-group-title"
+          class="mocked-styled-8 el-menu-item-group-title"
         >
           Group Title
         </div>
         <a
-          class="mocked-styled-6 el-menu-item-anchor"
+          class="mocked-styled-7 el-menu-item-anchor"
           data-close-menu="true"
           href="/#"
           role="menuitem"
@@ -35,7 +35,7 @@ exports[`Menu list component > should render menu with list components and match
           </div>
         </a>
         <button
-          class="mocked-styled-5 el-menu-item-button"
+          class="mocked-styled-6 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
           tabindex="0"

--- a/src/components/menu/__tests__/menu.molecules.test.tsx
+++ b/src/components/menu/__tests__/menu.molecules.test.tsx
@@ -6,4 +6,16 @@ describe('MenuItem component', () => {
     const { asFragment } = render(<MenuItem label="Test Menu Item" />)
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('should render with complete features enabled and match snapshot', () => {
+    const { asFragment } = render(
+      <MenuItem
+        label="Test Menu Item"
+        leftIcon={<span>Left Icon</span>}
+        rightIcon={<span>Right Icon</span>}
+        closeMenu={false}
+      />,
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 })

--- a/src/components/menu/menu.molecules.tsx
+++ b/src/components/menu/menu.molecules.tsx
@@ -1,17 +1,21 @@
-import type { FC } from 'react'
+import type { FC, ReactNode } from 'react'
 import { MenuItemContainer, type MenuItemContainerProps } from './menu.atoms'
-import { ElMenuItemContent, ElMenuItemLabel } from './styles'
+import { ElMenuItemContent, ElMenuItemIcon, ElMenuItemLabel, elMenuItemLeftIcon } from './styles'
 
 export interface MenuItemProps extends Omit<MenuItemContainerProps, 'children'> {
   label: string
+  leftIcon?: ReactNode
+  rightIcon?: ReactNode
 }
 
-export const MenuItem: FC<MenuItemProps> = ({ label, ...props }) => {
+export const MenuItem: FC<MenuItemProps> = ({ label, leftIcon, rightIcon, ...props }) => {
   return (
     <MenuItemContainer {...(props as MenuItemContainerProps)}>
+      {leftIcon && <ElMenuItemIcon className={elMenuItemLeftIcon}>{leftIcon}</ElMenuItemIcon>}
       <ElMenuItemContent>
         <ElMenuItemLabel>{label}</ElMenuItemLabel>
       </ElMenuItemContent>
+      {rightIcon && <ElMenuItemIcon>{rightIcon}</ElMenuItemIcon>}
     </MenuItemContainer>
   )
 }

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -34,6 +34,50 @@ export const Default: StoryObj = {
   },
 }
 
+export const WithCompleteFeatures: StoryObj = {
+  render: () => {
+    return (
+      <Menu>
+        <Menu.Trigger>
+          {({ getTriggerProps }) => <Button {...getTriggerProps()} iconLeft={<Icon icon="more" fontSize="1rem" />} />}
+        </Menu.Trigger>
+        <Menu.Popover>
+          <Menu.List>
+            <Menu.Group label="Group Title">
+              <Menu.Item
+                label="Menu Item"
+                onClick={console.log}
+                leftIcon={<Icon icon="property" />}
+                rightIcon={<Icon icon="exportIcon" />}
+              />
+              <Menu.Item
+                label="Menu Item anchor"
+                href="/#"
+                leftIcon={<Icon icon="property" />}
+                rightIcon={<Icon icon="exportIcon" />}
+              />
+              <Menu.Item
+                label="Menu Item active"
+                isActive
+                onClick={console.log}
+                leftIcon={<Icon icon="property" />}
+                rightIcon={<Icon icon="exportIcon" />}
+              />
+              <Menu.Item
+                label="Menu Item (disabled)"
+                onClick={console.log}
+                disabled
+                leftIcon={<Icon icon="property" />}
+                rightIcon={<Icon icon="exportIcon" />}
+              />
+            </Menu.Group>
+          </Menu.List>
+        </Menu.Popover>
+      </Menu>
+    )
+  },
+}
+
 export const WithCustomAlignment: Story = {
   render: () => {
     return (

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -1,3 +1,4 @@
+import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
 export const ElMenuPopover = styled.div`
@@ -7,7 +8,6 @@ export const ElMenuPopover = styled.div`
 
 export const ElMenu = styled.div`
   position: relative;
-  width: fit-content;
 
   &[data-alignment='left'] {
     > ${ElMenuPopover} {
@@ -22,7 +22,10 @@ export const ElMenu = styled.div`
 `
 
 export const ElMenuList = styled.div`
+  /* TODO: use token variable when available */
   min-width: 200px;
+  max-width: 301px;
+
   width: fit-content;
   padding: var(--spacing-2) var(--spacing-2);
   border-radius: var(--corner-default);
@@ -44,6 +47,23 @@ export const ElMenuItemLabel = styled.span`
   font-weight: var(--font-sm-regular-weight);
   line-height: var(--font-sm-regular-line_height);
   letter-spacing: var(--font-sm-regular-letter_spacing);
+  text-align: left;
+`
+
+export const ElMenuItemIcon = styled.div`
+  &,
+  svg {
+    width: var(--icon_size-m);
+    height: var(--icon_size-m);
+    color: var(--comp-menu-colour-icon-default-right);
+  }
+`
+
+export const elMenuItemLeftIcon = css`
+  &,
+  svg {
+    color: var(--comp-menu-colour-icon-default-left);
+  }
 `
 
 const baseMenuItemStyles = `
@@ -88,7 +108,14 @@ export const ElMenuItemButton = styled.button`
   ${baseMenuItemStyles}
   &[aria-current="true"], &[aria-current="page"] {
     ${ElMenuItemLabel} {
-      color: var(--comp-menu-colour-text-default-action) !important;
+      color: var(--comp-menu-colour-text-default-action);
+    }
+
+    .${elMenuItemLeftIcon} {
+      &,
+      svg {
+        color: var(--comp-menu-colour-icon-default-action);
+      }
     }
   }
 


### PR DESCRIPTION
## Context

As there is redesign in new v5 Menu #316 . this pr is to refactor existing meu based on a POC that has been discussed [here](https://github.com/reapit/elements/issues/316#issuecomment-2853782912) which focusing on adding support for `leftIcon` and `rightIcon`

# Pull request checklist
- [x] add leftIcon and rightIcon support
- [x] add storybook example
 
**Detail as per issue below (required):**

![image](https://github.com/user-attachments/assets/db7b46d7-66be-438f-9e5f-b6589fba38f3)
