### PR TITLE
chore: #477 fix up top bar nav search et al names

### DIFF
--- a/src/components/top-bar/nav-search-button/nav-search-button.stories.tsx
+++ b/src/components/top-bar/nav-search-button/nav-search-button.stories.tsx
@@ -1,10 +1,10 @@
-import { NavSearchButton } from './nav-search-button'
+import { TopBarNavSearchButton } from './nav-search-button'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
   title: 'Components/TopBar/NavSearchButton',
-  component: NavSearchButton,
+  component: TopBarNavSearchButton,
   argTypes: {
     onClick: {
       control: false,
@@ -13,7 +13,7 @@ const meta = {
       control: 'text',
     },
   },
-} satisfies Meta<typeof NavSearchButton>
+} satisfies Meta<typeof TopBarNavSearchButton>
 
 export default meta
 

--- a/src/components/top-bar/nav-search-button/nav-search-button.tsx
+++ b/src/components/top-bar/nav-search-button/nav-search-button.tsx
@@ -1,13 +1,13 @@
 import {
-  ElNavSearchButton,
-  ElNavSearchButtonIcon,
-  ElNavSearchButtonPlaceholder,
-  ElNavSearchButtonShortcutText,
+  ElTopBarNavSearchButton,
+  ElTopBarNavSearchButtonIcon,
+  ElTopBarNavSearchButtonPlaceholder,
+  ElTopBarNavSearchButtonShortcutText,
 } from './styles'
 
 import type { ComponentProps, MouseEventHandler, ReactNode } from 'react'
 
