### PR TITLE
feat: #316 new Menu - add Menu Group's divider

### DIFF
--- a/src/components/app-switcher/explore-menu-group/__test__/__snapshots__/explore-menu-group.test.tsx.snap
+++ b/src/components/app-switcher/explore-menu-group/__test__/__snapshots__/explore-menu-group.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`renders AppSwitcherExploreMenuGroup properly 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-11 el-menu-item-group"
+    class="mocked-styled-10 el-menu-item-group"
     role="group"
   >
     <div
-      class="mocked-styled-10 el-menu-item-group-title"
+      class="mocked-styled-9 el-menu-item-group-title"
     >
       EXPLORE
     </div>
     <div
-      class="mocked-styled-12 el-menu-item-group-list"
+      class="mocked-styled-11 el-menu-item-group-list"
       style="max-height: var(undefined);"
     >
       Fake child

--- a/src/components/app-switcher/your-apps-menu-group/__test__/__snapshots__/your-apps-menu-group.test.tsx.snap
+++ b/src/components/app-switcher/your-apps-menu-group/__test__/__snapshots__/your-apps-menu-group.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`renders AppSwitcherYourAppsMenuGroup properly 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-11 el-menu-item-group"
+    class="mocked-styled-10 el-menu-item-group"
     role="group"
   >
     <div
-      class="mocked-styled-10 el-menu-item-group-title"
+      class="mocked-styled-9 el-menu-item-group-title"
     >
       YOUR APPS
     </div>
     <div
-      class="mocked-styled-12 el-menu-item-group-list"
+      class="mocked-styled-11 el-menu-item-group-list"
       style="max-height: var(undefined);"
     >
       Fake child

