### PR TITLE
chore: #503 use `font` in `AppSwitcher`, `Avatar`, `SideBar`, and `TopBar`

### DIFF
--- a/src/components/app-switcher/menu-item/styles.ts
+++ b/src/components/app-switcher/menu-item/styles.ts
@@ -1,3 +1,4 @@
+import { font } from '#src/components/text'
 import { styled } from '@linaria/react'
 
 // If we don't have the transparent border, the component will move a slight bit, which is not what we want
@@ -45,14 +46,7 @@ export const ElAppSwitcherMenuItemLabel = styled.span`
   overflow-wrap: anywhere;
 
   color: var(--comp-menu-colour-text-default-primary);
-
-  /* text-sm/Medium */
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  font-style: normal;
-  font-weight: var(--font-weight-medium);
-  line-height: var(--line-height-sm);
-  letter-spacing: var(--letter-spacing-sm);
+  ${font('sm', 'medium')}
 `
 
 export const ElAppSwitcherMenuItemSupplementaryInfo = styled.span`
@@ -60,12 +54,5 @@ export const ElAppSwitcherMenuItemSupplementaryInfo = styled.span`
   overflow-wrap: anywhere;
 
   color: var(--comp-menu-colour-text-default-secondary);
-
-  /* text-xs/Regular */
-  font-family: var(--font-xs-regular-family);
-  font-size: var(--font-xs-regular-size);
-  font-style: normal;
-  font-weight: var(--font-xs-regular-weight);
-  line-height: var(--font-xs-regular-line_height);
-  letter-spacing: var(--font-xs-regular-letter_spacing);
+  ${font('xs', 'regular')}
 `

--- a/src/components/avatar/styles.ts
+++ b/src/components/avatar/styles.ts
@@ -1,3 +1,4 @@
+import { font } from '#src/components/text'
 import { styled } from '@linaria/react'
 
 interface ElAvatarProps {
@@ -14,13 +15,7 @@ export const ElAvatar = styled.span<ElAvatarProps>`
   justify-content: center;
   align-items: center;
 
