### PR TITLE
feat: #145 Add new `DrawerBody` component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -30,6 +30,12 @@ const preview: Preview = {
     },
   },
   parameters: {
+    backgrounds: {
+      values: [
+        { name: 'light', value: 'var(--colour-fill-neutral-lightest)' },
+        { name: 'dark', value: 'var(--colour-fill-neutral-darkest)' },
+      ],
+    },
     viewport: {
       viewports: {
         superWideScreen: {

--- a/src/components/drawer/__story__/useDrawerBreakpointDecorator.tsx
+++ b/src/components/drawer/__story__/useDrawerBreakpointDecorator.tsx
@@ -1,0 +1,66 @@
+import { DRAWER_WIDTH_XS_SM, DRAWER_WIDTH_MD_2XL } from '../constants'
+
+import type { Decorator } from '@storybook/react'
+import type { ReactNode } from 'react'
+
+export function useDrawerBreakpointDecorator(): Decorator {
+  return (Story) => (
+    <BreakpointsLayout>
+      <p style={{ color: '#FA00FF', textAlign: 'center' }}>XS-SM breakpoints</p>
+      <p style={{ color: '#FA00FF', textAlign: 'center' }}>MD-2XL breakpoints</p>
+      <Story />
+    </BreakpointsLayout>
+  )
+}
+
+interface BreakpointsLayoutProps {
+  children: ReactNode
+}
+
+function BreakpointsLayout({ children }: BreakpointsLayoutProps) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        columnGap: 'var(--spacing-10)',
+        rowGap: 'var(--spacing-10)',
+        gridTemplateColumns: `${DRAWER_WIDTH_XS_SM} ${DRAWER_WIDTH_MD_2XL}`,
+        gridTemplateRows: 'min-content 400px',
+        gridAutoRows: '400px',
+        height: 'max-content',
+        width: '100%',
+        justifyContent: 'center',
+        alignItems: 'stretch',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface BreakpointProps {
+  breakpoint: 'XS-SM' | 'MD-2XL'
+  children: ReactNode
+}
+
+export function Breakpoint({ breakpoint, children }: BreakpointProps) {
+  return (
+    <div
+      style={{
+        containerName: 'drawer',
+        containerType: 'inline-size',
+        display: 'grid',
+        gridTemplateAreas: '"header" "body" "footer"',
+        gridTemplateColumns: '1fr',
+        gridTemplateRows: 'auto 1fr auto',
+        height: '400px',
+        width: breakpoint === 'XS-SM' ? DRAWER_WIDTH_XS_SM : DRAWER_WIDTH_MD_2XL,
+        overflow: 'auto',
+        border: '1px solid #FA00FF',
+        boxSizing: 'content-box',
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/drawer/body/__test__/body.test.tsx
+++ b/src/components/drawer/body/__test__/body.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { DrawerBody } from '../body'
+
+test('renders a div element with the expected content', () => {
+  render(<DrawerBody>Test content</DrawerBody>)
+  expect(screen.getByText('Test content')).toBeVisible()
+})
+
+test('forwards additional props to the div element', () => {
+  render(<DrawerBody data-testid="test-id">Test content</DrawerBody>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/components/drawer/body/body.stories.tsx
+++ b/src/components/drawer/body/body.stories.tsx
@@ -1,0 +1,63 @@
+import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
+import { DrawerBody } from './body'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/Drawer/Body',
+  component: DrawerBody,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'light',
+    },
+  },
+} satisfies Meta<typeof DrawerBody>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'Drawer content',
+  },
+}
+
+/**
+ * The drawer body will grow to the height of its content. It is the drawer itself that handles the overflow and
+ * subsequent scrolling of the content.
+ */
+export const LongContent: Story = {
+  args: {
+    children: (
+      <div style={{ color: '#FA00FF' }}>
+        ↓↓↓↓
+        <div style={{ height: '500px' }} />
+        ↑↑↑↑
+      </div>
+    ),
+  },
+}
+
+/**
+ * Like the header and footer, the drawer body will adjust it's layout based on the inline-size of its parent
+ * container. This story demonstrates the layout changes within containers that mimic the drawer's width within
+ * different breakpoints.
+ */
+export const DynamicLayout: StoryObj = {
+  decorators: [useDrawerBreakpointDecorator()],
+  render: () => (
+    <>
+      <Breakpoint breakpoint="XS-SM">
+        <DrawerBody {...Example.args} />
+      </Breakpoint>
+      <Breakpoint breakpoint="MD-2XL">
+        <DrawerBody {...Example.args} />
+      </Breakpoint>
+    </>
+  ),
+}

--- a/src/components/drawer/body/body.tsx
+++ b/src/components/drawer/body/body.tsx
@@ -1,0 +1,18 @@
+import { ElDrawerBody } from './styles'
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface DrawerBodyProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The content of the drawer's body.
+   */
+  children: ReactNode
+}
+
+/**
+ * The body of the drawer. This is where the drawer's primary content goes. It will fill the width of its
+ * container and grow to the height of its content. Like the drawer's header and footer, the body also
+ * adjusts its padding based on the inline-size of the drawer.
+ */
+export function DrawerBody({ children, ...rest }: DrawerBodyProps) {
+  return <ElDrawerBody {...rest}>{children}</ElDrawerBody>
+}

--- a/src/components/drawer/body/index.ts
+++ b/src/components/drawer/body/index.ts
@@ -1,0 +1,2 @@
+export * from './body'
+export * from './styles'

--- a/src/components/drawer/body/styles.ts
+++ b/src/components/drawer/body/styles.ts
@@ -1,0 +1,15 @@
+import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { styled } from '@linaria/react'
+
+export const ElDrawerBody = styled.div`
+  grid-area: body;
+  background: var(--fill-white);
+  height: 100%;
+
+  /* XS-SM container size */
+  padding: var(--spacing-5);
+
+  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding: var(--spacing-6) var(--spacing-8);
+  }
+`

--- a/src/components/drawer/constants.ts
+++ b/src/components/drawer/constants.ts
@@ -1,0 +1,2 @@
+export const DRAWER_WIDTH_XS_SM = '375px'
+export const DRAWER_WIDTH_MD_2XL = '480px'


### PR DESCRIPTION
### Context

- We're implementing new a `Drawer` component that will not be backwards-compatible with the existing one.
- The existing `Drawer` was deprecated and moved in #516

### This PR

Part 2 of #145

- Implements the `DrawerBody` subcomponent.

<img width="924" alt="Screenshot 2025-06-18 at 12 01 40 pm" src="https://github.com/user-attachments/assets/bd97eeef-4aac-43e7-9576-4de0933a8614" />
<img width="927" alt="Screenshot 2025-06-18 at 12 01 49 pm" src="https://github.com/user-attachments/assets/9e2c58e1-3ae8-4b9e-952d-889594eaeb80" />
<img width="926" alt="Screenshot 2025-06-18 at 12 01 56 pm" src="https://github.com/user-attachments/assets/cfa2f6d1-c6b3-4368-b55d-1b5edb4b307a" />