### PR TITLE
chore: #483 add extra tests and tidy up docs

### DIFF
--- a/src/components/top-bar/main-nav/__test__/main-nav-list-item.test.tsx
+++ b/src/components/top-bar/main-nav/__test__/main-nav-list-item.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { TopBarMainNavListItem } from '../main-nav-list-item'
+
+test('renders as a list item containing a navigation link', () => {
+  render(
+    <TopBarMainNavListItem href="https://example.com" aria-current={false}>
+      My Link
+    </TopBarMainNavListItem>,
+  )
+
+  const listItem = screen.getByRole('listitem')
+  expect(listItem).toBeVisible()
+
+  const link = screen.getByRole('link', { name: 'My Link' })
+  expect(link).toBeVisible()
+})
+
+test('forwards props to the underlying nav item', () => {
+  render(
+    <TopBarMainNavListItem aria-current={false} data-testid="nav-item" href="https://example.com">
+      My Link
+    </TopBarMainNavListItem>,
+  )
+
+  const link = screen.getByTestId('nav-item')
+  expect(link).toBeVisible()
+})
+
+test('has `aria-current="false"` when `aria-current={false}`', () => {
+  render(
+    <TopBarMainNavListItem href="https://example.com" aria-current={false}>
+      My Link
+    </TopBarMainNavListItem>,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('aria-current', 'false')
+})
+
+test('has `aria-current="page"` when `aria-current="page"`', () => {
+  render(
+    <TopBarMainNavListItem href="https://example.com" aria-current="page">
+      My Link
+    </TopBarMainNavListItem>,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('aria-current', 'page')
+})
+
+test('renders the correct href attribute', () => {
+  render(
+    <TopBarMainNavListItem href="https://custom-url.com" aria-current={false}>
+      My Link
+    </TopBarMainNavListItem>,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('href', 'https://custom-url.com')
+})

--- a/src/components/top-bar/main-nav/__test__/main-nav-menu-list-item.test.tsx
+++ b/src/components/top-bar/main-nav/__test__/main-nav-menu-list-item.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Menu } from '#src/components/menu'
+import { TopBarMainNavMenuListItem } from '../main-nav-menu-list-item'
+
+test('renders as a list item containing a button', () => {
+  render(<TopBarMainNavMenuListItem label="More">More</TopBarMainNavMenuListItem>)
+
+  const listItem = screen.getByRole('listitem')
+  expect(listItem).toBeVisible()
+
+  const button = screen.getByRole('button', { name: 'More' })
+  expect(button).toBeVisible()
+})
+
+test('forwards props to the underlying nav item', () => {
+  render(
+    <TopBarMainNavMenuListItem data-testid="nav-item" label="More">
+      Fake child
+    </TopBarMainNavMenuListItem>,
+  )
+
+  const button = screen.getByTestId('nav-item')
+  expect(button).toBeVisible()
+})
+
+test('opens the menu when clicked', () => {
+  render(
+    <TopBarMainNavMenuListItem label="More">
+      <Menu.Item label="Item 1" />
+      <Menu.Item label="Item 2" />
+      <Menu.Item label="Item 3" />
+    </TopBarMainNavMenuListItem>,
+  )
+
+  const button = screen.getByRole('button')
+
+  fireEvent.click(button)
+
+  expect(button).toHaveAttribute('aria-expanded', 'true')
+  expect(screen.getByText('Item 1')).toBeVisible()
+  expect(screen.getByText('Item 2')).toBeVisible()
+  expect(screen.getByText('Item 3')).toBeVisible()
+})

--- a/src/components/top-bar/main-nav/main-nav-menu-list-item.tsx
+++ b/src/components/top-bar/main-nav/main-nav-menu-list-item.tsx
@@ -2,9 +2,9 @@ import { ElTopBarMainNavListItem } from './styles'
 import { Menu } from '../../menu'
 import { TopBarNavDropdownButton } from '../nav-dropdown-button'
 
-import type { ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface TopBarMainNavMenuListItemProps {
+interface TopBarMainNavMenuListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode
   label: string
   maxWidth?: `--size-${string}`
@@ -15,12 +15,14 @@ interface TopBarMainNavMenuListItemProps {
  * A combination of a `TopBar.NavDropdownButton` and `Menu` that is contained within a list item (`<li>`) for
  * correct semantics and accessibility when used with `TopBar.MainNav`.
  */
-export function TopBarMainNavMenuListItem({ children, label }: TopBarMainNavMenuListItemProps) {
+export function TopBarMainNavMenuListItem({ children, label, ...rest }: TopBarMainNavMenuListItemProps) {
   return (
     <ElTopBarMainNavListItem>
       <Menu>
         <Menu.Trigger>
-          {({ getTriggerProps }) => <TopBarNavDropdownButton {...getTriggerProps()}>{label}</TopBarNavDropdownButton>}
+          {({ getTriggerProps }) => (
+            <TopBarNavDropdownButton {...getTriggerProps(rest)}>{label}</TopBarNavDropdownButton>
+          )}
         </Menu.Trigger>
         <Menu.Popover>
           <Menu.List>{children}</Menu.List>

--- a/src/components/top-bar/main-nav/main-nav.stories.tsx
+++ b/src/components/top-bar/main-nav/main-nav.stories.tsx
@@ -59,10 +59,10 @@ export const WithMenu: Story = {
 
 function buildNav(type: 'No selected item' | 'Selected item' | 'With menu') {
   return [
-    <TopBarMainNav.Item key="1" href={href} isActive={type === 'Selected item'}>
+    <TopBarMainNav.Item key="1" href={href} aria-current={type === 'Selected item' ? 'page' : false}>
       Nav item 1
     </TopBarMainNav.Item>,
-    <TopBarMainNav.Item key="2" href={href}>
+    <TopBarMainNav.Item key="2" aria-current={false} href={href}>
       Nav item 2
     </TopBarMainNav.Item>,
     type === 'With menu' && (

--- a/src/components/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
+++ b/src/components/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
@@ -21,9 +21,9 @@ export interface TopBarNavDropdownButtonProps extends HTMLAttributes<HTMLButtonE
  * Currently, it does not visually or accessibly communicate if one of it's menu items represents the current page.
  * A menu item that does represent the current page should have an `aria-current="page"` attribute.
  *
- * **Important:** ⚠️ This component should rarely be used directly. Instead, use `TopBar.NavMenuItem` as it comes with
- * an integrated `Menu` and is correctly wrapped by a list item (`<li>`) to ensure good semantics and accessibility
- * when used with `TopBar.MainNav`.
+ * **Important:** ⚠️ Ensure you use this component via `TopBar.NavMenuItem` as it comes with an integrated `Menu` and
+ * is correctly wrapped by a list item (`<li>`) to ensure good semantics and accessibility when used with
+ * `TopBar.MainNav`.
  */
 export function TopBarNavDropdownButton({
   'aria-expanded': ariaExpanded,

--- a/src/components/top-bar/nav-icon-item/nav-icon-item-anchor.tsx
+++ b/src/components/top-bar/nav-icon-item/nav-icon-item-anchor.tsx
@@ -19,8 +19,8 @@ interface TopBarNavIconItemAnchorProps extends AnchorHTMLAttributes<HTMLAnchorEl
  * A simple icon-only navigation item for use in the Top Bar's secondary navigation region. Is always an anchor
  * element because Top Bar navigation items should always navigate users to another page in the product.
  *
- * **Important:** ⚠️ This component should rarely be used directly. Instead, use `TopBar.NavIconItem` as it wraps the
- * item in a list item (`<li>`) to ensure good semantics and accessibility when used with `SideBar.SecondaryNav`.
+ * **Important:** ⚠️ Ensure you use this component via `TopBar.NavIconItem` as it wraps the anchor element in a list
+ * item (`<li>`) to ensure good semantics and accessibility when used with `TopBar.SecondaryNav`.
  *
  * To integrate this component with React Router, simply wrap `TopBar.NavIconItem`. For example, with React Router 6,
  * you would do:

--- a/src/components/top-bar/nav-icon-item/nav-icon-item-button.tsx
+++ b/src/components/top-bar/nav-icon-item/nav-icon-item-button.tsx
@@ -20,8 +20,8 @@ export interface TopBarNavIconItemButtonProps extends ButtonHTMLAttributes<HTMLB
  *
  * Button-based nav icon items do currently support an "active" state like their anchor-based counterparts.
  *
- * **Important:** ⚠️ This component should rarely be used directly. Instead, use `TopBar.NavIconMenuItem` as it wraps
- * the item in a list item (`<li>`) to ensure good semantics and accessibility when used with `SideBar.SecondaryNav`.
+ * **Important:** ⚠️ Ensure you use this component via `TopBar.NavIconMenuItem` as it wraps the button element in a
+ * list item (`<li>`) to ensure good semantics and accessibility when used with `TopBar.SecondaryNav`.
  */
 export function TopBarNavIconItemButton(props: TopBarNavIconItemButtonProps) {
   return <TopBarNavIconItemBase as="button" {...props} />

--- a/src/components/top-bar/nav-item/nav-item.stories.tsx
+++ b/src/components/top-bar/nav-item/nav-item.stories.tsx
@@ -13,9 +13,9 @@ type Story = StoryObj<typeof TopBarNavItem>
 
 export const Example: Story = {
   args: {
+    'aria-current': false,
     children: 'Nav Item',
     href: globalThis.top?.location.href!,
-    isActive: false,
   },
 }
 
@@ -29,7 +29,7 @@ export const Example: Story = {
 export const Selected: Story = {
   args: {
     ...Example.args,
-    isActive: true,
+    'aria-current': 'page',
   },
 }
 

--- a/src/components/top-bar/nav-item/nav-item.tsx
+++ b/src/components/top-bar/nav-item/nav-item.tsx
@@ -5,22 +5,21 @@ import type { AnchorHTMLAttributes } from 'react'
 
 interface TopBarNavItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /**
+   * Whether the nav item represents the current page.
+   */
+  'aria-current': 'page' | false
+  /**
    * The URL to navigate to when this item is activated.
    */
   href: string
-  /**
-   * When the item represents the current page, `isActive` should be supplied to communicate to visual and accessible
-   * users that the item is currently "selected".
-   **/
-  isActive?: boolean
 }
 
 /**
  * A simple navigation item for use in the Top Bar's main navigation region. It is always an anchor element because
  * main navigation items should always navigate users to another page in the product.
  *
- * **Important:** ⚠️ This component should rarely be used directly. Instead, use `TopBar.NavItem` as it wraps the
- * anchor element in a list item (`<li>`) to ensure good semantics and accessibility when used with `SideBar.MainNav`.
+ * **Important:** ⚠️ Ensure you use this component via `TopBar.NavItem` as it wraps the anchor element in a list item
+ * (`<li>`) to ensure good semantics and accessibility when used with `TopBar.MainNav`.
  *
  * To integrate this component with React Router, simply wrap `TopBar.NavItem`. For example, with React Router 6,
  * you would do:
@@ -28,16 +27,16 @@ interface TopBarNavItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
  * ```tsx
  * function MyTopBarNavItem({ to, ...rest}) {
  *   const href = useHref(to)
- *   const isActive = useMatch(to)
+ *   const isCurrentPage = useMatch(to)
  *   return (
- *     <TopBar.NavItem {...rest} href={href} isActive={isActive} />
+ *     <TopBar.NavItem {...rest} aria-current={isCurrentPage ? 'page' : false} href={href} />
  *   )
  * }
  * ```
  */
-export function TopBarNavItem({ children, className, isActive, ...rest }: TopBarNavItemProps) {
+export function TopBarNavItem({ 'aria-current': ariaCurrent, children, className, ...rest }: TopBarNavItemProps) {
   return (
-    <a {...rest} aria-current={isActive ? 'page' : false} className={cx(elTopBarNavItem, className)}>
+    <a {...rest} aria-current={ariaCurrent} className={cx(elTopBarNavItem, className)}>
       <ElTopBarNavItemLabel>{children}</ElTopBarNavItemLabel>
     </a>
   )

--- a/src/components/top-bar/nav-search-button/nav-search-button.tsx
+++ b/src/components/top-bar/nav-search-button/nav-search-button.tsx
@@ -35,9 +35,9 @@ interface TopBarNavSearchButtonProps extends ComponentProps<typeof ElTopBarNavSe
  * the search experience to be launched via a keyboard shortcut; usually `Ctrl+K` or `⌘K`. If so, the shortcut
  * should be displayed via the `shortcut` prop.
  */
-export function TopBarNavSearchButton({ shortcut, onClick, ...props }: TopBarNavSearchButtonProps) {
+export function TopBarNavSearchButton({ shortcut, onClick, ...rest }: TopBarNavSearchButtonProps) {
   return (
-    <ElTopBarNavSearchButton {...props} onClick={onClick} type="button">
+    <ElTopBarNavSearchButton {...rest} onClick={onClick} type="button">
       <ElTopBarNavSearchButtonIcon aria-hidden="true" />
       <ElTopBarNavSearchButtonPlaceholder>Search</ElTopBarNavSearchButtonPlaceholder>
       {shortcut && (

--- a/src/components/top-bar/secondary-nav/__test__/secondary-nav-list-item.test.tsx
+++ b/src/components/top-bar/secondary-nav/__test__/secondary-nav-list-item.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import { Icon } from '../../../icon'
+import { TopBarSecondaryNavListItem } from '../secondary-nav-list-item'
+
+test('renders as a list item containing a navigation link', () => {
+  render(
+    <TopBarSecondaryNavListItem
+      href="https://example.com"
+      aria-current={false}
+      aria-label="My nav item"
+      icon={<Icon icon="star" />}
+    />,
+  )
+
+  const listItem = screen.getByRole('listitem')
+  expect(listItem).toBeVisible()
+
+  const link = screen.getByRole('link', { name: 'My nav item' })
+  expect(link).toBeVisible()
+})
+
+test('forwards props to the underlying nav icon item', () => {
+  render(
+    <TopBarSecondaryNavListItem
+      href="https://example.com"
+      aria-current={false}
+      aria-label="My nav item"
+      icon={<Icon icon="star" />}
+      data-testid="nav-icon-item"
+    />,
+  )
+
+  const link = screen.getByTestId('nav-icon-item')
+  expect(link).toBeVisible()
+})
+
+test('has `aria-current="false"` when `aria-current={false}`', () => {
+  render(
+    <TopBarSecondaryNavListItem
+      href="https://example.com"
+      aria-current={false}
+      aria-label="My nav item"
+      icon={<Icon icon="star" />}
+    />,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('aria-current', 'false')
+})
+
+test('has `aria-current="page"` when `aria-current="page"`', () => {
+  render(
+    <TopBarSecondaryNavListItem
+      href="https://example.com"
+      aria-current="page"
+      aria-label="My nav item"
+      icon={<Icon icon="star" />}
+    />,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('aria-current', 'page')
+})
+
+test('renders the correct href attribute', () => {
+  render(
+    <TopBarSecondaryNavListItem
+      href="https://custom-url.com"
+      aria-current={false}
+      aria-label="My nav item"
+      icon={<Icon icon="star" />}
+    />,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('href', 'https://custom-url.com')
+})
+
+test('can display a badge when `hasBadge` is `true`', () => {
+  render(
+    <TopBarSecondaryNavListItem
+      href="https://example.com"
+      aria-current={false}
+      aria-label="Notifications"
+      icon={<Icon icon="notification" />}
+      hasBadge={true}
+    />,
+  )
+
+  const link = screen.getByRole('link', { name: 'Notifications' })
+  expect(link.querySelector('span')).toBeVisible()
+})

--- a/src/components/top-bar/secondary-nav/__test__/secondary-nav-menu-list-item.test.tsx
+++ b/src/components/top-bar/secondary-nav/__test__/secondary-nav-menu-list-item.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Menu } from '#src/components/menu'
+import { TopBarSecondaryNavMenuListItem } from '../secondary-nav-menu-list-item'
+import { Icon } from '#src/components/icon'
+
+test('renders as a list item containing a button', () => {
+  render(
+    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<Icon icon="star" />}>
+      More
+    </TopBarSecondaryNavMenuListItem>,
+  )
+
+  const listItem = screen.getByRole('listitem')
+  expect(listItem).toBeVisible()
+
+  const button = screen.getByRole('button', { name: 'More' })
+  expect(button).toBeVisible()
+})
+
+test('forwards props to the underlying nav item', () => {
+  render(
+    <TopBarSecondaryNavMenuListItem data-testid="nav-item" aria-label="More" icon={<Icon icon="star" />}>
+      Fake child
+    </TopBarSecondaryNavMenuListItem>,
+  )
+
+  const button = screen.getByTestId('nav-item')
+  expect(button).toBeVisible()
+})
+
+test('opens the menu when clicked', () => {
+  render(
+    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<Icon icon="star" />}>
+      <Menu.Item label="Item 1" />
+      <Menu.Item label="Item 2" />
+      <Menu.Item label="Item 3" />
+    </TopBarSecondaryNavMenuListItem>,
+  )
+
+  const button = screen.getByRole('button')
+
+  fireEvent.click(button)
+
+  expect(button).toHaveAttribute('aria-expanded', 'true')
+  expect(screen.getByText('Item 1')).toBeVisible()
+  expect(screen.getByText('Item 2')).toBeVisible()
+  expect(screen.getByText('Item 3')).toBeVisible()
+})

--- a/src/components/top-bar/secondary-nav/secondary-nav-menu-list-item.tsx
+++ b/src/components/top-bar/secondary-nav/secondary-nav-menu-list-item.tsx
@@ -2,9 +2,9 @@ import { ElTopBarSecondaryNavListItem } from './styles'
 import { Menu } from '../../menu'
 import { TopBarNavIconItemButton } from '../nav-icon-item/nav-icon-item-button'
 
-import type { ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface TopBarSecondaryNavMenuListItemProps {
+interface TopBarSecondaryNavMenuListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   'aria-label': string
   children: ReactNode
   icon: ReactNode
@@ -20,13 +20,14 @@ export function TopBarSecondaryNavMenuListItem({
   'aria-label': ariaLabel,
   children,
   icon,
+  ...rest
 }: TopBarSecondaryNavMenuListItemProps) {
   return (
     <ElTopBarSecondaryNavListItem>
       <Menu>
         <Menu.Trigger>
           {({ getTriggerProps }) => (
-            <TopBarNavIconItemButton {...getTriggerProps()} aria-label={ariaLabel} icon={icon} />
+            <TopBarNavIconItemButton {...getTriggerProps(rest)} aria-label={ariaLabel} icon={icon} />
           )}
         </Menu.Trigger>
         <Menu.Popover>

--- a/src/components/top-bar/top-bar.stories.tsx
+++ b/src/components/top-bar/top-bar.stories.tsx
@@ -80,17 +80,31 @@ export default {
         None: null,
         Few: (
           <TopBar.MainNav>
-            <TopBar.MainNav.Item href={href}>Button 1</TopBar.MainNav.Item>
-            <TopBar.MainNav.Item href={href}>Button 2</TopBar.MainNav.Item>
+            <TopBar.MainNav.Item aria-current={false} href={href}>
+              Button 1
+            </TopBar.MainNav.Item>
+            <TopBar.MainNav.Item aria-current="page" href={href}>
+              Button 2
+            </TopBar.MainNav.Item>
           </TopBar.MainNav>
         ),
         Many: (
           <TopBar.MainNav>
-            <TopBar.NavItem href={href}>Button 1</TopBar.NavItem>
-            <TopBar.NavItem href={href}>Button 2</TopBar.NavItem>
-            <TopBar.NavItem href={href}>Button 3</TopBar.NavItem>
-            <TopBar.NavItem href={href}>Button 4</TopBar.NavItem>
-            <TopBar.NavItem href={href}>Button 5</TopBar.NavItem>
+            <TopBar.NavItem aria-current={false} href={href}>
+              Button 1
+            </TopBar.NavItem>
+            <TopBar.NavItem aria-current="page" href={href}>
+              Button 2
+            </TopBar.NavItem>
+            <TopBar.NavItem aria-current={false} href={href}>
+              Button 3
+            </TopBar.NavItem>
+            <TopBar.NavItem aria-current={false} href={href}>
+              Button 4
+            </TopBar.NavItem>
+            <TopBar.NavItem aria-current={false} href={href}>
+              Button 5
+            </TopBar.NavItem>
             <TopBar.NavMenuItem label="More">
               <Menu.Item label="Button 6" />
               <Menu.Item label="Button 7" />

--- a/src/components/top-bar/top-bar.tsx
+++ b/src/components/top-bar/top-bar.tsx
@@ -48,8 +48,25 @@ interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> 
 }
 
 /**
- * A responsive navigation bar that contains the product's app switcher, logo, main navigation, secondary navigation,
- * search entry point, and user profile menu.
+ * A responsive header that contains the product's app switcher, logo, main navigation, search entry point,
+ * secondary navigation, and user avatar. There are specific components designed for use in each region.
+ *
+ * Only the logo and user avatar are required; all other regions are optional.
+ *
+ * - **App switcher:** [AppSwitcher](/docs/components-appswitcher--docs)
+ * - **Avatar:** [Menu](/docs/components-menu--docs),
+ *   [TopBar.AvatarButton](/docs/components-topbar-avatarbutton--docs)
+ * - **Logo:** TODO
+ * - **Main navigation:** [TopBar.MainNav](/docs/components-topbar-mainnav--docs),
+ *   [TopBar.NavItem](/docs/components-topbar-navitem--docs),
+ *   [TopBar.NavMenuItem](/docs/components-topbar-navmenuitem--docs)
+ * - **Menu:** TODO
+ * - **Search:** [TopBar.NavSearch](/docs/components-topbar-navsearch--docs),
+ *   [TopBar.NavSearchButton](/docs/components-topbar-navsearchbutton--docs),
+ *   [TopBar.NavSearchIconItem](/docs/components-topbar-navsearchiconitem--docs)
+ * - **Secondary navigation:** [TopBar.SecondaryNav](/docs/components-topbar-secondarynav--docs),
+ *   [TopBar.NavIconItem](/docs/components-topbar-naviconitem--docs),
+ *   [TopBar.NavIconMenuItem](/docs/components-topbar-naviconmenuitem--docs)
  */
 export function TopBar({ appSwitcher, avatar, logo, mainNav, menu, search, secondaryNav, ...rest }: TopBarProps) {
   return (

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -32,6 +32,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat!:** Move `NavDropdownButton` into `TopBar` and rename it and its related classes to use the `TopBar` prefix.
 - **feat!:** Move `NavIconItem` into `TopBar` and rename it and its related classes to use the `TopBar` prefix. It's prop interface has also been updated to explicitly `as="button"` if a button is desired; by default, the component will render as a link.
 - **feat!:** Move `AvatarButton` into `TopBar` and rename it and its related classes to use the `TopBar` prefix.
+- **feat:** Add new `MainNav` and `SecondaryNav` components to `TopBar`.
 
 ### **5.0.0-beta.29 - 05/06/25**
 


### PR DESCRIPTION
### Context

- The Top Bar components are all separated in their own folders. This was largely done because they were implemented in isolation from each other.
- Now, we want to co-locate them all within the `/top-bar` folder.
- We also want to apply the same patterns used in the `SideBar` to these `TopBar` components.

### Scope of work in #483

- Move `/nav-item` to `/top-bar/nav-item`
- Move `/nav-dropdown-item` to `/top-bar/nav-dropdown-item`
- Move `/nav-icon-item` to `/top-bar/nav-icon-item`
- Move `/avatar-button` to `/top-bar/avatar-button`
- Add new `TopBar.MainNav` component in `/top-bar/main-nav`
- Add new `TopBar.SecondaryNav` component in `/top-bar/secondary-nav`
- Update docs for all `TopBar` components

### This PR

Part 7 of #483.
Follows on from #485, #486, #487, #488, #491, and #492.

- Adds extra tests.
- Standardises on `aria-current` instead of `isActive` (i.e. we're just exposing the ARIA attribute instead of abstracting it via `isActive`).
- Updates some docs.
