### PR TITLE
chore: #443 refactor sidebar components and update styles (part 4)

### DIFF
--- a/src/components/side-bar/menu-group/__test__/menu-group-summary.test.tsx
+++ b/src/components/side-bar/menu-group/__test__/menu-group-summary.test.tsx
@@ -1,0 +1,116 @@
+import { elSideBarMenuItem } from '../../menu-item'
+import { elSideBarMenuGroupSummary } from '../styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SideBarMenuGroupSummary } from '../menu-group-summary'
+import { SideBarMenuGroupLabelIdContext } from '../menu-group-label-id-context'
+
+import type { ReactNode } from 'react'
+
+test('renders a <summary> element', () => {
+  render(
+    <SideBarMenuGroupSummary data-testid="summary" icon="😎">
+      Item
+    </SideBarMenuGroupSummary>,
+    { wrapper },
+  )
+  // NOTE: <summary> elements have no implicit role, so we cannot use `getByRole` here to select <summary> element
+  // See https://w3c.github.io/html-aria/#el-summary. While the spec suggests some user agents apply an implicit
+  // button role, this does not appear to the case for React Testing Library
+  const summary = screen.getByTestId('summary')
+  expect(summary.tagName).toBe('SUMMARY')
+})
+
+test(`combines the .${elSideBarMenuItem}, .${elSideBarMenuGroupSummary} and consumer-supplied classes correctly`, () => {
+  render(
+    <SideBarMenuGroupSummary className="my-custom-class" data-testid="summary" icon="😎">
+      Item
+    </SideBarMenuGroupSummary>,
+    { wrapper },
+  )
+  // NOTE: We don't use the `toHaveClass` matcher here because it does not enforce the order of classes, which we are
+  // specifically interested in here.
+  expect(screen.getByTestId('summary')).toHaveAttribute(
+    'class',
+    `${elSideBarMenuItem} ${elSideBarMenuGroupSummary} my-custom-class`,
+  )
+})
+
+test('the `id` published by the menu group is used by default', () => {
+  render(
+    <SideBarMenuGroupSummary data-testid="summary" icon="😎">
+      Item
+    </SideBarMenuGroupSummary>,
+    { wrapper },
+  )
+  expect(screen.getByTestId('summary')).toHaveAttribute('id', 'test-label-id') // This `id` is provided by the wrapper
+})
+
+test('a consumer-supplied `id` will be used instead of the `id` published by the menu group', () => {
+  render(
+    <SideBarMenuGroupSummary data-testid="summary" icon="😎" id="my-id">
+      Item
+    </SideBarMenuGroupSummary>,
+    { wrapper },
+  )
+  expect(screen.getByTestId('summary')).toHaveAttribute('id', 'my-id')
+})
+
+test('icon is visible, but hidden from the accessibility tree', () => {
+  render(<SideBarMenuGroupSummary icon="😎">Item</SideBarMenuGroupSummary>, { wrapper })
+  const icon = screen.getByText('😎')
+
+  expect(icon).toBeVisible()
+  expect(icon).toHaveAttribute('aria-hidden')
+})
+
+test('calls a consumer-supplied `onClick` handler', () => {
+  const onClick = vi.fn()
+  render(
+    <SideBarMenuGroupSummary data-testid="summary" icon="😎" onClick={onClick}>
+      Item
+    </SideBarMenuGroupSummary>,
+    { wrapper },
+  )
+  const summaryText = screen.getByTestId('summary')
+  fireEvent.click(summaryText)
+
+  expect(onClick).toHaveBeenCalledTimes(1)
+})
+
+test('prevents default action for click events if the menu group contains a link for the current page', async () => {
+  render(
+    <details open>
+      <SideBarMenuGroupSummary icon="😎">Item</SideBarMenuGroupSummary>
+      <a href="/" aria-current="page">
+        Link
+      </a>
+    </details>,
+    { wrapper },
+  )
+  const summaryText = screen.getByText('Item')
+  fireEvent.click(summaryText)
+
+  // If the event was NOT prevented, the <details> element would be closed and thus not visible
+  await expect(screen.findByRole('group')).resolves.toBeVisible()
+})
+
+test('allows default action for click events if the menu group does NOT contain a link for the current page', async () => {
+  render(
+    <details open>
+      <SideBarMenuGroupSummary icon="😎">Item</SideBarMenuGroupSummary>
+      <a href="/">Link</a>
+    </details>,
+    { wrapper },
+  )
+  const summaryText = screen.getByText('Item')
+  fireEvent.click(summaryText)
+
+  // If the event was prevented, the <details> element would not be open and thus not visible
+  await expect(screen.findByRole('group')).resolves.toBeVisible()
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SideBarMenuGroupLabelIdContext.Provider value="test-label-id">{children}</SideBarMenuGroupLabelIdContext.Provider>
+  )
+}