-  /* text-base/Bold */
-  font-family: var(--font-base-bold-family);
-  font-size: var(--font-base-bold-size);
-  font-style: normal;
-  font-weight: var(--font-base-bold-weight);
-  line-height: var(--font-base-bold-line_height);
-  letter-spacing: var(--font-base-bold-letter_spacing);
+  ${font('base', 'bold')}
 
   /** Colour styles */
   &[data-colour='default'] {

--- a/src/components/side-bar/collapse-button/styles.ts
+++ b/src/components/side-bar/collapse-button/styles.ts
@@ -1,3 +1,4 @@
+import { font } from '#src/components/text'
 import { styled } from '@linaria/react'
 
 export const ElSideBarCollapseButton = styled.button`
@@ -47,12 +48,5 @@ export const ElSideBarCollapseLabel = styled.span`
   overflow: hidden;
   color: var(--comp-navigation-colour-text-sidebar-default);
   text-overflow: ellipsis;
-
-  /* text-sm/Regular */
-  font-family: var(--font-sm-regular-family);
-  font-size: var(--font-sm-regular-size);
-  font-style: normal;
-  font-weight: var(--font-sm-regular-weight);
-  line-height: var(--font-sm-regular-line_height);
-  letter-spacing: var(--font-sm-regular-letter_spacing);
+  ${font('sm', 'regular')}
 `

--- a/src/components/side-bar/menu-group/styles.ts
+++ b/src/components/side-bar/menu-group/styles.ts
@@ -2,6 +2,7 @@ import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 import { ElIcon } from '../../icon'
 import { ElSideBarMenuItemIcon, ElSideBarMenuItemLabel } from '../menu-item'
+import { font } from '#src/components/text'
 
 export const elSideBarMenuGroup = css`
   border-radius: var(--comp-navigation-border-radius-menu_item);
@@ -33,7 +34,7 @@ export const ElSideBarMenuGroupSummaryIcon = styled(ElSideBarMenuItemIcon)`
 export const ElSideBarMenuGroupSummaryLabel = styled(ElSideBarMenuItemLabel)`
   :where(details[data-is-active='true'], details:has([aria-current='page'])) & {
     color: var(--comp-navigation-colour-text-sidebar-select);
-    font-weight: var(--font-weight-medium);
+    ${font('sm', 'medium')}
   }
 `
 

--- a/src/components/side-bar/menu-item/styles.ts
+++ b/src/components/side-bar/menu-item/styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 import { ElIcon } from '../../icon'
+import { font } from '#src/components/text'
 
 // NOTE: This class is used as the basis for the menu group's summary element as well. Changes here
 // will also affect that component.
@@ -37,15 +38,9 @@ export const ElSideBarMenuItemLabel = styled.span`
 
   padding-block: var(--spacing-half);
 
-  /* text-sm/Regular */
-  font-family: var(--font-sm-regular-family);
-  font-size: var(--font-sm-regular-size);
-  font-style: normal;
-  font-weight: var(--font-sm-regular-weight);
-  line-height: var(--font-sm-regular-line_height);
-  letter-spacing: var(--font-sm-regular-letter_spacing);
-
   color: var(--comp-navigation-colour-text-sidebar-default);
+  ${font('sm', 'regular')}
+
   [aria-current='page'] > & {
     color: var(--comp-navigation-colour-text-sidebar-select);
     font-weight: var(--font-weight-medium);

--- a/src/components/side-bar/submenu-item/styles.ts
+++ b/src/components/side-bar/submenu-item/styles.ts
@@ -1,23 +1,18 @@
 import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
+import { font } from '#src/components/text'
 
 export const ElSideBarSubmenuItemLabel = styled.span`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  /* text-sm/Regular */
-  font-family: var(--font-sm-regular-family);
-  font-size: var(--font-sm-regular-size);
-  font-style: normal;
-  font-weight: var(--font-sm-regular-weight);
-  line-height: var(--font-sm-regular-line_height);
-  letter-spacing: var(--font-sm-regular-letter_spacing);
-
   color: var(--comp-navigation-colour-text-sidebar-default);
+  ${font('sm', 'regular')}
+
   [aria-current='page'] > & {
     color: var(--comp-navigation-colour-text-sidebar-select);
-    font-weight: var(--font-weight-medium);
+    ${font('sm', 'medium')}
   }
 `
 

--- a/src/components/top-bar/nav-dropdown-button/styles.ts
+++ b/src/components/top-bar/nav-dropdown-button/styles.ts
@@ -1,5 +1,6 @@
 import { styled } from '@linaria/react'
 import { ElIcon } from '../../icon'
+import { font } from '#src/components/text'
 
 export const ElTopBarNavDropdownButton = styled.button`
   --__padding-block: calc(var(--spacing-half) + var(--spacing-1));
@@ -45,14 +46,7 @@ export const ElTopBarNavDropdownButtonLabel = styled.span`
   white-space: nowrap;
 
   color: var(--comp-navigation-colour-text-nav_item-default);
-
-  /* text-sm/Medium */
-  font-family: var(--font-sm-medium-family);
-  font-size: var(--font-sm-medium-size);
-  font-style: normal;
-  font-weight: var(--font-sm-medium-weight);
-  line-height: var(--font-sm-medium-line_height);
-  letter-spacing: var(--font-sm-medium-letter_spacing);
+  ${font('sm', 'medium')}
 `
 
 export const ElTopBarNavDropdownButtonIcon = styled.span`

--- a/src/components/top-bar/nav-item/styles.ts
+++ b/src/components/top-bar/nav-item/styles.ts
@@ -1,3 +1,4 @@
+import { font } from '#src/components/text'
 import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
@@ -39,14 +40,7 @@ export const ElTopBarNavItemLabel = styled.span`
   white-space: nowrap;
 
   color: var(--comp-navigation-colour-text-nav_item-default);
-
-  /* text-sm/Medium */
-  font-family: var(--font-sm-medium-family);
-  font-size: var(--font-sm-medium-size);
-  font-style: normal;
-  font-weight: var(--font-sm-medium-weight);
-  line-height: var(--font-sm-medium-line_height);
-  letter-spacing: var(--font-sm-medium-letter_spacing);
+  ${font('sm', 'medium')}
 
   [aria-current='page'] & {
     color: var(--comp-navigation-colour-text-nav_item-select);

--- a/src/components/top-bar/nav-search-button/styles.ts
+++ b/src/components/top-bar/nav-search-button/styles.ts
@@ -1,3 +1,4 @@
+import { font } from '#src/components/text'
 import SearchIcon from './icons/search-icon.svg?react'
 import { styled } from '@linaria/react'
 
@@ -36,12 +37,7 @@ export const ElTopBarNavSearchButtonIcon = styled(SearchIcon)`
 
 export const ElTopBarNavSearchButtonPlaceholder = styled.span`
   color: var(--comp-navigation-colour-text-nav_search-placeholder);
-  font-family: var(--font-family);
-  font-style: normal;
-  font-size: var(--font-xs-regular-size);
-  font-weight: var(--font-xs-regular-weight);
-  line-height: var(--font-xs-regular-line_height);
-  letter-spacing: var(--font-xs-regular-letter_spacing);
+  ${font('xs', 'regular')}
 
   flex: 1;
   text-align: left;

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -19,6 +19,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 ### **5.0.0-beta.31 - xx/xx/25**
 
 - **feat:** Add `Text` and `font` helpers
+- **chore:** Use new `font` helper in `AppSwitcher`, `Avatar`, `SideBar`, and `TopBar`
 
 ### **5.0.0-beta.30 - 16/06/25**
 


### PR DESCRIPTION
### Context

#504 added a new `font` helper that we can use in our styled elements to reduce the duplication of CSS properties for a particular font size/font weight combination.

### This PR

- **fixes:** #503 
- Uses `font`  for the styled elements involved in the `AppSwitcher`, `Avatar`, `SideBar`, and `TopBar` components.