### PR TITLE
chore: #443 refactor sidebar components and update styles (part 5)

### DIFF
--- a/src/components/side-bar/menu-list/__test__/menu-list-group.test.tsx
+++ b/src/components/side-bar/menu-list/__test__/menu-list-group.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { SideBarContextPublisher } from '../../side-bar-context'
+import { SideBarMenuListGroup } from '../menu-list-group'
+
+import type { ReactNode } from 'react'
+
+test('renders a <details> element as the child of a <li>', () => {
+  render(<SideBarMenuListGroup summary={<summary>Item</summary>}>Children</SideBarMenuListGroup>, { wrapper })
+  const listItem = screen.getByRole('listitem')
+  const details = screen.getByRole('group')
+
+  expect(listItem).toBeVisible()
+  // NOTE: <details> is only considered visible if it has an open attribute
+  expect(details).toBeInTheDocument()
+  expect(listItem.firstChild).toBe(details)
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  const noop = () => void 0
+  return (
+    <SideBarContextPublisher id="test-id" expand={noop} setState={noop} state="expanded" toggle={noop}>
+      {children}
+    </SideBarContextPublisher>
+  )
+}

--- a/src/components/side-bar/menu-list/__test__/menu-list-item.test.tsx
+++ b/src/components/side-bar/menu-list/__test__/menu-list-item.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { SideBarMenuListItem } from '../menu-list-item'
+
+test('renders an <a> element as child of a <li>', () => {
+  render(
+    <SideBarMenuListItem href="/" icon="😎">
+      Item
+    </SideBarMenuListItem>,
+  )
+  const listItem = screen.getByRole('listitem')
+  const anchor = screen.getByRole('link', { name: 'Item' })
+
+  expect(listItem).toBeVisible()
+  expect(anchor).toBeVisible()
+  expect(listItem.firstChild).toBe(anchor)
+})
+
+test('<a> element has `aria-current="page"` attribute present when `isActive`', () => {
+  render(
+    <SideBarMenuListItem href="/" icon="😎" isActive>
+      Item
+    </SideBarMenuListItem>,
+  )
+  expect(screen.getByRole('link', { name: 'Item' })).toHaveAttribute('aria-current', 'page')
+})

--- a/src/components/side-bar/menu-list/__test__/menu-list.test.tsx
+++ b/src/components/side-bar/menu-list/__test__/menu-list.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { SideBarMenuList } from '../menu-list'
+
+test('renders an <ul> element', () => {
+  render(<SideBarMenuList>Children</SideBarMenuList>)
+  expect(screen.getByRole('list')).toBeVisible()
+})
+
+test('all children are rendered', async () => {
+  render(
+    <SideBarMenuList>
+      <li>Item 1</li>
+      <li>Item 2</li>
+    </SideBarMenuList>,
+  )
+  const items = await screen.findAllByRole('listitem')
+
+  expect(items).toHaveLength(2)
+})

--- a/src/components/side-bar/menu-list/index.ts
+++ b/src/components/side-bar/menu-list/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './menu-list'

--- a/src/components/side-bar/menu-list/menu-list-group.tsx
+++ b/src/components/side-bar/menu-list/menu-list-group.tsx
@@ -1,0 +1,22 @@
+import { SideBarMenuGroup } from '../menu-group'
+import { ElSideBarMenuListItem } from './styles'
+
+import type { ComponentProps } from 'react'
+
+interface SideBarMenuListGroupProps extends ComponentProps<typeof SideBarMenuGroup> {}
+
+/**
+ * A thin wrapper around `SideBarMenuGroup` that ensures it is contained within a list item (`<li>`) for
+ * correct semantics and accessibility when used with `SideBar.MenuList`.
+ *
+ * All props are passed through to `SideBarMenuGroup`.
+ */
+export function SideBarMenuListGroup({ children, ...props }: SideBarMenuListGroupProps) {
+  return (
+    <ElSideBarMenuListItem>
+      <SideBarMenuGroup {...props}>{children}</SideBarMenuGroup>
+    </ElSideBarMenuListItem>
+  )
+}
+
+SideBarMenuListGroup.Summary = SideBarMenuGroup.Summary

--- a/src/components/side-bar/menu-list/menu-list-item.tsx
+++ b/src/components/side-bar/menu-list/menu-list-item.tsx
@@ -1,0 +1,20 @@
+import { SideBarMenuItem as BaseSideBarMenuItem } from '../menu-item'
+import { ElSideBarMenuListItem } from './styles'
+
+import type { ComponentProps } from 'react'
+
+interface SideBarMenuListItemProps extends ComponentProps<typeof BaseSideBarMenuItem> {}
+
+/**
+ * A thin wrapper around `SideBarMenuItem` that ensures it is contained within a list item (`<li>`) for
+ * correct semantics and accessibility when used with `SideBar.MenuList`.
+ *
+ * All props are passed through to `SideBarMenuItem`.
+ */
+export function SideBarMenuListItem({ children, ...props }: SideBarMenuListItemProps) {
+  return (
+    <ElSideBarMenuListItem>
+      <BaseSideBarMenuItem {...props}>{children}</BaseSideBarMenuItem>
+    </ElSideBarMenuListItem>
+  )
+}

--- a/src/components/side-bar/menu-list/menu-list.stories.tsx
+++ b/src/components/side-bar/menu-list/menu-list.stories.tsx
@@ -1,0 +1,109 @@
+import { Icon } from '../../icon'
+import { SideBarMenuList } from './menu-list'
+import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
+import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+// Common href for all menu items that links to the current storybook page.
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Components/SideBar/MenuList',
+  component: SideBarMenuList,
+  argTypes: {
+    children: {
+      control: 'radio',
+      options: ['No selected item', 'Selected item', 'Selected submenu item'],
+      mapping: {
+        'No selected item': buildMenu('No selected item'),
+        'Selected item': buildMenu('Selected item'),
+        'Selected submenu item': buildMenu('Selected submenu item'),
+      },
+    },
+  },
+  decorators: [useSideBarContextDecorator],
+} satisfies Meta<typeof SideBarMenuList>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'No selected item',
+  },
+}
+
+/**
+ * If a menu item represents the current page, it should be marked as "selected". See the `SideBar.MenuItem`
+ * documentation for details on how.
+ */
+export const SelectedItem: Story = {
+  args: {
+    children: 'Selected item',
+  },
+}
+
+/**
+ * Likewise, if a submenu item represents the current page, it should be marked as "selected". This will
+ * automatically cause the parent `SideBar.MenuGroup` to be displayed as "selected" itself. See the
+ * `SideBar.SubmenuItem` documentation for details on how.
+ */
+export const SelectedSubmenuItem: Story = {
+  args: {
+    children: 'Selected submenu item',
+  },
+}
+
+/**
+ * The menu list simply fills it parent container. If that parent does not have enough space for the labels
+ * of some or all of the submenu items, those labels will truncate as per the behaviour documented for each
+ * individual component. That said, authors (both designers and engineers) should typically ensure the side bar
+ * is afforded enough space for the menu items it contains.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    sideBar: {
+      width: '120px',
+    },
+  },
+}
+
+/**
+ * When the side bar is collapsed, only the menu item's icons will be visible.
+ */
+export const Collapsed: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useSideBarWidthDecorator],
+  parameters: {
+    sideBar: {
+      state: 'collapsed',
+    },
+  },
+}
+
+function buildMenu(type: 'No selected item' | 'Selected item' | 'Selected submenu item') {
+  return [
+    <SideBarMenuList.Item key="1" href={href} icon={<Icon icon="property" />} isActive={type === 'Selected item'}>
+      Menu item 1
+    </SideBarMenuList.Item>,
+    <SideBarMenuList.Group
+      key="2"
+      summary={<SideBarMenuList.GroupSummary icon={<Icon icon="property" />}>Menu item 2</SideBarMenuList.GroupSummary>}
+    >
+      <SideBarMenuList.Submenu>
+        <SideBarMenuList.SubmenuItem href={href} isActive={type === 'Selected submenu item'}>
+          Submenu item 1
+        </SideBarMenuList.SubmenuItem>
+        <SideBarMenuList.SubmenuItem href={href}>Submenu item 2</SideBarMenuList.SubmenuItem>
+      </SideBarMenuList.Submenu>
+    </SideBarMenuList.Group>,
+  ]
+}

