### PR TITLE
feat: #468 Allow SideBar.MenuGroup to be forced active

### DIFF
--- a/src/components/side-bar/menu-group/__test__/menu-group-summary.test.tsx
+++ b/src/components/side-bar/menu-group/__test__/menu-group-summary.test.tsx
@@ -94,6 +94,23 @@ test('prevents default action for click events if the menu group contains a link
   await expect(screen.findByRole('group')).resolves.toBeVisible()
 })
 
+test('prevents default action for click events if the menu group is marked as active', async () => {
+  render(
+    <details data-is-active="true" open>
+      <SideBarMenuGroupSummary icon="😎">Item</SideBarMenuGroupSummary>
+      <a href="/" aria-current="page">
+        Link
+      </a>
+    </details>,
+    { wrapper },
+  )
+  const summaryText = screen.getByText('Item')
+  fireEvent.click(summaryText)
+
+  // If the event was NOT prevented, the <details> element would be closed and thus not visible
+  await expect(screen.findByRole('group')).resolves.toBeVisible()
+})
+
 test('allows default action for click events if the menu group does NOT contain a link for the current page', async () => {
   render(
     <details open>

--- a/src/components/side-bar/menu-group/__test__/use-menu-group-controller.test.tsx
+++ b/src/components/side-bar/menu-group/__test__/use-menu-group-controller.test.tsx
@@ -89,6 +89,37 @@ test('`<details>` is closed when a descendant no longer represents the current p
   await waitFor(() => expect(screen.getByRole('group')).not.toBeVisible())
 })
 
+test('`<details>` is opened when it becomes active', async () => {
+  const { rerender } = render(
+    // NOTE: the `open` attribute is absent when we first render
+    <Details sideBarState="expanded" />,
+  )
+  expect(screen.getByRole('group')).not.toBeVisible()
+
+  rerender(
+    // NOTE: the `open` attribute is still absent when we rerender, but we expect the <details> element to be
+    // opened by our useSideBarMenuGroupController because the <details> element is marked as active
+    <Details data-is-active="true" sideBarState="expanded" />,
+  )
+  await waitFor(() => expect(screen.getByRole('group')).toBeVisible())
+})
+
+test('`<details>` is closed when it is no longer active', async () => {
+  const { rerender } = render(
+    // NOTE: the `open` attribute is present when we first render
+    <Details data-is-active="true" open sideBarState="expanded" />,
+  )
+  expect(screen.getByRole('group')).toBeVisible()
+
+  rerender(
+    // NOTE: the `open` attribute is still present when we rerender, but we expect the <details> element to be
+    // closed by our useSideBarMenuGroupController because the <details> element is no longer marked as active
+    // current page
+    <Details open sideBarState="expanded" />,
+  )
+  await waitFor(() => expect(screen.getByRole('group')).not.toBeVisible())
+})
+
 interface DetailsProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
   sideBarState: SideBarState
 }

--- a/src/components/side-bar/menu-group/menu-group-summary.tsx
+++ b/src/components/side-bar/menu-group/menu-group-summary.tsx
@@ -7,12 +7,12 @@ import {
   ElSideBarMenuGroupSummaryDropdownIcon,
 } from './styles'
 import { elSideBarMenuItem } from '../menu-item'
-import { elSideBarSubmenuItem } from '../submenu-item'
 import { Icon } from '../../icon'
 import { useCallback } from 'react'
 import { useSideBarMenuGroupLabelIdContext } from './menu-group-label-id-context'
 
 import type { HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+import { shouldBeOpen } from './should-be-open'
 
 interface SideBarMenuGroupSummaryProps extends HTMLAttributes<HTMLElement> {
   /**
@@ -52,9 +52,8 @@ export function SideBarMenuGroupSummary({
       onClick?.(event)
 
       const detailsElement = event.currentTarget.closest(`details.${elSideBarMenuGroup}`)
-      const hasCurrentPageElement = !!detailsElement?.querySelector(`.${elSideBarSubmenuItem}[aria-current="page"]`)
 
-      if (hasCurrentPageElement) {
+      if (detailsElement instanceof HTMLDetailsElement && shouldBeOpen(detailsElement)) {
         event.preventDefault()
       }
     },

--- a/src/components/side-bar/menu-group/menu-group.stories.tsx
+++ b/src/components/side-bar/menu-group/menu-group.stories.tsx
@@ -57,8 +57,8 @@ type Story = StoryObj<typeof meta>
 export const Example: Story = {
   args: {
     children: 'No selected item',
+    isActive: false,
     summary: <SideBarMenuGroup.Summary icon={<Icon icon="property" />}>Menu group</SideBarMenuGroup.Summary>,
-    open: false,
   },
 }
 
@@ -108,4 +108,15 @@ export const SelectedAndCollapsed = {
     ...Collapsed.parameters,
   },
   storyName: 'Selected and collapsed',
+}
+
+/**
+ * When a menu group needs to be open and visually active but no submenu item within a group can be uniquely identified
+ * as representing the current page, the group can be forced open via the `isActive` prop.
+ */
+export const ManuallyActive: Story = {
+  args: {
+    ...Example.args,
+    isActive: true,
+  },
 }

--- a/src/components/side-bar/menu-group/menu-group.tsx
+++ b/src/components/side-bar/menu-group/menu-group.tsx
@@ -14,6 +14,16 @@ export interface SideBarMenuGroupProps extends DetailsHTMLAttributes<HTMLDetails
    */
   children: ReactNode
   /**
+   * Allows consumers to "force" the menu group to be active in scenarios where it does not have a submenu item
+   * that represents the current page. Typically, this should not be necessary, but it can be a useful escape hatch
+   * when dealing with pages that, from an Information Architecture (IA) perspective, are part of a menu group,
+   * but where no submenu items can be uniquely marked as representing current page.
+   *
+   * Being active means the menu group will be open (except when the `SideBar` is collapsed). However, being `open`
+   * does not mean the menu group is active.
+   */
+  isActive?: boolean
+  /**
    * Indicates whether the menu group's contents---that is, the submenu of items---are currently visible.
    *
    * Typically, the open state of menu groups can remain uncontrolled. If this state is controlled, it is important
@@ -45,6 +55,7 @@ export function SideBarMenuGroup({
   'aria-labelledby': ariaLabelledBy,
   children,
   className,
+  isActive,
   summary,
   ...rest
 }: SideBarMenuGroupProps) {
@@ -52,7 +63,13 @@ export function SideBarMenuGroup({
   const sideBar = useSideBarContext()
   const ref = useSideBarMenuGroupController(sideBar.state)
   return (
-    <details {...rest} className={cx(elSideBarMenuGroup, className)} aria-labelledby={labelId} ref={ref}>
+    <details
+      {...rest}
+      aria-labelledby={labelId}
+      className={cx(elSideBarMenuGroup, className)}
+      data-is-active={isActive}
+      ref={ref}
+    >
       <SideBarMenuGroupLabelIdContext.Provider value={labelId}>{summary}</SideBarMenuGroupLabelIdContext.Provider>
       {children}
     </details>

--- a/src/components/side-bar/menu-group/should-be-open.ts
+++ b/src/components/side-bar/menu-group/should-be-open.ts
@@ -1,0 +1,14 @@
+export function shouldBeOpen(detailsElement: HTMLDetailsElement): boolean {
+  // If the details element is active or has a descendant representing the current page, it should be open.
+  return isActive(detailsElement) || hasCurrentPageElement(detailsElement)
+}
+
+/** Returns true if data-is-active="true" attribute is present  */
+function isActive(detailsElement: HTMLDetailsElement): boolean {
+  return detailsElement.dataset.isActive === 'true'
+}
+
+/** Returns true if a descendant represents the current page  */
+function hasCurrentPageElement(detailsElement: HTMLDetailsElement): boolean {
+  return !!detailsElement.querySelector('[aria-current="page"]')
+}

--- a/src/components/side-bar/menu-group/styles.ts
+++ b/src/components/side-bar/menu-group/styles.ts
@@ -9,6 +9,7 @@ export const elSideBarMenuGroup = css`
 
   &:open,
   &[open],
+  &[data-is-active='true'],
   &:has([aria-current='page']) {
     background: var(--comp-navigation-colour-fill-sidebar-select);
   }
@@ -24,13 +25,13 @@ export const elSideBarMenuGroupSummary = css`
 `
 
 export const ElSideBarMenuGroupSummaryIcon = styled(ElSideBarMenuItemIcon)`
-  details:has([aria-current='page']) & {
+  :where(details[data-is-active='true'], details:has([aria-current='page'])) & {
     color: var(--comp-navigation-colour-icon-sidebar-select);
   }
 `
 
 export const ElSideBarMenuGroupSummaryLabel = styled(ElSideBarMenuItemLabel)`
-  details:has([aria-current='page']) & {
+  :where(details[data-is-active='true'], details:has([aria-current='page'])) & {
     color: var(--comp-navigation-colour-text-sidebar-select);
     font-weight: var(--font-weight-medium);
   }


### PR DESCRIPTION
### Context

- With the SideBar, there are use-cases in existing products that require menu groups to be marked as active without them containing a submenu item that represents the current page.

### This PR

- Adds an escape hatch to the menu group component that allows consumers to "force" it to be considered active.
- Updates `useSideBarMenuGroupController` to be aware of this "forced active" state, as it needs to ensure it opens/closes the underlying `<details>` element when this state changes.
- Updates `SideBar.MenuGroupSummary` to be aware of this "forced active" state as well, as it needs to ensure it prevents the default click action if it's parent menu group is active.