### PR TITLE
feat: #476 Use CSS container queries in `TopBar` and `NavSearchButton`

### DIFF
--- a/src/components/nav-search-button/__tests__/__snapshots__/nav-search-button.test.tsx.snap
+++ b/src/components/nav-search-button/__tests__/__snapshots__/nav-search-button.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`NavSearchButton > render without shortcut and match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-5 el-nav-search-button-container"
+    class="mocked-styled-3 el-nav-search-button-container"
   >
     <button
       aria-label="Search"
-      class="mocked-styled-3 el-nav-search-icon-item el-button-nav-icon-item"
+      class="mocked-styled-4 el-nav-search-icon-item el-button-nav-icon-item"
     >
       <span
         class="mocked-styled-9 el-icon"
@@ -29,7 +29,7 @@ exports[`NavSearchButton > render without shortcut and match snapshot 1`] = `
       </span>
     </button>
     <button
-      class="mocked-styled-4 el-nav-search-button"
+      class="mocked-styled-5 el-nav-search-button"
       type="button"
     >
       <svg
@@ -59,11 +59,11 @@ exports[`NavSearchButton > render without shortcut and match snapshot 1`] = `
 exports[`NavSearchButton > should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-5 el-nav-search-button-container"
+    class="mocked-styled-3 el-nav-search-button-container"
   >
     <button
       aria-label="Search"
-      class="mocked-styled-3 el-nav-search-icon-item el-button-nav-icon-item"
+      class="mocked-styled-4 el-nav-search-icon-item el-button-nav-icon-item"
     >
       <span
         class="mocked-styled-9 el-icon"
@@ -85,7 +85,7 @@ exports[`NavSearchButton > should match snapshot 1`] = `
       </span>
     </button>
     <button
-      class="mocked-styled-4 el-nav-search-button"
+      class="mocked-styled-5 el-nav-search-button"
       type="button"
     >
       <svg

--- a/src/components/nav-search-button/styles.ts
+++ b/src/components/nav-search-button/styles.ts
@@ -3,9 +3,23 @@ import SearchIcon from './icons/search-icon.svg?react'
 import { isTablet } from '#src/styles/media'
 import { NavIconItem } from '../nav-icon-item'
 
+export const ElNavSearchButtonContainer = styled.div`
+  width: 100%;
+  container-name: nav-search-button-container;
+  container-type: inline-size;
+`
+
 export const ElNavSearchIconItem = styled(NavIconItem)`
