### PR TITLE
chore: #443 refactor sidebar components and update styles (part 2)

### DIFF
--- a/src/components/side-bar/__story__/use-side-bar-context-decorator.tsx
+++ b/src/components/side-bar/__story__/use-side-bar-context-decorator.tsx
@@ -1,0 +1,16 @@
+import type { Decorator } from '@storybook/react'
+import { useSideBar } from '../use-side-bar'
+import { useId } from 'react'
+import { SideBarContextPublisher } from '../side-bar-context'
+
+export const useSideBarContextDecorator: Decorator = (Story, context) => {
+  const id = useId()
+  const { initialState, state } = context.parameters.sideBar ?? { initialState: 'expanded' }
+  const sideBar = useSideBar(initialState)
+
+  return (
+    <SideBarContextPublisher {...sideBar} id={id} state={state ?? sideBar.state}>
+      <Story />
+    </SideBarContextPublisher>
+  )
+}

--- a/src/components/side-bar/__story__/use-side-bar-width-decorator.tsx
+++ b/src/components/side-bar/__story__/use-side-bar-width-decorator.tsx
@@ -1,0 +1,30 @@
+import type { Decorator } from '@storybook/react'
+import { useSideBarContext } from '../side-bar-context'
+
+export const useSideBarWidthDecorator: Decorator = (Story, context) => {
+  // The `useSideBarContextDecorator` will internally track collapsed <--> expanded state changes for the fake
+  // side bar, but it also allows stories to specify a pinnded state for the side bar that should be used for
+  // that story regardless of what interaction or state changes would otherwise occur.
+  //
+  // - `useSideBarContext` gives us the current state of the side bar.
+  // - `context.parameters.sideBar.state` gives us the fixed state of the side bar, if any.
+  // - `context.parameters.sideBar.width` gives us the custom width of the side bar, if any.
+  const { id, state: currentState } = useSideBarContext()
+  const { state: fixedState, width } = context.parameters.sideBar ?? {}
+
+  return (
+    <div
+      id={id}
+      style={{
+        containerType: 'inline-size',
+        // If the side bar is fixed to its collapsed state or there is a specific width specified, we show a border
+        border: fixedState === 'collapsed' || width ? '1px solid #FA00FF' : '1px solid transparent',
+        boxSizing: 'content-box',
+        // If the side bar is currently collapsed
+        width: currentState === 'collapsed' || fixedState === 'collapsed' ? '40px' : width,
+      }}
+    >
+      <Story />
+    </div>
+  )
+}

--- a/src/components/side-bar/side-bar-context.tsx
+++ b/src/components/side-bar/side-bar-context.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useMemo } from 'react'
+import type { UseSideBarResult } from './use-side-bar'
+
+interface SideBarContextValue extends UseSideBarResult {
+  id: string
+}
+
+export const SideBarContext = createContext<SideBarContextValue | undefined>(undefined)
+
+interface SideBarContextPublisherProps extends SideBarContextValue {
+  children: React.ReactNode
+}
+
+export function SideBarContextPublisher(props: SideBarContextPublisherProps) {
+  const contextValue = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we need to drop `children` */
+    const { children: _children, ...contextValue } = props
+    return contextValue
+  }, [props])
+
+  return <SideBarContext.Provider value={contextValue}>{props.children}</SideBarContext.Provider>
+}
+
+export function useSideBarContext(): SideBarContextValue {
+  const context = useContext(SideBarContext)
+  if (!context) {
+    throw new Error('useSideBarContext must be used within a SideBarContext.Provider')
+  }
+  return context
+}

--- a/src/components/side-bar/submenu-item/__test__/submenu-item.test.tsx
+++ b/src/components/side-bar/submenu-item/__test__/submenu-item.test.tsx
@@ -1,0 +1,28 @@
+import { composeStories } from '@storybook/react'
+import { elSideBarSubmenuItem } from '../styles'
+import { render, screen } from '@testing-library/react'
+import * as stories from '../submenu-item.stories'
+
+const SubmenuItemStories = composeStories(stories)
+
+test('renders an <a> element', () => {
+  render(<SubmenuItemStories.Example>Test item</SubmenuItemStories.Example>)
+  expect(screen.getByRole('link', { name: 'Test item' })).toBeVisible()
+})
+
+test(`combines the .${elSideBarSubmenuItem} and consumer-supplied classes correctly`, () => {
+  render(<SubmenuItemStories.Example className="my-custom-class" />)
+  // NOTE: We don't use the `toHaveClass` matcher here because it does not enforce the order of classes, which we are
+  // specifically interested in here.
+  expect(screen.getByRole('link')).toHaveAttribute('class', `${elSideBarSubmenuItem} my-custom-class`)
+})
+
+test('has `aria-current="false"` attribute present when `isActive={false}`', () => {
+  render(<SubmenuItemStories.Example>Test item</SubmenuItemStories.Example>)
+  expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'false')
+})
+
+test('has `aria-current="page"` attribute present when `isActive={true}`', () => {
+  render(<SubmenuItemStories.Selected>Test item</SubmenuItemStories.Selected>)
+  expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'page')
+})