-export interface NavSearchButtonProps extends ComponentProps<typeof ElNavSearchButton> {
+interface TopBarNavSearchButtonProps extends ComponentProps<typeof ElTopBarNavSearchButton> {
   /**
    * Indicates the keyboard shortcut that has been implemented to activate this button. Should typically
    * be Ctrl+K or Meta+K depending on the platform used by the currently logged in user.
@@ -35,12 +35,14 @@ export interface NavSearchButtonProps extends ComponentProps<typeof ElNavSearchB
  * the search experience to be launched via a keyboard shortcut; usually `Ctrl+K` or `⌘K`. If so, the shortcut
  * should be displayed via the `shortcut` prop.
  */
-export function NavSearchButton({ shortcut, onClick, ...props }: NavSearchButtonProps) {
+export function TopBarNavSearchButton({ shortcut, onClick, ...props }: TopBarNavSearchButtonProps) {
   return (
-    <ElNavSearchButton {...props} onClick={onClick} type="button">
-      <ElNavSearchButtonIcon aria-hidden="true" />
-      <ElNavSearchButtonPlaceholder>Search</ElNavSearchButtonPlaceholder>
-      {shortcut && <ElNavSearchButtonShortcutText aria-hidden="true">{shortcut}</ElNavSearchButtonShortcutText>}
-    </ElNavSearchButton>
+    <ElTopBarNavSearchButton {...props} onClick={onClick} type="button">
+      <ElTopBarNavSearchButtonIcon aria-hidden="true" />
+      <ElTopBarNavSearchButtonPlaceholder>Search</ElTopBarNavSearchButtonPlaceholder>
+      {shortcut && (
+        <ElTopBarNavSearchButtonShortcutText aria-hidden="true">{shortcut}</ElTopBarNavSearchButtonShortcutText>
+      )}
+    </ElTopBarNavSearchButton>
   )
 }

--- a/src/components/top-bar/nav-search-button/styles.ts
+++ b/src/components/top-bar/nav-search-button/styles.ts
@@ -1,7 +1,7 @@
-import { styled } from '@linaria/react'
 import SearchIcon from './icons/search-icon.svg?react'
+import { styled } from '@linaria/react'
 
-export const ElNavSearchButton = styled.button`
+export const ElTopBarNavSearchButton = styled.button`
   cursor: pointer;
   display: flex;
   justify-content: space-between;
@@ -27,21 +27,17 @@ export const ElNavSearchButton = styled.button`
   outline: none;
 `
 
-export const ElNavSearchButtonIcon = styled(SearchIcon)`
+export const ElTopBarNavSearchButtonIcon = styled(SearchIcon)`
   width: var(--icon-sm);
   height: var(--icon-sm);
   flex-shrink: 0;
   color: var(--comp-navigation-colour-icon-nav_search);
 `
 
-const basePlaceholderStyle = `
+export const ElTopBarNavSearchButtonPlaceholder = styled.span`
   color: var(--comp-navigation-colour-text-nav_search-placeholder);
   font-family: var(--font-family);
   font-style: normal;
-`
-
-export const ElNavSearchButtonPlaceholder = styled.span`
-  ${basePlaceholderStyle}
   font-size: var(--font-xs-regular-size);
   font-weight: var(--font-xs-regular-weight);
   line-height: var(--font-xs-regular-line_height);
@@ -51,8 +47,10 @@ export const ElNavSearchButtonPlaceholder = styled.span`
   text-align: left;
 `
 
-export const ElNavSearchButtonShortcutText = styled.kbd`
-  ${basePlaceholderStyle}
+export const ElTopBarNavSearchButtonShortcutText = styled.kbd`
+  color: var(--comp-navigation-colour-text-nav_search-placeholder);
+  font-family: var(--font-family);
+  font-style: normal;
   font-size: var(--font-2xs-medium-size);
   font-weight: var(--font-2xs-medium-weight);
   line-height: var(--font-2xs-medium-line_height);

--- a/src/components/top-bar/nav-search-icon-item/nav-search-icon-item.stories.tsx
+++ b/src/components/top-bar/nav-search-icon-item/nav-search-icon-item.stories.tsx
@@ -1,11 +1,11 @@
-import { NavSearchIconItem } from './nav-search-icon-item'
+import { TopBarNavSearchIconItem } from './nav-search-icon-item'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
   title: 'Components/TopBar/NavSearchIconItem',
-  component: NavSearchIconItem,
-} satisfies Meta<typeof NavSearchIconItem>
+  component: TopBarNavSearchIconItem,
+} satisfies Meta<typeof TopBarNavSearchIconItem>
 
 export default meta
 

--- a/src/components/top-bar/nav-search-icon-item/nav-search-icon-item.tsx
+++ b/src/components/top-bar/nav-search-icon-item/nav-search-icon-item.tsx
@@ -3,7 +3,7 @@ import { NavIconItem } from '../../nav-icon-item'
 
 import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
 
-export interface NavSearchIconItemProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+export interface TopBarNavSearchIconItemProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   /**
    * A click handler that launches the product's search experience.
    */
@@ -14,7 +14,7 @@ export interface NavSearchIconItemProps extends Omit<ButtonHTMLAttributes<HTMLBu
  * A `NavIconItem` button used to launch the search experience for a product on mobile devices. It is designed
  * for use on mobile devices. For tablet devices and wider, `TopBar.NavSearchButton` should be used instead.
  */
-export function NavSearchIconItem({ 'aria-label': ariaLabel, onClick, ...rest }: NavSearchIconItemProps) {
+export function TopBarNavSearchIconItem({ 'aria-label': ariaLabel, onClick, ...rest }: TopBarNavSearchIconItemProps) {
   return (
     <NavIconItem
       {...rest}

--- a/src/components/top-bar/nav-search/__test__/nav-search.test.tsx
+++ b/src/components/top-bar/nav-search/__test__/nav-search.test.tsx
@@ -1,33 +1,33 @@
 import { render, screen } from '@testing-library/react'
-import { NavSearch } from '../nav-search'
+import { TopBarNavSearch } from '../nav-search'
 
 // IMPORTANT: React Testing Library does not support CSS container queries. This means we are not able
 // to adequately test this components CSS-based visibility logic for the button and icon item.
 
 test('renders button when provided', () => {
-  const button = <NavSearch.Button onClick={() => void 0} />
-  render(<NavSearch button={button} />)
+  const button = <TopBarNavSearch.Button onClick={() => void 0} />
+  render(<TopBarNavSearch button={button} />)
 
   expect(screen.getByRole('button')).toBeInTheDocument()
 })
 
 test('renders icon item when provided', () => {
-  const iconItem = <NavSearch.IconItem onClick={() => void 0} />
-  render(<NavSearch iconItem={iconItem} />)
+  const iconItem = <TopBarNavSearch.IconItem onClick={() => void 0} />
+  render(<TopBarNavSearch iconItem={iconItem} />)
 
   expect(screen.getByRole('button')).toBeInTheDocument()
 })
 
 test('renders both button and icon item when both are provided', () => {
-  const button = <NavSearch.Button onClick={() => void 0} />
-  const iconItem = <NavSearch.IconItem onClick={() => void 0} />
-  render(<NavSearch button={button} iconItem={iconItem} />)
+  const button = <TopBarNavSearch.Button onClick={() => void 0} />
+  const iconItem = <TopBarNavSearch.IconItem onClick={() => void 0} />
+  render(<TopBarNavSearch button={button} iconItem={iconItem} />)
 
   const buttons = screen.getAllByRole('button')
   expect(buttons).toHaveLength(2)
 })
 
 test('renders nothing when no button or icon item is provided', () => {
-  render(<NavSearch />)
+  render(<TopBarNavSearch />)
   expect(screen.queryByRole('button')).not.toBeInTheDocument()
 })

--- a/src/components/top-bar/nav-search/nav-search.stories.tsx
+++ b/src/components/top-bar/nav-search/nav-search.stories.tsx
@@ -1,10 +1,10 @@
-import { NavSearch } from './nav-search'
+import { TopBarNavSearch } from './nav-search'
 
 import type { Decorator, Meta, StoryObj } from '@storybook/react'
 
 const meta = {
   title: 'Components/TopBar/NavSearch',
-  component: NavSearch,
+  component: TopBarNavSearch,
   argTypes: {
     button: {
       control: false,
@@ -13,7 +13,7 @@ const meta = {
       control: false,
     },
   },
-} satisfies Meta<typeof NavSearch>
+} satisfies Meta<typeof TopBarNavSearch>
 
 export default meta
 
@@ -24,8 +24,8 @@ type Story = StoryObj<typeof meta>
  */
 export const Example: Story = {
   args: {
-    button: <NavSearch.Button onClick={() => void 0} />,
-    iconItem: <NavSearch.IconItem onClick={() => void 0} />,
+    button: <TopBarNavSearch.Button onClick={() => void 0} />,
+    iconItem: <TopBarNavSearch.IconItem onClick={() => void 0} />,
   },
   decorators: [useConstrainedWidthDecorator('150px')],
 }

--- a/src/components/top-bar/nav-search/nav-search.tsx
+++ b/src/components/top-bar/nav-search/nav-search.tsx
@@ -1,10 +1,10 @@
-import { ElNavSearch, ElNavSearchButtonContainer, ElNavSearchIconItemContainer } from './styles'
-import { NavSearchButton } from '../nav-search-button'
-import { NavSearchIconItem } from '../nav-search-icon-item'
+import { ElTopBarNavSearch, ElTopBarNavSearchButtonContainer, ElTopBarNavSearchIconItemContainer } from './styles'
+import { TopBarNavSearchButton } from '../nav-search-button'
+import { TopBarNavSearchIconItem } from '../nav-search-icon-item'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface NavSearchProps extends ComponentProps<typeof ElNavSearch> {
+interface TopBarNavSearchProps extends ComponentProps<typeof ElTopBarNavSearch> {
   /**
    * The button to display on tablet devices and wider. Will typically be a `TopBar.NavSearchButton`.
    */
@@ -20,14 +20,14 @@ interface NavSearchProps extends ComponentProps<typeof ElNavSearch> {
  * (minimum of 150px), and the provided icon item when there isn't. Typically used with `TopBar.NavSearchButton`
  * and `TopBar.NavSearchIconItem`.
  */
-export function NavSearch({ button, iconItem, ...rest }: NavSearchProps) {
+export function TopBarNavSearch({ button, iconItem, ...rest }: TopBarNavSearchProps) {
   return (
-    <ElNavSearch {...rest}>
-      <ElNavSearchButtonContainer>{button}</ElNavSearchButtonContainer>
-      <ElNavSearchIconItemContainer>{iconItem}</ElNavSearchIconItemContainer>
-    </ElNavSearch>
+    <ElTopBarNavSearch {...rest}>
+      <ElTopBarNavSearchButtonContainer>{button}</ElTopBarNavSearchButtonContainer>
+      <ElTopBarNavSearchIconItemContainer>{iconItem}</ElTopBarNavSearchIconItemContainer>
+    </ElTopBarNavSearch>
   )
 }
 
-NavSearch.Button = NavSearchButton
-NavSearch.IconItem = NavSearchIconItem
+TopBarNavSearch.Button = TopBarNavSearchButton
+TopBarNavSearch.IconItem = TopBarNavSearchIconItem

--- a/src/components/top-bar/nav-search/styles.ts
+++ b/src/components/top-bar/nav-search/styles.ts
@@ -1,12 +1,12 @@
 import { isTablet } from '#src/styles/media'
 import { styled } from '@linaria/react'
 
-export const ElNavSearch = styled.div`
+export const ElTopBarNavSearch = styled.div`
   container-name: nav-search;
   container-type: inline-size;
 `
 
-export const ElNavSearchButtonContainer = styled.div`
+export const ElTopBarNavSearchButtonContainer = styled.div`
   display: none;
 
   @supports not (container-type: inline-size) {
@@ -21,7 +21,7 @@ export const ElNavSearchButtonContainer = styled.div`
   }
 `
 
-export const ElNavSearchIconItemContainer = styled.div`
+export const ElTopBarNavSearchIconItemContainer = styled.div`
   display: block;
 
   @supports not (container-type: inline-size) {

--- a/src/components/top-bar/top-bar.tsx
+++ b/src/components/top-bar/top-bar.tsx
@@ -8,7 +8,7 @@ import {
   ElTopBarSearchContainer,
   ElTopBarSecondaryNavContainer,
 } from './styles'
-import { NavSearch } from './nav-search'
+import { TopBarNavSearch } from './nav-search'
 
 import type { ComponentProps, ReactNode } from 'react'
 
@@ -64,6 +64,6 @@ export function TopBar({ appSwitcher, avatar, logo, mainNav, menu, search, secon
   )
 }
 
-TopBar.NavSearch = NavSearch
-TopBar.NavSearchButton = NavSearch.Button
-TopBar.NavSearchIconItem = NavSearch.IconItem
+TopBar.NavSearch = TopBarNavSearch
+TopBar.NavSearchButton = TopBarNavSearch.Button
+TopBar.NavSearchIconItem = TopBarNavSearch.IconItem

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -27,6 +27,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
   - `TopBar.NavSearchButton`, a simple button that should be used to launch the search experience on tablet and wider screen sizes;
   - `TopBar.NavSearchIconItem`, a thin wrapper around `NavItemIcon` that should be used to launch the search experience on mobile screen sizes.
   - **BREAKING CHANGE:** Consumers using just `NavSearchButton` will no longer see a responsive change to the icon item version on mobile screen sizes.
+- **feat!:** Renamed `NavSearch`, `NavSearchButton` and `NavSearchIconItem` components and styled elements to have a `TopBar` prefix.
 
 ### **5.0.0-beta.29 - 05/06/25**
 


### PR DESCRIPTION
fixes: #477 

#481 missed some necessary changes. In particular, the components and their styled elements were not renamed to be prefixed with `TopBar`. This PR makes those name changes.
