### PR TITLE
feat: #145 Add new `DrawerFooter` component

### DIFF
--- a/src/components/drawer/footer/__test__/footer.test.tsx
+++ b/src/components/drawer/footer/__test__/footer.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { DrawerFooter } from '../footer'
+
+test('renders a footer element with the expected content', () => {
+  render(<DrawerFooter>Test content</DrawerFooter>)
+  expect(screen.getByText('Test content')).toBeVisible()
+})
+
+test('forwards additional props to the footer element', () => {
+  render(<DrawerFooter data-testid="test-id">Test content</DrawerFooter>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/components/drawer/footer/footer.stories.tsx
+++ b/src/components/drawer/footer/footer.stories.tsx
@@ -1,0 +1,94 @@
+import { Button } from '../../button'
+import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
+import { DrawerFooter } from './footer'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/Drawer/Footer',
+  component: DrawerFooter,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      // NOTE: The footer requires a parent container with `containerType: 'inline-size'` to allow its container
+      // queries to work. Typically, this would be the Drawer itself, but we're not rendering that here.
+      <div style={{ containerType: 'inline-size' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+} satisfies Meta<typeof DrawerFooter>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: (
+      <>
+        {/* Note: We use `display: contents` to allow the grid layout of the footer to affect the Cancel button.
+         * There are other ways to achieve this, but this is one of the simplest. We may chose, in future, to
+         * provide a Drawer-specific Cancel button similar to the header's Close button.*/}
+        <form style={{ display: 'contents' }}>
+          <Button formMethod="dialog" type="submit">
+            Cancel
+          </Button>
+        </form>
+        <Button variant="primary">Add</Button>
+      </>
+    ),
+  },
+}
+
+/**
+ * The drawer footer is sticky positioned to the bottom of its parent when it scrolls.
+ */
+export const Sticky: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'border-box',
+          border: '1px solid #FA00FF',
+          containerType: 'inline-size',
+          maxHeight: '200px',
+          overflow: 'auto',
+        }}
+      >
+        <div style={{ color: '#FA00FF', height: '300px' }}>↓↓↓↓</div>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Like the header and body, the drawer footer will adjust it's layout based on the inline-size of its parent
+ * container. This story demonstrates the layout changes within containers that mimic the drawer's width within
+ * different breakpoints.
+ */
+export const DynamicLayout: StoryObj = {
+  decorators: [useDrawerBreakpointDecorator()],
+  render: () => (
+    <>
+      <Breakpoint breakpoint="XS-SM">
+        <DrawerFooter {...Example.args} />
+      </Breakpoint>
+      <Breakpoint breakpoint="MD-2XL">
+        <DrawerFooter {...Example.args} />
+      </Breakpoint>
+    </>
+  ),
+}

--- a/src/components/drawer/footer/footer.tsx
+++ b/src/components/drawer/footer/footer.tsx
@@ -1,0 +1,16 @@
+import { ElDrawerFooter } from './styles'
+
+import type { ComponentProps, ReactNode } from 'react'
+
+interface DrawerFooterProps extends ComponentProps<typeof ElDrawerFooter> {
+  /** The footer actions. Typically one or more buttons. */
+  children: ReactNode
+}
+
+/**
+ * A footer for drawers. Typically used to display a set of actions related to the drawer's content (e.g.
+ * "Save" and "Cancel" buttons when the drawer contains a form).
+ */
+export function DrawerFooter({ children, ...rest }: DrawerFooterProps) {
+  return <ElDrawerFooter {...rest}>{children}</ElDrawerFooter>
+}

--- a/src/components/drawer/footer/index.ts
+++ b/src/components/drawer/footer/index.ts
@@ -1,0 +1,2 @@
+export * from './footer'
+export * from './styles'

--- a/src/components/drawer/footer/styles.ts
+++ b/src/components/drawer/footer/styles.ts
@@ -1,0 +1,29 @@
+import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { styled } from '@linaria/react'
+
+export const ElDrawerFooter = styled.div`
+  grid-area: footer;
+
+  position: sticky;
+  inset-block-end: 0;
+
+  background: var(--colour-fill-white);
+  border-block-start: var(--border-width-default, 1px) solid var(--colour-border-light_default);
+
+  width: 100%;
+
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: var(--spacing-2);
+  align-items: center;
+  justify-content: end;
+
+  /* XS-SM container size */
+  grid-auto-columns: 1fr;
+  padding: var(--spacing-3) var(--spacing-6);
+
+  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding: var(--spacing-3) var(--spacing-8);
+    grid-auto-columns: auto;
+  }
+`


### PR DESCRIPTION
### Context

- We're implementing new a `Drawer` component that will not be backwards-compatible with the existing one.
- The existing `Drawer` was deprecated and moved in #516
- The `DrawerBody` component was added in #518 

### This PR

Part 3 of #145

- Implements the `DrawerFooter` subcomponent.

<img width="931" alt="Screenshot 2025-06-18 at 2 29 02 pm" src="https://github.com/user-attachments/assets/9e51e7a8-a7d2-49a9-9ca7-688f0475a868" />
<img width="936" alt="Screenshot 2025-06-18 at 2 29 07 pm" src="https://github.com/user-attachments/assets/0f65941e-c77b-48e6-b1c0-28250039dab0" />
<img width="931" alt="Screenshot 2025-06-18 at 1 56 19
 pm" src="https://github.com/user-attachments/assets/f4b1d7f2-7f76-4830-a738-8c341df2446f" />