--- a/src/components/side-bar/submenu-item/index.ts
+++ b/src/components/side-bar/submenu-item/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './submenu-item'

--- a/src/components/side-bar/submenu-item/styles.ts
+++ b/src/components/side-bar/submenu-item/styles.ts
@@ -1,0 +1,51 @@
+import { css } from '@linaria/core'
+import { styled } from '@linaria/react'
+
+export const ElSideBarSubmenuItemLabel = styled.span`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  /* text-sm/Regular */
+  font-family: var(--font-sm-regular-family);
+  font-size: var(--font-sm-regular-size);
+  font-style: normal;
+  font-weight: var(--font-sm-regular-weight);
+  line-height: var(--font-sm-regular-line_height);
+  letter-spacing: var(--font-sm-regular-letter_spacing);
+
+  color: var(--comp-navigation-colour-text-sidebar-default);
+  [aria-current='page'] > & {
+    color: var(--comp-navigation-colour-text-sidebar-select);
+    font-weight: var(--font-weight-medium);
+  }
+`
+
+export const elSideBarSubmenuItem = css`
+  display: flex;
+  align-items: center;
+  text-align: start;
+  width: 100%;
+
+  padding: var(--spacing-none) var(--spacing-3) var(--spacing-none) 44px;
+
+  /* NOTE: If the container width is 40px or less, the side bar must be collapsed,
+   * so we want to reduce our inline start padding to ensure we aren't overflowing
+   * the container. */
+  @container (width <= 40px) {
+    padding-inline-start: 28px; /* 40px - var(--spacing-3) */
+  }
+
+  border-radius: var(--comp-navigation-border-radius-none);
+  height: var(--size-8);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--comp-navigation-colour-fill-sidebar-hover);
+  }
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+`

--- a/src/components/side-bar/submenu-item/submenu-item.stories.tsx
+++ b/src/components/side-bar/submenu-item/submenu-item.stories.tsx
@@ -1,0 +1,73 @@
+import { SideBarSubmenuItem } from './submenu-item'
+import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
+import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/SideBar/SubmenuItem',
+  component: SideBarSubmenuItem,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+  },
+  decorators: [useSideBarContextDecorator],
+} satisfies Meta<typeof SideBarSubmenuItem>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    isActive: false,
+    children: 'Submenu Item',
+    href: globalThis.top?.location.href!,
+  },
+}
+
+/**
+ * When the item represents the current page, `isActive` should be supplied to communicate to visual and accessible
+ * users that the item is currently "selected". For accessible users, this internally facilitated via
+ * `aria-current="page"` on the underlying `<a>` element. The visual styling of the item is also applied based on
+ * this ARIA attribute, so CSS-only consumers just need to ensure they provide `aria-current="page"` to their anchor
+ * when appropriate.
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    isActive: true,
+  },
+}
+
+/**
+ * When there is not enough space to display the full label, it will be truncated with an ellipsis. That said,
+ * author's should typically ensure submenu item labels are short enough to fit within the available space in
+ * the `SideBar`. Importantly, when the `SideBar` is collapsed, the submenu item's label will be available in
+ * the accessibility tree despite not being fully visible.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    sideBar: { width: '100px' },
+  },
+}
+
+/**
+ * When the `SideBar` is collapsed, the submenu item's label will be completely hidden. However, submenu's should not
+ * generally be visible at all when the `SideBar` is collapsed because their parent menu group should be closed. Again
+ * though, while the label is not visible, it is still available in the accessibility tree.
+ */
+export const Collapsed: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    sideBar: { state: 'collapsed' },
+  },
+}

