### PR TITLE
fix: #474 `SideBar` list elements no longer impacted by user-agent styles

### DIFF
--- a/src/components/side-bar/menu-list/styles.ts
+++ b/src/components/side-bar/menu-list/styles.ts
@@ -6,6 +6,8 @@ export const ElSideBarMenuList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
+  margin-block: 0;
+  padding-inline: 0;
   padding-block-end: var(--spacing-2);
   width: 100%;
 

--- a/src/components/side-bar/submenu/styles.ts
+++ b/src/components/side-bar/submenu/styles.ts
@@ -6,6 +6,8 @@ export const ElSideBarSubmenuList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
+  margin-block: 0;
+  padding-inline: 0;
   padding-block-end: var(--spacing-2);
 `
 

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,8 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.30 - 06/06/25**
 
-- Fix: `TopBar` secondary nav now applies correct `display` CSS property for widescreen or larger breakpoints
+- fix: `TopBar` secondary nav now applies correct `display` CSS property for widescreen or larger breakpoints
+- fix: Prevent `SideBar.MenuList` and `SideBar.Submenu` list elements from being impacted by user-agent applied padding and margin styles
 
 ### **5.0.0-beta.29 - 05/06/25**
 


### PR DESCRIPTION
fixes: #474

**note:** I have no idea why these user agent styles don't surface in Storybook. When I inspect the side bar list elements in Storybook, the same user agent styles are being applied, but they seem to be having no effect 🤷 Will need to dig into this later I think.