--- a/src/components/side-bar/menu-group/__test__/menu-group.test.tsx
+++ b/src/components/side-bar/menu-group/__test__/menu-group.test.tsx
@@ -1,0 +1,79 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+import { SideBarMenuGroup } from '../menu-group'
+import * as stories from '../menu-group.stories'
+import { elSideBarMenuGroup } from '../styles'
+
+const MenuGroupStories = composeStories(stories)
+
+test('renders a <details> element', () => {
+  render(<MenuGroupStories.Example />)
+  const group = screen.getByRole('group')
+
+  expect(group.tagName).toBe('DETAILS')
+  expect(group).toBeInTheDocument()
+})
+
+test(`combines the .${elSideBarMenuGroup} and consumer-supplied classes correctly`, () => {
+  render(<MenuGroupStories.Example className="my-custom-class" />)
+  // NOTE: We don't use the `toHaveClass` matcher here because it does not enforce the order of classes, which we are
+  // specifically interested in here.
+  expect(screen.getByRole('group')).toHaveAttribute('class', `${elSideBarMenuGroup} my-custom-class`)
+})
+
+test('has an accessible name when the `SideBar` is collapsed', () => {
+  render(<MenuGroupStories.Collapsed summary={<SideBarMenuGroup.Summary icon="😎">Group</SideBarMenuGroup.Summary>} />)
+  expect(screen.getByRole('group', { name: 'Group' })).toBeInTheDocument()
+})
+
+test('is labelled by the <summary> element', () => {
+  render(<MenuGroupStories.Selected />)
+  const detailsElement = screen.getByRole('group')
+  const summaryElement = detailsElement.firstElementChild
+  expect(detailsElement.getAttribute('aria-labelledby')).toBe(summaryElement?.id)
+})
+
+test('is open by default when a descendant submenu item represents the current page', () => {
+  render(<MenuGroupStories.Selected />)
+  // NOTE: <details> elements are only considered visible when they are open
+  expect(screen.getByRole('group')).toBeVisible()
+})
+
+test('is closed by default when NO descendant submenu items represent the current page', () => {
+  render(<MenuGroupStories.Example />)
+  // NOTE: <details> elements are only considered visible when they are open
+  expect(screen.getByRole('group')).not.toBeVisible()
+})
+
+test('is closed when the `SideBar` is collapsed', () => {
+  const { rerender } = render(<MenuGroupStories.Selected />)
+
+  expect(screen.getByRole('group')).toBeVisible()
+
+  // Simulate the `SideBar` being collapsed
+  rerender(<MenuGroupStories.Collapsed />)
+
+  expect(screen.getByRole('group')).not.toBeVisible()
+})
+
+test('is opened when the `SideBar` is expanded and a descendant submenu item represents the current page', () => {
+  const { rerender } = render(<MenuGroupStories.SelectedAndCollapsed />)
+
+  expect(screen.getByRole('group')).not.toBeVisible()
+
+  // Simulate the `SideBar` being expanded
+  rerender(<MenuGroupStories.Selected />)
+
+  expect(screen.getByRole('group')).toBeVisible()
+})
+
+test('is opened when the `SideBar` is expanded and a descendant submenu item represents the current page', () => {
+  const { rerender } = render(<MenuGroupStories.SelectedAndCollapsed />)
+
+  expect(screen.getByRole('group')).not.toBeVisible()
+
+  // Simulate the `SideBar` being expanded
+  rerender(<MenuGroupStories.Selected />)
+
+  expect(screen.getByRole('group')).toBeVisible()
+})