-  ${isTablet} {
-    display: none;
+  @supports not (container: inline-size) {
+    ${isTablet} {
+      display: none;
+    }
+  }
+
+  @supports (container: inline-size) {
+    @container nav-search-button-container (width >= 150px) {
+      display: none;
+    }
   }
 `
 
@@ -14,8 +28,10 @@ export const ElNavSearchButton = styled.button`
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  max-width: 200px;
   padding: var(--spacing-2);
   gap: var(--spacing-2);
+
   border-radius: var(--comp-navigation-border-radius-nav_search);
   background: var(--comp-navigation-colour-fill-nav_search-default);
 
@@ -31,12 +47,18 @@ export const ElNavSearchButton = styled.button`
   outline: none;
 
   display: none;
-  ${isTablet} {
-    display: flex;
+  @supports not (container: inline-size) {
+    ${isTablet} {
+      display: flex;
+    }
+  }
+
+  @supports (container: inline-size) {
+    @container nav-search-button-container (width >= 150px) {
+      display: flex;
+    }
   }
 `
-
-export const ElNavSearchButtonContainer = styled.div``
 
 export const ElNavSearchButtonIcon = styled(SearchIcon)`
   width: var(--icon-sm);
@@ -68,4 +90,10 @@ export const ElNavSearchButtonShortcutText = styled.span`
   font-weight: var(--font-2xs-medium-weight);
   line-height: var(--font-2xs-medium-line_height);
   letter-spacing: var(--font-2xs-medium-letter_spacing);
+
+  @supports (container: inline-size) {
+    @container nav-search-button-container (width < 150px) {
+      display: none;
+    }
+  }
 `

--- a/src/components/top-bar/__test__/__snapshots__/top-bar.test.tsx.snap
+++ b/src/components/top-bar/__test__/__snapshots__/top-bar.test.tsx.snap
@@ -3,20 +3,20 @@
 exports[`TopBar snapshot 1`] = `
 <DocumentFragment>
   <nav
-    class="mocked-styled-6 el-top-bar"
+    class="mocked-styled-1 el-top-bar"
   >
     <div
-      class="mocked-styled-1 el-top-bar-app-switcher-container"
+      class="mocked-styled-2 el-top-bar-app-switcher-container"
     >
       App switcher
     </div>
     <div
-      class="mocked-styled-2 el-top-bar-logo-container"
+      class="mocked-styled-3 el-top-bar-logo-container"
     >
       Logo
     </div>
     <div
-      class="mocked-styled-4 el-button-group el-top-bar-main-nav-container el-button-group"
+      class="mocked-styled-5 el-button-group el-top-bar-main-nav-container el-button-group"
     >
       Main nav
     </div>
@@ -26,7 +26,7 @@ exports[`TopBar snapshot 1`] = `
       Search
     </div>
     <div
-      class="mocked-styled-5 el-button-group el-top-bar-secondary-nav-container el-button-group"
+      class="mocked-styled-6 el-button-group el-top-bar-secondary-nav-container el-button-group"
     >
       Secondary nav
     </div>
@@ -36,7 +36,7 @@ exports[`TopBar snapshot 1`] = `
       Mobile nav
     </div>
     <div
-      class="mocked-styled-3 el-top-bar-avatar-container"
+      class="mocked-styled-4 el-top-bar-avatar-container"
     >
       Profile
     </div>

--- a/src/components/top-bar/styles.ts
+++ b/src/components/top-bar/styles.ts
@@ -3,16 +3,53 @@ import { isTablet, isDesktop, isWideScreen } from '../../styles/media'
 import { ElButtonGroup } from '../button-group'
 import { css } from '@linaria/core'
 
+export const ElTopBar = styled.nav`
+  display: grid;
+  align-items: center;
+  grid-template-areas: 'app-switcher logo main-nav search secondary-nav mobile-nav profile';
+  grid-template-columns: min-content min-content 1fr auto auto auto auto;
+  height: var(--size-14);
+  width: 100%;
+
+  container-name: top-bar;
+  container-type: inline-size;
+
+  padding-block: var(--spacing-2);
+  padding-inline: var(--spacing-4) var(--spacing-2);
+  ${isTablet} {
+    padding-inline: var(--spacing-4);
+  }
+  ${isWideScreen} {
+    padding-inline: var(--spacing-5);
+  }
+
+  border-bottom: var(--comp-navigation-border-width-top_bar) solid var(--comp-navigation-colour-border-top_bar);
+  background: var(--comp-navigation-colour-fill-top_bar);
+`
+
 export const ElTopBarAppSwitcherContainer = styled.div`
   grid-area: app-switcher;
 
   display: none;
   padding-inline-end: var(--spacing-4);
-  ${isTablet} {
-    display: block;
+  @supports not (container: inline-size) {
+    ${isTablet} {
+      display: block;
+    }
+    ${isWideScreen} {
+      padding-inline-end: var(--spacing-5);
+    }
   }
-  ${isWideScreen} {
-    padding-inline-end: var(--spacing-5);
+
+  @supports (container: inline-size) {
+    /* isTablet equivalent inline size; i.e. 768px - 2 * var(--spacing-4) */
+    @container top-bar (width >= 736px) {
+      display: block;
+    }
+    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
+    @container top-bar (width >= 1400px) {
+      padding-inline-end: var(--spacing-5);
+    }
   }
 `
 
@@ -29,8 +66,18 @@ export const ElTopBarAvatarContainer = styled.div`
   padding-block: var(--spacing-1);
 
   display: none;
-  ${isDesktop} {
-    display: flex;
+
+  @supports not (container: inline-size) {
+    ${isDesktop} {
+      display: flex;
+    }
+  }
+
+  @supports (container: inline-size) {
+    /* isDesktop equivalent inline size; i.e. 1024px - 2 * var(--spacing-4) */
+    @container top-bar (width >= 992px) {
+      display: flex;
+    }
   }
 `
 
@@ -41,11 +88,22 @@ export const ElTopBarMainNavContainer = styled(ElButtonGroup)`
   width: 100%;
 
   display: none;
-  ${isWideScreen} {
-    display: flex;
+
+  @supports not (container: inline-size) {
+    ${isWideScreen} {
+      display: flex;
+    }
+  }
+
+  @supports (container: inline-size) {
+    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
+    @container top-bar (width >= 1400px) {
+      display: flex;
+    }
   }
 
   /* Required to enable individual nav items to be displayed (or not) using container queries */
+  container-name: top-bar-main-nav-container;
   container-type: inline-size;
 `
 
@@ -55,40 +113,43 @@ export const ElTopBarSecondaryNavContainer = styled(ElButtonGroup)`
   padding-right: var(--spacing-2);
 
   display: none;
-  ${isWideScreen} {
-    display: flex;
-  }
-`
 
-export const ElTopBar = styled.nav`
-  display: grid;
-  align-items: center;
-  grid-template-areas: 'app-switcher logo main-nav search secondary-nav mobile-nav profile';
-  grid-template-columns: min-content min-content 1fr auto auto auto auto;
-  height: var(--size-14);
-
-  padding-block: var(--spacing-2);
-  padding-inline: var(--spacing-4) var(--spacing-2);
-  ${isTablet} {
-    padding-inline: var(--spacing-4);
-  }
-  ${isWideScreen} {
-    padding-inline: var(--spacing-5);
+  @supports not (container: inline-size) {
+    ${isWideScreen} {
+      display: flex;
+    }
   }
 
-  border-bottom: var(--comp-navigation-border-width-top_bar) solid var(--comp-navigation-colour-border-top_bar);
-  background: var(--comp-navigation-colour-fill-top_bar);
+  @supports (container: inline-size) {
+    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
+    @container top-bar (width >= 1400px) {
+      display: flex;
+    }
+  }
 `
 
 export const ElTopBarSearchContainer = styled.div`
   grid-area: search;
 
   width: var(--size-12);
-  padding-inline: 0 var(--spacing-2);
-  ${isTablet} {
-    width: var(--size-52);
-    padding-block: var(--spacing-1);
-    padding-inline-end: var(--spacing-4);
+  padding-block: var(--spacing-none);
+  padding-inline-end: var(--spacing-2);
+
+  @supports not (container: inline-size) {
+    ${isTablet} {
+      width: 216px;
+      padding-block: var(--spacing-1);
+      padding-inline-end: var(--spacing-4);
+    }
+  }
+
+  @supports (container: inline-size) {
+    /* isTablet equivalent inline size; i.e. 768px - 2 * var(--spacing-4) */
+    @container top-bar (width >= 736px) {
+      width: 216px;
+      padding-block: var(--spacing-1);
+      padding-inline-end: var(--spacing-4);
+    }
   }
 `
 
@@ -97,11 +158,25 @@ export const ElTopBarMenuContainer = styled.div`
 
   display: block;
   padding-inline-end: 0;
-  ${isDesktop} {
-    padding-inline-end: var(--spacing-2);
+
+  @supports not (container: inline-size) {
+    ${isDesktop} {
+      padding-inline-end: var(--spacing-2);
+    }
+    ${isWideScreen} {
+      display: none;
+    }
   }
-  ${isWideScreen} {
-    display: none;
+
+  @supports (container: inline-size) {
+    /* isDesktop equivalent inline size; i.e. 1024px - 2 * var(--spacing-4) */
+    @container top-bar (width >= 992px) {
+      padding-inline-end: var(--spacing-2);
+    }
+    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
+    @container top-bar (width >= 1400px) {
+      display: none;
+    }
   }
 `
 

--- a/src/components/top-bar/top-bar.stories.tsx
+++ b/src/components/top-bar/top-bar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
 import { AvatarButton } from '../avatar-button'
 import { elIcon } from '../button'
 import { CSSContainerQuery } from '../container-query/container-query'
@@ -12,7 +12,7 @@ import { ReapitLogo } from '../reapit-logo'
 import MenuIcon from './icons/menu-icon.svg?react'
 import { elTopBarMenuPopover } from './styles'
 import { TopBar } from './top-bar'
-import { elNewTopBarAppSwitcher, NavResponsiveAppSwitcher } from '../deprecated-nav'
+import { AppSwitcher } from '../app-switcher'
 
 export default {
   title: 'Components/TopBar',
@@ -23,20 +23,27 @@ export default {
       options: ['None', 'Legacy App Switcher'],
       mapping: {
         None: null,
-        'Legacy App Switcher': (
-          <NavResponsiveAppSwitcher
-            className={elNewTopBarAppSwitcher}
-            options={[
-              {
-                text: 'AppMarket',
-                callback: console.log,
-              },
-              {
-                text: 'DevPortal',
-                callback: console.log,
-              },
-            ]}
-          />
+        'App Switcher': (
+          <AppSwitcher>
+            <AppSwitcher.YourAppsMenuGroup>
+              {AppSwitcher.getDisplayableProductsForYourAppsGroup(['consoleCloud']).map((productId) => (
+                <AppSwitcher.ProductMenuItem
+                  key={productId}
+                  href={globalThis.top?.location.href!}
+                  productId={productId}
+                />
+              ))}
+            </AppSwitcher.YourAppsMenuGroup>
+            <AppSwitcher.ExploreMenuGroup>
+              {AppSwitcher.getDisplayableProductsForExploreGroup(['consoleCloud']).map((productId) => (
+                <AppSwitcher.ProductMenuItem
+                  key={productId}
+                  href={globalThis.top?.location.href!}
+                  productId={productId}
+                />
+              ))}
+            </AppSwitcher.ExploreMenuGroup>
+          </AppSwitcher>
         ),
       },
     },
@@ -138,13 +145,34 @@ export default {
       },
     },
   },
+  parameters: {
+    backgrounds: { default: 'light' },
+  },
 } satisfies Meta<typeof TopBar>
 
 type Story = StoryObj<typeof TopBar>
 
