### PR TITLE
chore: bump version to v5.0.0-beta.31 and prepare changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reapit/elements",
-  "version": "5.0.0-beta.30",
+  "version": "5.0.0-beta.31",
   "description": "A collection of React components and utilities for building apps for Reapit Marketplace",
   "homepage": "https://github.com/reapit/elements#readme",
   "bugs": {

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,6 +16,10 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
+### **5.0.0-beta.31 - xx/xx/25**
+
+- ...
+
 ### **5.0.0-beta.30 - 16/06/25**
 
 - **fix:** `TopBar` secondary nav now applies correct `display` CSS property for widescreen or larger breakpoints


### PR DESCRIPTION
Bumps version to `v5.0.0-beta.31` and prepares changelog