--- a/src/components/side-bar/menu-group/__test__/use-menu-group-controller.test.tsx
+++ b/src/components/side-bar/menu-group/__test__/use-menu-group-controller.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { useSideBarMenuGroupController } from '../use-menu-group-controller'
+
+import type { DetailsHTMLAttributes } from 'react'
+import type { SideBarState } from '../../use-side-bar'
+
+test('`<details>` is opened when the `SideBar` is expanded and a descendant represents the current page', () => {
+  const { rerender } = render(
+    // NOTE: the `open` attribute is absent when we first render
+    <Details sideBarState="collapsed">
+      <a href="/" aria-current="page">
+        Current Page
+      </a>
+    </Details>,
+  )
+  expect(screen.getByRole('group')).not.toBeVisible()
+
+  rerender(
+    // NOTE: the `open` attribute is still absent when we rerender with the SideBar expanded, but we expect the
+    // <details> element to be opened by our useSideBarMenuGroupController because one of its descendants represents
+    // the current page
+    <Details sideBarState="expanded">
+      <a href="/" aria-current="page">
+        Current Page
+      </a>
+    </Details>,
+  )
+  expect(screen.getByRole('group')).toBeVisible()
+})
+
+test('`<details>` is closed when the `SideBar` is collapsed', () => {
+  const { rerender } = render(
+    <Details open sideBarState="expanded">
+      Content
+    </Details>,
+  )
+  expect(screen.getByRole('group')).toBeVisible()
+
+  rerender(
+    // NOTE: the `open` attribute is still present when we rerender, but we expect the <details> element
+    // to be closed by our useSideBarMenuGroupController
+    <Details open sideBarState="collapsed">
+      Content
+    </Details>,
+  )
+  expect(screen.getByRole('group')).not.toBeVisible()
+})
+
+test('`<details>` is opened when a descendant comes to represent the current page', async () => {
+  const { rerender } = render(
+    // NOTE: the `open` attribute is absent when we first render
+    <Details sideBarState="expanded">
+      <a aria-current="false">Current Page</a>
+    </Details>,
+  )
+  expect(screen.getByRole('group')).not.toBeVisible()
+
+  rerender(
+    // NOTE: the `open` attribute is still absent when we rerender, but we expect the <details> element to be
+    // opened by our useSideBarMenuGroupController because one of its descendants _now_ represents the current page
+    <Details sideBarState="expanded">
+      <a aria-current="page">Current Page</a>
+    </Details>,
+  )
+  await waitFor(() => expect(screen.getByRole('group')).toBeVisible())
+})
+
+test('`<details>` is closed when a descendant no longer represents the current page', async () => {
+  const { rerender } = render(
+    // NOTE: the `open` attribute is present when we first render
+    <Details open sideBarState="expanded">
+      <a href="/" aria-current="page">
+        Current Page
+      </a>
+    </Details>,
+  )
+  expect(screen.getByRole('group')).toBeVisible()
+
+  rerender(
+    // NOTE: the `open` attribute is still present when we rerender, but we expect the <details> element to be
+    // closed by our useSideBarMenuGroupController because one of its descendants _no longer_ represents the
+    // current page
+    <Details open sideBarState="expanded">
+      <a href="/" aria-current="false">
+        Current Page
+      </a>
+    </Details>,
+  )
+  await waitFor(() => expect(screen.getByRole('group')).not.toBeVisible())
+})
+
+interface DetailsProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
+  sideBarState: SideBarState
+}
+
+/** Simple integration of the subject under test (useSideBarMenuGroupController) and a `<details>` element */
+function Details({ children, sideBarState, ...props }: DetailsProps) {
+  const ref = useSideBarMenuGroupController(sideBarState)
+  return (
+    <details {...props} ref={ref}>
+      {children}
+    </details>
+  )
+}

--- a/src/components/side-bar/menu-group/index.ts
+++ b/src/components/side-bar/menu-group/index.ts
@@ -1,0 +1,3 @@
+export * from './styles'
+export * from './menu-group'
+export * from './menu-group-summary'

--- a/src/components/side-bar/menu-group/menu-group-label-id-context.ts
+++ b/src/components/side-bar/menu-group/menu-group-label-id-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * Simple context object to allow the SideBar.MenuGroup to automatically wire-up an `aria-labelledby` attribute
+ * on the `<details>` element that references the `id` attribute of the `<summary>` element.
+ */
+export const SideBarMenuGroupLabelIdContext = createContext<string | null>(null)
+
+export function useSideBarMenuGroupLabelIdContext(): string {
+  const menuGroupId = useContext(SideBarMenuGroupLabelIdContext)
+  if (!menuGroupId) {
+    throw new Error('useSideBarMenuGroupIdContext must be used within a SideBarMenuGroupIdContext.Provider')
+  }
+  return menuGroupId
+}