--- a/src/components/side-bar/submenu-item/submenu-item.stories.tsx
+++ b/src/components/side-bar/submenu-item/submenu-item.stories.tsx
@@ -29,7 +29,7 @@ export const Example: Story = {
 
 /**
  * When the item represents the current page, `isActive` should be supplied to communicate to visual and accessible
- * users that the item is currently "selected". For accessible users, this internally facilitated via
+ * users that the item is currently "selected". For accessible users, this is internally facilitated via
  * `aria-current="page"` on the underlying `<a>` element. The visual styling of the item is also applied based on
  * this ARIA attribute, so CSS-only consumers just need to ensure they provide `aria-current="page"` to their anchor
  * when appropriate.

--- a/src/components/side-bar/submenu-item/submenu-item.tsx
+++ b/src/components/side-bar/submenu-item/submenu-item.tsx
@@ -29,18 +29,18 @@ interface SideBarSubmenuItemProps extends Omit<AnchorHTMLAttributes<HTMLAnchorEl
  * you would do:
  *
  * ```
- * function MySideBarSubmenuItem({ to, ...props}) {
+ * function MySideBarSubmenuItem({ to, ...rest}) {
  *   const href = useHref(to)
  *   const isActive = useMatch(to)
  *   return (
- *     <SideBarSubmenu.Item {...props} href={href} isActive={isActive} />
+ *     <SideBarSubmenu.Item {...rest} href={href} isActive={isActive} />
  *   )
  * }
  * ```
  */
-export function SideBarSubmenuItem({ children, className, isActive, ...props }: SideBarSubmenuItemProps) {
+export function SideBarSubmenuItem({ children, className, isActive, ...rest }: SideBarSubmenuItemProps) {
   return (
-    <a {...props} aria-current={isActive ? 'page' : false} className={cx(elSideBarSubmenuItem, className)}>
+    <a {...rest} aria-current={isActive ? 'page' : false} className={cx(elSideBarSubmenuItem, className)}>
       <ElSideBarSubmenuItemLabel>{children}</ElSideBarSubmenuItemLabel>
     </a>
   )

--- a/src/components/side-bar/submenu-item/submenu-item.tsx
+++ b/src/components/side-bar/submenu-item/submenu-item.tsx
@@ -1,0 +1,47 @@
+import { elSideBarSubmenuItem, ElSideBarSubmenuItemLabel } from './styles'
+import { cx } from '@linaria/core'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+
+interface SideBarSubmenuItemProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-current'> {
+  /**
+   * The label of the menu item.
+   */
+  children: ReactNode
+  /**
+   * The URL to navigate to when this item is activated.
+   */
+  href: string
+  /**
+   * When the item represents the current page, `isActive` should be supplied to communicate to visual and accessible
+   * users that the item is currently "selected".
+   */
+  isActive?: boolean
+}
+
+/**
+ * A simple menu item for use in submenus within a `SideBar`. Is always an anchor element because side bar navigation
+ * items should always navigate users to another page in the product.
+ *
+ * **Important:** ⚠️ This component should rarely be used directly. Instead, use `SideBar.SubmenuItem` as it wraps the
+ * anchor element in a list item (`<li>`) to ensure good semantics and accessibility when used with `SideBar.Submenu`.
+ *
+ * To integrate this component with React Router, simply wrap `SideBar.SubmenuItem`. For example, with React Router 6,
+ * you would do:
+ *
+ * ```
+ * function MySideBarSubmenuItem({ to, ...props}) {
+ *   const href = useHref(to)
+ *   const isActive = useMatch(to)
+ *   return (
+ *     <SideBarSubmenu.Item {...props} href={href} isActive={isActive} />
+ *   )
+ * }
+ * ```
+ */
+export function SideBarSubmenuItem({ children, className, isActive, ...props }: SideBarSubmenuItemProps) {
+  return (
+    <a {...props} aria-current={isActive ? 'page' : false} className={cx(elSideBarSubmenuItem, className)}>
+      <ElSideBarSubmenuItemLabel>{children}</ElSideBarSubmenuItemLabel>
+    </a>
+  )
+}

--- a/src/components/side-bar/submenu/__test__/submenu-list-item.test.tsx
+++ b/src/components/side-bar/submenu/__test__/submenu-list-item.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { SideBarSubmenuListItem } from '../submenu-list-item'
+
+test('renders a link as child of a list item', () => {
+  render(<SideBarSubmenuListItem href="/">Item</SideBarSubmenuListItem>)
+  const listItem = screen.getByRole('listitem')
+  const anchor = screen.getByRole('link', { name: 'Item' })
+
+  expect(listItem).toBeVisible()
+  expect(anchor).toBeVisible()
+  expect(listItem.firstChild).toBe(anchor)
+})
+
+test('link `aria-current="page"` attribute present when `isActive`', () => {
+  render(
+    <SideBarSubmenuListItem href="/" isActive>
+      Item
+    </SideBarSubmenuListItem>,
+  )
+  expect(screen.getByRole('link', { name: 'Item' })).toHaveAttribute('aria-current', 'page')
+})

--- a/src/components/side-bar/submenu/__test__/submenu.test.tsx
+++ b/src/components/side-bar/submenu/__test__/submenu.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { SideBarSubmenu } from '../submenu'
+
+test('renders a list', () => {
+  render(<SideBarSubmenu>Children</SideBarSubmenu>)
+  expect(screen.getByRole('list')).toBeVisible()
+})
+
+test('all children are rendered', async () => {
+  render(
+    <SideBarSubmenu>
+      <li>Item 1</li>
+      <li>Item 2</li>
+    </SideBarSubmenu>,
+  )
+  const items = await screen.findAllByRole('listitem')
+
+  expect(items).toHaveLength(2)
+})

--- a/src/components/side-bar/submenu/index.ts
+++ b/src/components/side-bar/submenu/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './submenu'

--- a/src/components/side-bar/submenu/styles.ts
+++ b/src/components/side-bar/submenu/styles.ts
@@ -1,0 +1,14 @@
+import { styled } from '@linaria/react'
+
+export const ElSideBarSubmenuList = styled.ul`
+  list-style: none;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding-block-end: var(--spacing-2);
+`
+
+export const ElSideBarSubmenuListItem = styled.li`
+  display: block;
+`

--- a/src/components/side-bar/submenu/submenu-list-item.tsx
+++ b/src/components/side-bar/submenu/submenu-list-item.tsx
@@ -1,0 +1,20 @@
+import { ElSideBarSubmenuListItem } from './styles'
+import { SideBarSubmenuItem as SideBarSubmenuItem } from '../submenu-item'
+
+import type { ComponentProps } from 'react'
+
+interface SideBarSubmenuListItemProps extends ComponentProps<typeof SideBarSubmenuItem> {}
+
+/**
+ * A thin wrapper around `SideBarSubmenuItem` that ensures it is contained within a list item (`<li>`) for
+ * correct semantics and accessibility when used with `SideBar.Submenu`.
+ *
+ * All props are passed through to `SideBarSubmenuItem`.
+ */
+export function SideBarSubmenuListItem({ children, ...props }: SideBarSubmenuListItemProps) {
+  return (
+    <ElSideBarSubmenuListItem>
+      <SideBarSubmenuItem {...props}>{children}</SideBarSubmenuItem>
+    </ElSideBarSubmenuListItem>
+  )
+}

--- a/src/components/side-bar/submenu/submenu.stories.tsx
+++ b/src/components/side-bar/submenu/submenu.stories.tsx
@@ -1,0 +1,71 @@
+import { SideBarSubmenu } from './submenu'
+import * as SideBarSubmenuItemStories from '../submenu-item/submenu-item.stories'
+import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
+import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/SideBar/Submenu',
+  component: SideBarSubmenu,
+  argTypes: {
+    children: {
+      control: 'radio',
+      options: ['No selected item', 'Selected item'],
+      mapping: {
+        'No selected item': [
+          <SideBarSubmenu.Item key="1" {...SideBarSubmenuItemStories.Example.args}>
+            Submenu item 1
+          </SideBarSubmenu.Item>,
+          <SideBarSubmenu.Item key="2" {...SideBarSubmenuItemStories.Example.args}>
+            Submenu item 2
+          </SideBarSubmenu.Item>,
+        ],
+        'Selected item': [
+          <SideBarSubmenu.Item key="1" {...SideBarSubmenuItemStories.Example.args}>
+            Submenu item 1
+          </SideBarSubmenu.Item>,
+          <SideBarSubmenu.Item key="2" {...SideBarSubmenuItemStories.Selected.args}>
+            Submenu item 2
+          </SideBarSubmenu.Item>,
+        ],
+      },
+    },
+  },
+  decorators: [useSideBarContextDecorator],
+} satisfies Meta<typeof SideBarSubmenu>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'No selected item',
+  },
+}
+
+/**
+ * There is no visual or accessible difference applied to the submenu itself when one of its items represents the
+ * current page. It is just the specific item that will appear differently.
+ */
+export const Selected: Story = {
+  args: {
+    children: 'Selected item',
+  },
+}
+
+/**
+ * The submenu simply fills it parent container. If that parent does not have enough space for the labels
+ * of some or all of the submenu items, those labels will truncate as per the behaviour documented for the
+ * `SideBar.SubmenuItem` component.
+ */
+export const Truncation = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    sideBar: { width: '100px' },
+  },
+}

