### PR TITLE
feat: #513 Add `Link` component

### DIFF
--- a/src/components/link/__tests__/link.test.tsx
+++ b/src/components/link/__tests__/link.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { Link } from '../link'
+
+test('renders a link with the correct text', () => {
+  render(<Link href="https://fake.url">Test Link</Link>)
+  expect(screen.getByRole('link', { name: 'Test Link' })).toBeVisible()
+})
+
+test('passes the `href` prop to the link element', () => {
+  render(
+    <Link href="https://fake.url" variant="secondary">
+      Test Link
+    </Link>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('href', 'https://fake.url')
+})
+
+test('applies the correct variant based on the `variant` prop', () => {
+  render(
+    <Link href="https://fake.url" variant="secondary">
+      Test Link
+    </Link>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('data-variant', 'secondary')
+})
+
+test('applies the correct size based on the `size` prop', () => {
+  render(
+    <Link href="https://fake.url" size="sm">
+      Test Link
+    </Link>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('data-size', 'sm')
+})
+
+test('applies the correct quiet state based on the `isQuiet` prop', () => {
+  render(
+    <Link href="https://fake.url" isQuiet>
+      Test Link
+    </Link>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('data-is-quiet', 'true')
+})
+
+test('forwards additional props to the anchor element', () => {
+  render(
+    <Link href="https://fake.url" data-testid="test-id">
+      Test Link
+    </Link>,
+  )
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/components/link/index.ts
+++ b/src/components/link/index.ts
@@ -1,0 +1,2 @@
+export * from './link'
+export * from './styles'

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -1,0 +1,92 @@
+import { Link } from './link'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/Link',
+  component: Link,
+  args: {
+    children: 'Example Link',
+    href: '#',
+  },
+} satisfies Meta<typeof Link>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * By default, links will use the primary variant and base size.
+ */
+export const Example: Story = {
+  args: {
+    children: 'This is a link',
+    href: globalThis.top?.location.href!,
+    isQuiet: false,
+    size: 'base',
+    variant: 'primary',
+  },
+}
+
+/**
+ * The secondary variant is used for less important actions.
+ */
+export const Secondary: Story = {
+  args: {
+    ...Example.args,
+    variant: 'secondary',
+  },
+}
+
+/**
+ * The reversed variant is intended for use on dark backgrounds.
+ */
+export const Reversed: Story = {
+  args: {
+    ...Example.args,
+    variant: 'reversed',
+  },
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+}
+
+/**
+ * There's three sizes for the link: `base`, `sm` and `xs`.
+ */
+export const Size: Story = {
+  args: {
+    ...Example.args,
+    size: 'xs',
+  },
+}
+
+/**
+ * Links can be displayed without a visible underline using the `isQuiet` prop.
+ */
+export const QuietLinks: Story = {
+  args: {
+    ...Example.args,
+    children: 'I am a quiet link',
+    isQuiet: true,
+  },
+}
+
+/**
+ * Link text that is too long to fit in the container will simply flow to a new line as normal.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    children: 'This is a link that is too long to fit in the container',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '200px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,0 +1,38 @@
+import { ElLink } from './styles'
+
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import type { LinkVariant, LinkSize } from './styles'
+
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /**
+   * The text content to be hyperlinked to the specified URL.
+   */
+  children: ReactNode
+  /**
+   * The URL to navigate to when the link is clicked.
+   */
+  href: string
+  /**
+   * Whether the link should be displayed without an underline
+   */
+  isQuiet?: boolean
+  /**
+   * The size of the link text
+   */
+  size?: LinkSize
+  /**
+   * The visual style variant of the link
+   */
+  variant?: LinkVariant
+}
+
+/**
+ * A simple, inline link component that can be used to navigate users to some other page.
+ */
+export function Link({ children, isQuiet = false, size = 'base', variant = 'primary', ...rest }: LinkProps) {
+  return (
+    <ElLink data-variant={variant} data-size={size} data-is-quiet={isQuiet} {...rest}>
+      {children}
+    </ElLink>
+  )
+}

--- a/src/components/link/styles.ts
+++ b/src/components/link/styles.ts
@@ -1,0 +1,62 @@
+import { font } from '../text'
+import { styled } from '@linaria/react'
+
+export type LinkSize = 'base' | 'sm' | 'xs'
+export type LinkVariant = 'primary' | 'secondary' | 'reversed'
+
+interface ElLinkProps {
+  'data-is-quiet'?: boolean
+  'data-size'?: LinkSize
+  'data-variant'?: LinkVariant
+}
+
+export const ElLink = styled.a<ElLinkProps>`
+  cursor: pointer;
+
+  &,
+  &[data-is-quiet='false'] {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 25%;
+  }
+
+  &[data-is-quiet='true'] {
+    text-decoration: none;
+  }
+
+  &,
+  &[data-size='base'] {
+    ${font('base', 'regular')}
+  }
+
+  &[data-size='sm'] {
+    ${font('sm', 'medium')}
+  }
+
+  &[data-size='xs'] {
+    ${font('xs', 'medium')}
+  }
+
+  &,
+  &[data-variant='primary'] {
+    color: var(--colour-text-action);
+  }
+
+  &[data-variant='secondary'] {
+    color: var(--colour-text-secondary);
+  }
+
+  &[data-variant='reversed'] {
+    color: var(--colour-text-white);
+  }
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-style: solid;
+  }
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+`

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -21,6 +21,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add `Text` and `font` helpers
 - **chore:** Use new `font` helper in `AppSwitcher`, `Avatar`, `SideBar`, and `TopBar`
 - **feat:** Add new `SupplementaryInfo` component
+- **feat:** Add new `Link` component
 
 ### **5.0.0-beta.30 - 16/06/25**
 


### PR DESCRIPTION
### Context

- There's a [Link](https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=5377-9100&m=dev) component in the Design System;
- It's not available in Elements

### This PR

- Resolves #513 
- Adds new, simple `Link` component

**note:** <mark>This component was written by Claude in Cursor, using Figma's MCP server to allow Claude to pull design context directly from the design spec.</mark> I then tidied up some of the docs, tests and updated the CSS to use the correct CSS variables (the Figma design spec was not using the latest variables).

<img width="1062" alt="Screenshot 2025-06-18 at 6 36 40 am" src="https://github.com/user-attachments/assets/b33bceb4-137a-4d05-a8db-d814c432ef06" />
<img width="1053" alt="Screenshot 2025-06-18 at 6 36 50 am" src="https://github.com/user-attachments/assets/81122b6e-b464-402c-81ed-0a17a3c19c11" />
<img width="1045" alt="Screenshot 2025-06-18 at 6 45 23 am" src="https://github.com/user-attachments/assets/c3a4c76b-5aad-4f3d-99db-21b49d959749" />