--- a/src/components/side-bar/menu-group/menu-group-summary.tsx
+++ b/src/components/side-bar/menu-group/menu-group-summary.tsx
@@ -1,0 +1,78 @@
+import { cx } from '@linaria/core'
+import {
+  elSideBarMenuGroup,
+  elSideBarMenuGroupSummary,
+  ElSideBarMenuGroupSummaryIcon,
+  ElSideBarMenuGroupSummaryLabel,
+  ElSideBarMenuGroupSummaryDropdownIcon,
+} from './styles'
+import { elSideBarMenuItem } from '../menu-item'
+import { elSideBarSubmenuItem } from '../submenu-item'
+import { Icon } from '../../icon'
+import { useCallback } from 'react'
+import { useSideBarMenuGroupLabelIdContext } from './menu-group-label-id-context'
+
+import type { HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+
+interface SideBarMenuGroupSummaryProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * The label for the menu group.
+   */
+  children: ReactNode
+  /**
+   * The icon to display next to the label.
+   */
+  icon: ReactNode
+}
+
+/**
+ * A summary element for the `SideBar.MenuGroup`. It is explicitly designed for use within a `<details>` element,
+ * relying on its `open` state to determine the orientation of the summary's dropdown indicator.
+ *
+ * ⚠️ **Important**: `<summary> elements are not interactive outside of a parent `<details>` element. This component
+ * should only be used as the summary for a `SideBar.MenuGroup` component.
+ */
+export function SideBarMenuGroupSummary({
+  children,
+  className,
+  icon,
+  id,
+  onClick,
+  ...props
+}: SideBarMenuGroupSummaryProps) {
+  const labelId = id ?? useSideBarMenuGroupLabelIdContext()
+
+  // We need to prevent the parent menu group from closing if it is currently active (i.e. one of its descendants
+  // represents the current page).
+  //
+  // NOTE: We don't add a click handler to the <details> element itself because that would be called for any
+  // click event that propogates from _any_ descendants, which would include this <summary> element.
+  const handleClick: MouseEventHandler<HTMLElement> = useCallback(
+    (event) => {
+      onClick?.(event)
+
+      const detailsElement = event.currentTarget.closest(`details.${elSideBarMenuGroup}`)
+      const hasCurrentPageElement = !!detailsElement?.querySelector(`.${elSideBarSubmenuItem}[aria-current="page"]`)
+
+      if (hasCurrentPageElement) {
+        event.preventDefault()
+      }
+    },
+    [onClick],
+  )
+
+  return (
+    <summary
+      {...props}
+      className={cx(elSideBarMenuItem, elSideBarMenuGroupSummary, className)}
+      id={labelId}
+      onClick={handleClick}
+    >
+      <ElSideBarMenuGroupSummaryIcon aria-hidden>{icon}</ElSideBarMenuGroupSummaryIcon>
+      <ElSideBarMenuGroupSummaryLabel>{children}</ElSideBarMenuGroupSummaryLabel>
+      <ElSideBarMenuGroupSummaryDropdownIcon aria-hidden>
+        <Icon icon="chevronDown" />
+      </ElSideBarMenuGroupSummaryDropdownIcon>
+    </summary>
+  )
+}

