### PR TITLE
chore: #497 use `font` helper in `SupplementaryInfo`

### DIFF
--- a/src/components/supplementary-info/styles.ts
+++ b/src/components/supplementary-info/styles.ts
@@ -1,3 +1,4 @@
+import { font } from '../text'
 import { styled } from '@linaria/react'
 import separatorDotBaseUrl from './separator-dot-base.svg?inline'
 import separatorDotSmUrl from './separator-dot-sm.svg?inline'
@@ -10,26 +11,15 @@ export const ElSupplementaryInfoList = styled.ul`
   padding-inline: 0;
   width: fit-content;
 
-  font-family: var(--font-base-regular-family);
-
   &,
   &[data-size='base'] {
-    /* text-base */
-    font-size: var(--font-base-regular-size);
-    line-height: var(--font-base-regular-line_height);
-    letter-spacing: var(--font-base-regular-letter_spacing);
+    ${font('base', 'regular')}
   }
   &[data-size='sm'] {
-    /* text-sm */
-    font-size: var(--font-sm-regular-size);
-    line-height: var(--font-sm-regular-line_height);
-    letter-spacing: var(--font-sm-regular-letter_spacing);
+    ${font('sm', 'regular')}
   }
   &[data-size='xs'] {
-    /* text-xs */
-    font-size: var(--font-xs-regular-size);
-    line-height: var(--font-xs-regular-line_height);
-    letter-spacing: var(--font-xs-regular-letter_spacing);
+    ${font('xs', 'regular')}
   }
 `
 
@@ -44,22 +34,19 @@ export const ElSupplementaryInfoItem = styled.li`
     display: inline-block;
     vertical-align: middle;
 
+    width: 1lh;
+    height: 1lh;
+
     /* NOTE: The separator dot changes size based on the size of parent */
     &,
     [data-size='base'] & {
       background: url(${separatorDotBaseUrl}) center/cover no-repeat;
-      width: var(--font-base-regular-line_height);
-      height: var(--font-base-regular-line_height);
     }
     [data-size='sm'] & {
       background: url(${separatorDotSmUrl}) center/cover no-repeat;
-      width: var(--font-sm-regular-line_height);
-      height: var(--font-sm-regular-line_height);
     }
     [data-size='xs'] & {
       background: url(${separatorDotXsUrl}) center/cover no-repeat;
-      width: var(--font-xs-regular-line_height);
-      height: var(--font-xs-regular-line_height);
     }
   }
 
@@ -94,15 +81,15 @@ export const ElSupplementaryInfoItem = styled.li`
   /* NOTE: Primary and Secondary colours are always regular weight, but the actual weight we apply is based on size */
   [data-size='base'] &[data-colour='primary'],
   [data-size='base'] &[data-colour='secondary'] {
-    font-weight: var(--font-base-regular-weight);
+    ${font('base', 'regular')}
   }
   [data-size='sm'] &[data-colour='primary'],
   [data-size='sm'] &[data-colour='secondary'] {
-    font-weight: var(--font-sm-regular-weight);
+    ${font('sm', 'regular')}
   }
   [data-size='xs'] &[data-colour='primary'],
   [data-size='xs'] &[data-colour='secondary'] {
-    font-weight: var(--font-xs-regular-weight);
+    ${font('xs', 'regular')}
   }
 
   /* NOTE: All other colours are always medium weight, but the actual weight we apply is still based on size */
@@ -113,7 +100,7 @@ export const ElSupplementaryInfoItem = styled.li`
   [data-size='base'] &[data-colour='danger'],
   [data-size='base'] &[data-colour='accent-1'],
   [data-size='base'] &[data-colour='accent-2'] {
-    font-weight: var(--font-base-medium-weight);
+    ${font('base', 'medium')}
   }
   [data-size='sm'] &[data-colour='neutral'],
   [data-size='sm'] &[data-colour='success'],
@@ -122,7 +109,7 @@ export const ElSupplementaryInfoItem = styled.li`
   [data-size='sm'] &[data-colour='danger'],
   [data-size='sm'] &[data-colour='accent-1'],
   [data-size='sm'] &[data-colour='accent-2'] {
-    font-weight: var(--font-sm-medium-weight);
+    ${font('sm', 'medium')}
   }
   [data-size='xs'] &[data-colour='neutral'],
   [data-size='xs'] &[data-colour='success'],
@@ -131,6 +118,6 @@ export const ElSupplementaryInfoItem = styled.li`
   [data-size='xs'] &[data-colour='danger'],
   [data-size='xs'] &[data-colour='accent-1'],
   [data-size='xs'] &[data-colour='accent-2'] {
-    font-weight: var(--font-xs-medium-weight);
+    ${font('xs', 'medium')}
   }
 `


### PR DESCRIPTION
Updates the recently added `SupplementaryInfo` and `SupplementaryInfo.Item` components to use the new `font` CSS helper.