+function useConstrainedWidthDecorator(width: string): Decorator {
+  return (Story) => (
+    <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width }}>
+      <Story />
+    </div>
+  )
+}
+
+/**
+ * The Top Bar is responsive to viewport size and will automatically show or hide its various sections based on the
+ * available space. For browsers that support then, CSS container queries will be used by each section to determine
+ * whether it should be visible or not. For browsers that do not support container queries, this behaviour will fall
+ * back to relying on media queries.
+ *
+ * If viewing this story directly in Storybook, you can change the viewport size to see the responsive behaviour.
+ * Alternatively, if you're browser supports container queries, you can see the responsible behaviour in the stories
+ * further down.
+ */
 export const Example: Story = {
   args: {
-    appSwitcher: 'Legacy App Switcher',
+    appSwitcher: 'App Switcher',
     avatar: 'Avatar Menu',
     logo: <ReapitLogo />,
     mainNav: 'Many',
@@ -152,4 +180,57 @@ export const Example: Story = {
     search: <NavSearchButton onClick={() => void 0} />,
     secondaryNav: 'Some',
   },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '400px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+/**
+ * For viewports under 768px, very few of the Top Bar's sections will be visible. Most will have collapsed
+ * into the overflow menu, except for the product's "global" search entry point, if one is available.
+ */
+export const Mobile: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useConstrainedWidthDecorator('375px')],
+}
+
+/**
+ * For viewports under between 768px and 1024px, the App Switcher will be available directly in the Top Bar
+ * and the "global" search entry point have more space available to itself. The main navigation, secondary
+ * navigation, and user profile menu will still be collapsed into the overflow menu.
+ */
+export const Tablet: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useConstrainedWidthDecorator('768px')],
+}
+
+/**
+ * For viewports between 1024px and 1440px, the user's profile menu will become available directly in the Top Bar.
+ */
+export const Desktop: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useConstrainedWidthDecorator('1024px')],
+}
+
+/**
+ * For viewports 1440px and wider, the Top Bar will display all of its regions.
+ */
+export const WideScreen: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [useConstrainedWidthDecorator('1440px')],
 }