--- a/src/components/side-bar/menu-group/menu-group.stories.tsx
+++ b/src/components/side-bar/menu-group/menu-group.stories.tsx
@@ -1,0 +1,111 @@
+import { Icon } from '../../icon'
+import { SideBarMenuGroup } from './menu-group'
+import { SideBarSubmenu } from '../submenu'
+import { useArgs } from '@storybook/preview-api'
+import * as SideBarSubmenuItemStories from '../submenu-item/submenu-item.stories'
+import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
+import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/SideBar/MenuGroup',
+  component: SideBarMenuGroup,
+  argTypes: {
+    children: {
+      control: 'radio',
+      options: ['No selected item', 'Selected item'],
+      mapping: {
+        'No selected item': (
+          <SideBarSubmenu>
+            <SideBarSubmenu.Item {...SideBarSubmenuItemStories.Example.args} />
+            <SideBarSubmenu.Item {...SideBarSubmenuItemStories.Example.args} />
+          </SideBarSubmenu>
+        ),
+        'Selected item': (
+          <SideBarSubmenu>
+            <SideBarSubmenu.Item {...SideBarSubmenuItemStories.Example.args} />
+            <SideBarSubmenu.Item {...SideBarSubmenuItemStories.Selected.args} />
+          </SideBarSubmenu>
+        ),
+      },
+    },
+    summary: {
+      control: false,
+    },
+  },
+  decorators: [useSideBarContextDecorator],
+  // NOTE: because we are controlling the `open` state of the group, we need to use the `useArgs` hook to update the
+  // `open` arg value if the group's state changes outside of the Storybook controls.
+  render: (args) => {
+    const [, updateArgs] = useArgs()
+    const updateOpenArg = (event) => {
+      updateArgs({ open: event.currentTarget.open })
+    }
+    return (
+      <SideBarMenuGroup {...args} onToggle={updateOpenArg}>
+        {args.children}
+      </SideBarMenuGroup>
+    )
+  },
+} satisfies Meta<typeof SideBarMenuGroup>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'No selected item',
+    summary: <SideBarMenuGroup.Summary icon={<Icon icon="property" />}>Menu group</SideBarMenuGroup.Summary>,
+    open: false,
+  },
+}
+
+/**
+ * When a submenu item within the group represents the current page, it should have an `aria-current="page"`
+ * attribute. This attribute is used by `SideBar.MenuGroup` and `SideBar.MenuGroupSummary` to visually communicate
+ * the group has a "selected" item. For acccessible users, this should be communicated via the underlying `<details>`
+ * element's `open` attribute.
+ *
+ * Importantly, if the `SideBar` is not collapsed, a group with an submenu item representing the current page should
+ * not be closable.
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    children: 'Selected item',
+    open: true,
+  },
+}
+
+/**
+ * When the `SideBar` is collapsed, the menu group's main label will be completely hidden. Importantly, the menu
+ * group's label will still be available in the accessibility tree despite not being visible.
+ */
+export const Collapsed = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    sideBar: { state: 'collapsed' },
+  },
+}
+
+/**
+ * Also, when the `SideBar` is collapsed, the menu group can still be selected, but it will not be expanded. Again,
+ * the label will still be available in the accessibility tree. Clicking on the group will cause the `SideBar` to
+ * expand, and the group to open, though this behaviour is handled by the `SideBar` component itself, not the group.
+ */
+export const SelectedAndCollapsed = {
+  args: {
+    ...Collapsed.args,
+    children: 'Selected item',
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    ...Collapsed.parameters,
+  },
+  storyName: 'Selected and collapsed',
+}