--- a/src/components/side-bar/menu-list/menu-list.tsx
+++ b/src/components/side-bar/menu-list/menu-list.tsx
@@ -11,8 +11,8 @@ interface SideBarMenuListProps extends ComponentProps<typeof ElSideBarMenuList> 
  * Main menu list for the `SideBar`. Typically provided a collection of `SideBar.MenuItem` and `SideBar.MenuGroup`
  * components as children.
  */
-export function SideBarMenuList({ children, ...props }: SideBarMenuListProps) {
-  return <ElSideBarMenuList {...props}>{children}</ElSideBarMenuList>
+export function SideBarMenuList({ children, ...rest }: SideBarMenuListProps) {
+  return <ElSideBarMenuList {...rest}>{children}</ElSideBarMenuList>
 }
 
 SideBarMenuList.Item = SideBarMenuListItem

--- a/src/components/side-bar/menu-list/menu-list.tsx
+++ b/src/components/side-bar/menu-list/menu-list.tsx
@@ -1,0 +1,22 @@
+import { ElSideBarMenuList } from './styles'
+import { SideBarMenuListItem } from './menu-list-item'
+import { SideBarMenuListGroup } from './menu-list-group'
+
+import type { ComponentProps } from 'react'
+import { SideBarSubmenu } from '../submenu'
+
+interface SideBarMenuListProps extends ComponentProps<typeof ElSideBarMenuList> {}
+
+/**
+ * Main menu list for the `SideBar`. Typically provided a collection of `SideBar.MenuItem` and `SideBar.MenuGroup`
+ * components as children.
+ */
+export function SideBarMenuList({ children, ...props }: SideBarMenuListProps) {
+  return <ElSideBarMenuList {...props}>{children}</ElSideBarMenuList>
+}
+
+SideBarMenuList.Item = SideBarMenuListItem
+SideBarMenuList.Group = SideBarMenuListGroup
+SideBarMenuList.GroupSummary = SideBarMenuListGroup.Summary
+SideBarMenuList.Submenu = SideBarSubmenu
+SideBarMenuList.SubmenuItem = SideBarSubmenu.Item

--- a/src/components/side-bar/menu-list/styles.ts
+++ b/src/components/side-bar/menu-list/styles.ts
@@ -1,0 +1,17 @@
+import { styled } from '@linaria/react'
+
+export const ElSideBarMenuList = styled.ul`
+  list-style: none;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding-block-end: var(--spacing-2);
+  width: 100%;
+
+  container-type: inline-size;
+`
+
+export const ElSideBarMenuListItem = styled.li`
+  display: block;
+`


### PR DESCRIPTION
### Context
- We somehow managed to use component names that don't match what Design are using 🤦 ;
- There's some styles that aren't quite right (e.g. focus outline, SideBar doesn't fill vertical space);
- The components are consistently available via SideBar itself (i.e. inconsistent application of the compound component pattern);
- State management is a little buggy (e.g. an active menu group can be collapsed)

### Scope
- Refactor component names/responsibilities to match Design
- Fix up styles to ensure correct visual behaviour
- Apply compound component pattern consistently
- Fix bugs in state management
- Improve Storybook documentation for all the components involved in the SideBar

### Preceding PRs
- #450 
- #451 
- #452 
- #453 

### This PR

- Adds a new `SideBarMenuList` component. This is primary child of the side bar and includes subcomponents for `SideBarMenuList.Item`, `SideBarMenuList.Group` and `SideBarMenuList.GroupSummary`.

<img width="1083" alt="Screenshot 2025-05-29 at 1 05 55 pm" src="https://github.com/user-attachments/assets/3252de8e-ae61-48fc-bce1-eb208746bed4" />
<img width="1083" alt="Screenshot 2025-05-29 at 1 06 06 pm" src="https://github.com/user-attachments/assets/871e1e51-b114-4da2-809f-8a04ada65480" />
<img width="1082" alt="Screenshot 2025-05-29 at 1 06 16 pm" src="https://github.com/user-attachments/assets/84684440-8674-4d0e-8513-a68798b94a04" />
<img width="1082" alt="Screenshot 2025-05-29 at 1 06 25 pm" src="https://github.com/user-attachments/assets/f63e89ac-e6d1-4da3-b935-96f7483685e3" />