--- a/src/components/top-bar/top-bar.tsx
+++ b/src/components/top-bar/top-bar.tsx
@@ -12,15 +12,41 @@ import {
 import type { ComponentProps, ReactNode } from 'react'
 
 interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> {
+  /**
+   * Typically an `AppSwitcher` component.
+   */
   appSwitcher?: ReactNode
+  /**
+   * The user's profile menu. Typically an `AvatarButton`.
+   */
   avatar?: ReactNode
+  /**
+   * The product's logo.
+   */
   logo: ReactNode
+  /**
+   * The main navigation region, typically containing `NavItem`'s for the product's top-level pages.
+   */
   mainNav?: ReactNode
+  /**
+   * The overflow menu for all navigation items in the Top Bar. Usually, each section of the Top Bar will
+   * collapse into this menu as the viewport narrows.
+   */
   menu?: ReactNode
+  /**
+   * The "global" search entry point for the product. Typically a `NavSeachButton`.
+   */
   search?: ReactNode
+  /**
+   * The secondary navigation region, typically containing `NavIconItem`'s for the product's secondary pages.
+   */
   secondaryNav?: ReactNode
 }
 
+/**
+ * A responsive navigation bar that contains the product's app switcher, logo, main navigation, secondary navigation,
+ * search entry point, and user profile menu.
+ */
 export function TopBar({ appSwitcher, avatar, logo, mainNav, menu, search, secondaryNav, ...props }: TopBarProps) {
   return (
     <ElTopBar {...props}>

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -20,6 +20,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 - fix: `TopBar` secondary nav now applies correct `display` CSS property for widescreen or larger breakpoints
 - fix: Prevent `SideBar.MenuList` and `SideBar.Submenu` list elements from being impacted by user-agent applied padding and margin styles
+- feat: `TopBar` and `NavSearchButton` now use CSS container queries, when supported, for their responsive behaviour. Storybook docs also updated to demonstrate.
 
 ### **5.0.0-beta.29 - 05/06/25**
 


### PR DESCRIPTION
**fixes:** #476

Each of the `TopBar`'s sections will now primarily use container queries to determine whether they should display or not. This allows us to more easily document the responsive behaviour of the `TopBar` in Storybook. With this change, the `NavSearchButton` was also updated to use container queries for its responsive behaviour, though it's likely we'll separate this component into separate mobile and non-mobile components as the current implementation has some issues (see #477)

The new `TopBar` docs look like:

<img width="1191" alt="Screenshot 2025-06-06 at 10 41 55 am" src="https://github.com/user-attachments/assets/9d628bc3-61f7-4e56-a441-9bfb2e83a277" />
<img width="1191" alt="Screenshot 2025-06-06 at 10 42 03 am" src="https://github.com/user-attachments/assets/3b1e9de8-a65e-4fdc-a63f-06dbc01996e9" />
<img width="1192" alt="Screenshot 2025-06-06 at 10 42 11 am" src="https://github.com/user-attachments/assets/38e54e89-ad9d-4f25-9b36-94c6ba668687" />
<img width="1190" alt="Screenshot 2025-06-06 at 10 42 19 am" src="https://github.com/user-attachments/assets/32e1bfd3-b53b-46b7-b927-1c69016d5a87" />
<img width="1191" alt="Screenshot 2025-06-06 at 10 42 25 am" src="https://github.com/user-attachments/assets/a1856ad7-5d20-4f7d-b454-cb1e3fb3d146" />