--- a/src/components/side-bar/menu-group/menu-group.tsx
+++ b/src/components/side-bar/menu-group/menu-group.tsx
@@ -1,0 +1,62 @@
+import { cx } from '@linaria/core'
+import { elSideBarMenuGroup } from './styles'
+import { SideBarMenuGroupLabelIdContext } from './menu-group-label-id-context'
+import { SideBarMenuGroupSummary } from './menu-group-summary'
+import { useId } from 'react'
+import { useSideBarContext } from '../side-bar-context'
+import { useSideBarMenuGroupController } from './use-menu-group-controller'
+
+import type { DetailsHTMLAttributes, ReactNode } from 'react'
+
+export interface SideBarMenuGroupProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
+  /**
+   * Typically a single `SideBar.Submenu` component that contains any number of submenu items
+   */
+  children: ReactNode
+  /**
+   * Indicates whether the menu group's contents---that is, the submenu of items---are currently visible.
+   *
+   * Typically, the open state of menu groups can remain uncontrolled. If this state is controlled, it is important
+   * for consumers to listen for
+   * [toggle](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#events) events fired after
+   * the underlying `<details>` element's `open` state changes. This is because the `SideBar` will, at times,
+   * imperatively control child `<details>` elements.
+   */
+  open?: boolean
+  /**
+   * The summary/main item for the menu group. Will typically be a `SideBar.MenuGroupSummary`. If a custom element is
+   * rendered, it should be a `<summary>` element.
+   */
+  summary: ReactNode
+}
+
+/**
+ * A menu group that can contain a submenu of items for use in a `SideBar`. The group leverages a `<details>`
+ * element to provide a native disclosure widget for showing and hiding the submenu. The group and its summary are
+ * styled to look like a traditional menu item.
+ *
+ * Generally, there should be no need to control the open state of menu groups; if you do, please surface your
+ * use-case with the Elements team so you can learn about the implications of doing so.
+ *
+ * **Note:** The `SideBar` handles keyboard navigation across all menu items and menu groups within it. As such,
+ * the menu group does not handle any of this itself.
+ */
+export function SideBarMenuGroup({
+  'aria-labelledby': ariaLabelledBy,
+  children,
+  className,
+  summary,
+  ...props
+}: SideBarMenuGroupProps) {
+  const labelId = ariaLabelledBy ?? useId()
+  const sideBar = useSideBarContext()
+  const ref = useSideBarMenuGroupController(sideBar.state)
+  return (
+    <details {...props} className={cx(elSideBarMenuGroup, className)} aria-labelledby={labelId} ref={ref}>
+      <SideBarMenuGroupLabelIdContext.Provider value={labelId}>{summary}</SideBarMenuGroupLabelIdContext.Provider>
+      {children}
+    </details>
+  )
+}
+
+SideBarMenuGroup.Summary = SideBarMenuGroupSummary