--- a/src/components/side-bar/submenu/submenu.tsx
+++ b/src/components/side-bar/submenu/submenu.tsx
@@ -13,8 +13,8 @@ interface SideBarSubmenuProps extends ComponentProps<typeof ElSideBarSubmenuList
  * `SideBar.MenuGroup`. The submenu itself will typically container a collection of `SideBar.SubmenuItem`'s
  * as children. Only one items, if any, in the submenu should represent the current page at any given time.
  */
-export function SideBarSubmenu({ children, ...props }: SideBarSubmenuProps) {
-  return <ElSideBarSubmenuList {...props}>{children}</ElSideBarSubmenuList>
+export function SideBarSubmenu({ children, ...rest }: SideBarSubmenuProps) {
+  return <ElSideBarSubmenuList {...rest}>{children}</ElSideBarSubmenuList>
 }
 
 SideBarSubmenu.Item = SideBarSubmenuListItem

--- a/src/components/side-bar/submenu/submenu.tsx
+++ b/src/components/side-bar/submenu/submenu.tsx
@@ -1,0 +1,20 @@
+import { SideBarSubmenuListItem } from './submenu-list-item'
+import { ElSideBarSubmenuList } from './styles'
+
+import type { ComponentProps, ReactNode } from 'react'
+
+interface SideBarSubmenuProps extends ComponentProps<typeof ElSideBarSubmenuList> {
+  /** A collection of items, typically `SideBar.SubmenuItem` components */
+  children: ReactNode
+}
+
+/**
+ * A simple submenu for use in a `SideBar`. Typically used via `SideBar.Submenu` as the child of a
+ * `SideBar.MenuGroup`. The submenu itself will typically container a collection of `SideBar.SubmenuItem`'s
+ * as children. Only one items, if any, in the submenu should represent the current page at any given time.
+ */
+export function SideBarSubmenu({ children, ...props }: SideBarSubmenuProps) {
+  return <ElSideBarSubmenuList {...props}>{children}</ElSideBarSubmenuList>
+}
+
+SideBarSubmenu.Item = SideBarSubmenuListItem

--- a/src/components/side-bar/use-side-bar.tsx
+++ b/src/components/side-bar/use-side-bar.tsx
@@ -1,0 +1,28 @@
+import { useCallback, useMemo, useState } from 'react'
+
+export type SideBarState = 'collapsed' | 'expanded'
+
+export interface UseSideBarResult {
+  expand: () => void
+  state: SideBarState
+  setState: (state: SideBarState) => void
+  toggle: () => void
+}
+
+/**
+ * Manages the collapsed/expanded state of the side bar and provides setters for changing that state.
+ */
+export function useSideBar(initialState: SideBarState | (() => SideBarState) = 'expanded'): UseSideBarResult {
+  const [state, setState] = useState(initialState)
+
+  const expand = useCallback(() => setState('expanded'), [])
+  const toggle = useCallback(
+    () =>
+      setState((prev) => {
+        return prev === 'collapsed' ? 'expanded' : 'collapsed'
+      }),
+    [],
+  )
+
+  return useMemo<UseSideBarResult>(() => ({ expand, state, setState, toggle }), [expand, state, setState, toggle])
+}


### PR DESCRIPTION
### Context
- We somehow managed to use component names that don't match what Design are using 🤦 ;
- There's some styles that aren't quite right (e.g. focus outline, SideBar doesn't fill vertical space);
- The components are consistently available via SideBar itself (i.e. inconsistent application of the compound component pattern);
- State management is a little buggy (e.g. an active menu group can be collapsed)

### Scope
- Refactor component names/responsibilities to match Design
- Fix up styles to ensure correct visual behaviour
- Apply compound component pattern consistently
- Fix bugs in state management
- Improve Storybook documentation for all the components involved in the SideBar

### Preceding PRs
- #450 

### This PR

- Adds a new `SideBarSubmenu` component. This includes a new subcomponent that wraps the `SideBarSubmenuItem` introduced in #450 in an `<li>` element.

<img width="1083" alt="Screenshot 2025-05-29 at 12 49 38 pm" src="https://github.com/user-attachments/assets/ba1b8989-cd67-4dc6-820d-ca428015259e" />
<img width="1082" alt="Screenshot 2025-05-29 at 12 49 52 pm" src="https://github.com/user-attachments/assets/8a28d035-2e36-47c8-a626-81eb5ac7a6c8" />
<img width="1083" alt="Screenshot 2025-05-29 at 12 49 59 pm" src="https://github.com/user-attachments/assets/d09a1fb5-9690-4d49-9b0f-fbd7024b98bc" />
