### PR TITLE
fix: #470 top bar secondary nav applies correct display CSS property

### DIFF
--- a/src/components/top-bar/styles.ts
+++ b/src/components/top-bar/styles.ts
@@ -56,7 +56,7 @@ export const ElTopBarSecondaryNavContainer = styled(ElButtonGroup)`
 
   display: none;
   ${isWideScreen} {
-    display: block;
+    display: flex;
   }
 `
 

--- a/src/components/top-bar/top-bar.stories.tsx
+++ b/src/components/top-bar/top-bar.stories.tsx
@@ -119,7 +119,18 @@ export default {
         None: null,
         Some: (
           <>
-            <NavIconItem aria-label="secondary nav item example" icon={<Icon icon="star" />} />
+            <Menu>
+              <Menu.Trigger>
+                {({ getTriggerProps }) => <NavIconItem {...getTriggerProps()} icon={<Icon icon="star" />} />}
+              </Menu.Trigger>
+              <Menu.Popover>
+                <Menu.List>
+                  <Menu.Item label="Menu item 1" />
+                  <Menu.Item label="Menu item 2" />
+                  <Menu.Item label="Menu item 3" />
+                </Menu.List>
+              </Menu.Popover>
+            </Menu>
             <NavIconItem aria-label="secondary nav item example" icon={<Icon icon="star" />} />
             <NavIconItem aria-label="secondary nav item example" icon={<Icon icon="star" />} />
           </>
@@ -127,7 +138,7 @@ export default {
       },
     },
   },
-} as Meta<typeof TopBar>
+} satisfies Meta<typeof TopBar>
 
 type Story = StoryObj<typeof TopBar>
 


### PR DESCRIPTION
fixes: #470 

We were applying the wrong `display` property for the top bar's secondary nav when the screen size is widescreen or above. The secondary nav is a button group, which relies on a `flex` layout, but the secondary nav's media query styles were changing the display property to `block` 🤦 