--- a/src/components/side-bar/menu-group/menu-group.tsx
+++ b/src/components/side-bar/menu-group/menu-group.tsx
@@ -46,13 +46,13 @@ export function SideBarMenuGroup({
   children,
   className,
   summary,
-  ...props
+  ...rest
 }: SideBarMenuGroupProps) {
   const labelId = ariaLabelledBy ?? useId()
   const sideBar = useSideBarContext()
   const ref = useSideBarMenuGroupController(sideBar.state)
   return (
-    <details {...props} className={cx(elSideBarMenuGroup, className)} aria-labelledby={labelId} ref={ref}>
+    <details {...rest} className={cx(elSideBarMenuGroup, className)} aria-labelledby={labelId} ref={ref}>
       <SideBarMenuGroupLabelIdContext.Provider value={labelId}>{summary}</SideBarMenuGroupLabelIdContext.Provider>
       {children}
     </details>

--- a/src/components/side-bar/menu-group/styles.ts
+++ b/src/components/side-bar/menu-group/styles.ts
@@ -1,0 +1,54 @@
+import { css } from '@linaria/core'
+import { styled } from '@linaria/react'
+import { ElIcon } from '../../icon'
+import { ElSideBarMenuItemIcon, ElSideBarMenuItemLabel } from '../menu-item'
+
+export const elSideBarMenuGroup = css`
+  border-radius: var(--comp-navigation-border-radius-menu_item);
+  width: 100%;
+
+  &:open,
+  &[open],
+  &:has([aria-current='page']) {
+    background: var(--comp-navigation-colour-fill-sidebar-select);
+  }
+`
+
+// NOTE: This is designed to work in conjunction with `elSideBarMenuItem`
+export const elSideBarMenuGroupSummary = css`
+  grid-template-areas: 'icon label dropdown';
+  grid-template-columns: auto 1fr auto;
+  overflow: hidden;
+
+  cursor: pointer;
+`
+
+export const ElSideBarMenuGroupSummaryIcon = styled(ElSideBarMenuItemIcon)`
+  details:has([aria-current='page']) & {
+    color: var(--comp-navigation-colour-icon-sidebar-select);
+  }
+`
+
+export const ElSideBarMenuGroupSummaryLabel = styled(ElSideBarMenuItemLabel)`
+  details:has([aria-current='page']) & {
+    color: var(--comp-navigation-colour-text-sidebar-select);
+    font-weight: var(--font-weight-medium);
+  }
+`
+
+export const ElSideBarMenuGroupSummaryDropdownIcon = styled.span`
+  grid-area: dropdown;
+
+  color: var(--comp-navigation-colour-icon-sidebar-default);
+
+  padding: var(--spacing-1);
+
+  ${ElIcon} {
+    width: var(--icon_size-xs);
+    height: var(--icon_size-xs);
+  }
+
+  details:open & {
+    transform: rotate(180deg);
+  }
+`

--- a/src/components/side-bar/menu-group/use-menu-group-controller.ts
+++ b/src/components/side-bar/menu-group/use-menu-group-controller.ts
@@ -1,0 +1,63 @@
+import { useLayoutEffect, useRef } from 'react'
+
+import type { RefObject } from 'react'
+import type { SideBarState } from '../use-side-bar'
+
+/**
+ * Controls the open state of a `SideBar.MenuGroup` when the `SideBar` is expanded or collapsed or when a descendant
+ * comes to represent, or stops representing, the current page.
+ */
+export function useSideBarMenuGroupController(sideBarState: SideBarState): RefObject<HTMLDetailsElement> {
+  const ref = useRef<HTMLDetailsElement>(null)
+
+  useLayoutEffect(
+    function openOrCloseMenuGroup() {
+      if (!ref.current) return
+
+      // If the sidebar is collapsed, we want the menu group to be closed.
+      if (sideBarState === 'collapsed') {
+        ref.current.open = false
+      } else {
+        // If the sidebar is expanded, and an element representing the current page is within this menu group, we
+        // want the group to be open.
+        if (hasCurrentPageElement(ref.current)) {
+          ref.current.open = true
+        }
+
+        // We also want to observe changes to the `aria-current` attribute of the menu group's descendants so we
+        // can update the group's open state as appropriate.
+        const observer = createAriaCurrentObserver(ref.current)
+        return () => observer.disconnect()
+      }
+    },
+    [sideBarState],
+  )
+
+  return ref
+}
+
+/**
+ * Creates a MutationObserver that listens for changes to the `aria-current` attribute within the given details element.
+ * and updates the open state of that details element based on the presence of a descenant that represents the current
+ * page (i.e. an element with `aria-current="page"`).
+ */
+function createAriaCurrentObserver(detailsElement: HTMLDetailsElement): MutationObserver {
+  const observer = new MutationObserver(() => {
+    // When we observe changes to the `aria-current` attribute, we want to open or close the menu element
+    // based on whether it contains an element with `aria-current="page"`.
+    detailsElement.open = hasCurrentPageElement(detailsElement)
+  })
+
+  // We want to observe changes to the details element's subtree, but only changes to the `aria-current` attribute.
+  observer.observe(detailsElement, {
+    subtree: true,
+    attributeFilter: ['aria-current'],
+  })
+
+  return observer
+}
+
+/** Returns true if a descendant represents the current page  */
+function hasCurrentPageElement(detailsElement: HTMLDetailsElement): boolean {
+  return !!detailsElement.querySelector('[aria-current="page"]')
+}


### PR DESCRIPTION
### Context
- We somehow managed to use component names that don't match what Design are using 🤦 ;
- There's some styles that aren't quite right (e.g. focus outline, SideBar doesn't fill vertical space);
- The components are consistently available via SideBar itself (i.e. inconsistent application of the compound component pattern);
- State management is a little buggy (e.g. an active menu group can be collapsed)

### Scope
- Refactor component names/responsibilities to match Design
- Fix up styles to ensure correct visual behaviour
- Apply compound component pattern consistently
- Fix bugs in state management
- Improve Storybook documentation for all the components involved in the SideBar

### Preceding PRs
- #450 
- #451 
- #452 

### This PR

- Adds a new `SideBarMenuGroup` component. This replaces the existing `SideBarMenuGroup` component and it's "molecules", only it's placed within the main `components/side-bar` folder.

<img width="1081" alt="Screenshot 2025-05-29 at 1 02 43 pm" src="https://github.com/user-attachments/assets/1054abb8-ed9d-4734-8152-518849c35925" />
<img width="1081" alt="Screenshot 2025-05-29 at 1 02 52 pm" src="https://github.com/user-attachments/assets/0c56d8fc-4fee-4c44-b714-a1fb172e6678" />
<img width="1082" alt="Screenshot 2025-05-29 at 1 03 00 pm" src="https://github.com/user-attachments/assets/fc3cc6d6-f833-4373-9002-4c77184e5a92" />
<img width="1081" alt="Screenshot 2025-05-29 at 1 03 09 pm" src="https://github.com/user-attachments/assets/0868dfe7-2cc1-42c2-8e2e-49a47f968919" />