--- a/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu-popover.test.tsx.snap
@@ -18,19 +18,19 @@ exports[`Menu Popover component > should render and close Popover based on any e
       style="top: 4px;"
     >
       <div
-        class="mocked-styled-5 el-menu-list"
+        class="mocked-styled-12 el-menu-list"
         data-has-max-width="false"
         role="menu"
         style="max-width: var(undefined); max-height: var(undefined);"
       >
         <button
-          class="mocked-styled-8 el-menu-item-button"
+          class="mocked-styled-7 el-menu-item-button"
           data-close-menu="true"
           role="menuitem"
           tabindex="0"
         >
           <div
-            class="mocked-styled-6 el-menu-item-content"
+            class="mocked-styled-5 el-menu-item-content"
           >
             <span
               class="mocked-styled-3 el-menu-item-label-container"
@@ -44,13 +44,13 @@ exports[`Menu Popover component > should render and close Popover based on any e
           </div>
         </button>
         <button
-          class="mocked-styled-8 el-menu-item-button"
+          class="mocked-styled-7 el-menu-item-button"
           data-close-menu="false"
           role="menuitem"
           tabindex="0"
         >
           <div
-            class="mocked-styled-6 el-menu-item-content"
+            class="mocked-styled-5 el-menu-item-content"
           >
             <span
               class="mocked-styled-3 el-menu-item-label-container"

--- a/src/components/menu/__tests__/__snapshots__/menu.molecules.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.molecules.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuItem component > should render with complete features enabled and match snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="mocked-styled-8 el-menu-item-button"
+    class="mocked-styled-7 el-menu-item-button"
     data-close-menu="false"
     role="menuitem"
     tabindex="0"
@@ -16,7 +16,7 @@ exports[`MenuItem component > should render with complete features enabled and m
       </span>
     </div>
     <div
-      class="mocked-styled-6 el-menu-item-content"
+      class="mocked-styled-5 el-menu-item-content"
     >
       <span
         class="mocked-styled-3 el-menu-item-label-container"
@@ -37,7 +37,7 @@ exports[`MenuItem component > should render with complete features enabled and m
       </span>
     </div>
     <div
-      class="mocked-styled-7 el-menu-item-icon"
+      class="mocked-styled-6 el-menu-item-icon"
     >
       <span>
         Right Icon
@@ -50,13 +50,13 @@ exports[`MenuItem component > should render with complete features enabled and m
 exports[`MenuItem component > should render with required props and match snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="mocked-styled-8 el-menu-item-button"
+    class="mocked-styled-7 el-menu-item-button"
     data-close-menu="true"
     role="menuitem"
     tabindex="0"
   >
     <div
-      class="mocked-styled-6 el-menu-item-content"
+      class="mocked-styled-5 el-menu-item-content"
     >
       <span
         class="mocked-styled-3 el-menu-item-label-container"

--- a/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/menu.test.tsx.snap
@@ -6,32 +6,32 @@ exports[`Menu list component > should render menu with list components and match
     class="mocked-styled-1 el-menu"
   >
     <div
-      class="mocked-styled-5 el-menu-list"
+      class="mocked-styled-12 el-menu-list"
       data-has-max-width="false"
       role="menu"
       style="max-width: var(undefined); max-height: var(undefined);"
     >
       <div
-        class="mocked-styled-11 el-menu-item-group"
+        class="mocked-styled-10 el-menu-item-group"
         role="group"
       >
         <div
-          class="mocked-styled-10 el-menu-item-group-title"
+          class="mocked-styled-9 el-menu-item-group-title"
         >
           Group Title
         </div>
         <div
-          class="mocked-styled-12 el-menu-item-group-list"
+          class="mocked-styled-11 el-menu-item-group-list"
           style="max-height: var(undefined);"
         >
           <a
-            class="mocked-styled-9 el-menu-item-anchor"
+            class="mocked-styled-8 el-menu-item-anchor"
             data-close-menu="true"
             href="/#"
             role="menuitem"
           >
             <div
-              class="mocked-styled-6 el-menu-item-content"
+              class="mocked-styled-5 el-menu-item-content"
             >
               <span
                 class="mocked-styled-3 el-menu-item-label-container"
@@ -45,13 +45,13 @@ exports[`Menu list component > should render menu with list components and match
             </div>
           </a>
           <button
-            class="mocked-styled-8 el-menu-item-button"
+            class="mocked-styled-7 el-menu-item-button"
             data-close-menu="true"
             role="menuitem"
             tabindex="0"
           >
             <div
-              class="mocked-styled-6 el-menu-item-content"
+              class="mocked-styled-5 el-menu-item-content"
             >
               <span
                 class="mocked-styled-3 el-menu-item-label-container"

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -45,21 +45,6 @@ export const ElMenuItemLabel = styled.span`
   margin-right: var(--spacing-2);
 `
 
-export const ElMenuList = styled.div`
-  width: max-content;
-  padding: var(--spacing-2) var(--spacing-2);
-  border-radius: var(--corner-default);
-  background-color: var(--fill-white);
-  box-shadow: 0px 4px 16px 0px #222b3329;
-  overflow: auto;
-
-  &[data-has-max-width='true'] {
-    ${ElMenuItemLabel} {
-      white-space: normal;
-    }
-  }
-`
-
 export const ElMenuItemContent = styled.div`
   display: flex;
   align-items: flex-start;
@@ -172,11 +157,34 @@ export const ElMenuItemGroupTitle = styled.div`
   align-items: center;
   align-self: stretch;
 `
-export const ElMenuItemGroup = styled.div``
+export const ElMenuItemGroup = styled.div`
+  padding-inline: var(--spacing-2);
+`
 
 export const ElMenuItemGroupList = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   overflow: auto;
+`
+
+export const ElMenuList = styled.div`
+  width: max-content;
+  padding: var(--spacing-2) 0;
+  border-radius: var(--corner-default);
+  background-color: var(--fill-white);
+  box-shadow: 0px 4px 16px 0px #222b3329;
+  overflow: auto;
+
+  &[data-has-max-width='true'] {
+    ${ElMenuItemLabel} {
+      white-space: normal;
+    }
+  }
+
+  ${ElMenuItemGroup}:not(:last-child) {
+    border-bottom: 1px solid var(--comp-divider-colour-border-solid);
+    padding-bottom: var(--spacing-2);
+    margin-bottom: var(--spacing-2);
+  }
 `


### PR DESCRIPTION
## Context

As there is redesign in new v5 Menu #316 . this pr is to refactor existing meu based on a POC that has been discussed [here](https://github.com/reapit/elements/issues/316#issuecomment-2853782912) which focusing on adding divider to Menu.group

in this pr I choose the approach by adding a bottom border to `Menu.Group` (except last group, this way the consumer not needed to manually display e.g `<Divider />`.

let me know if its something that we avoid, and I'll update it, thanks.

# Pull request checklist
- [x] add bottom border to menu group as divider
 
**Detail as per issue below (required):**

![image](https://github.com/user-attachments/assets/fb1e01fa-7e27-4ece-8389-75377cd440db)




