### PR TITLE
feat: #145 Add new `DrawerHeader` component

### DIFF
--- a/src/components/drawer/header/__test__/close-button.test.tsx
+++ b/src/components/drawer/header/__test__/close-button.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { DrawerHeaderCloseButton } from '../close-button'
+
+test('renders a button within a form', () => {
+  render(<DrawerHeaderCloseButton />)
+  const button = screen.getByRole('button', { name: 'Close' })
+  expect(button).toBeVisible()
+  expect(button.parentElement?.tagName).toBe('FORM')
+})
+
+test('button is configured to be auto-focused', () => {
+  render(<DrawerHeaderCloseButton />)
+  const button = screen.getByRole('button')
+  expect(button).toHaveFocus()
+})
+
+test('button is configured to close its parent dialog element', () => {
+  render(<DrawerHeaderCloseButton />)
+  const button = screen.getByRole('button')
+  expect(button).toHaveAttribute('formMethod', 'dialog')
+  expect(button).toHaveAttribute('type', 'submit')
+})
+
+test('button has the expected icon', () => {
+  render(<DrawerHeaderCloseButton />)
+  const button = screen.getByRole('button')
+  expect(button.querySelector('svg')).toBeInTheDocument()
+})

--- a/src/components/drawer/header/__test__/header.test.tsx
+++ b/src/components/drawer/header/__test__/header.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { DrawerHeader } from '../header'
+
+test('renders a header element with the expected content', () => {
+  render(<DrawerHeader>Test Title</DrawerHeader>)
+  expect(screen.getByText('Test Title')).toBeVisible()
+})
+
+test('renders overline when provided', () => {
+  render(<DrawerHeader overline="Test Overline">Test Title</DrawerHeader>)
+  expect(screen.getByText('Test Overline')).toBeVisible()
+})
+
+test('renders supplementary info when provided', () => {
+  render(<DrawerHeader supplementaryInfo="Test Info">Test Title</DrawerHeader>)
+  expect(screen.getByText('Test Info')).toBeVisible()
+})
+
+test('renders tabs when provided', () => {
+  render(<DrawerHeader tabs="Test Tabs">Test Title</DrawerHeader>)
+  expect(screen.getByText('Test Tabs')).toBeVisible()
+})
+
+test('renders action when provided', () => {
+  render(<DrawerHeader action="Test Action">Test Title</DrawerHeader>)
+  expect(screen.getByText('Test Action')).toBeVisible()
+})
+
+test('forwards additional props to the header element', () => {
+  render(<DrawerHeader data-testid="test-id">Test Title</DrawerHeader>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/components/drawer/header/close-button.tsx
+++ b/src/components/drawer/header/close-button.tsx
@@ -1,0 +1,23 @@
+import { Button } from '../../button'
+import { CloseIcon } from '#src/icons/close'
+
+/**
+ * A close button for drawer headers. Combines a form with a button in order to close the drawer via the
+ * `formMethod="dialog"` attribute. See
+ * [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#formmethod) for more information.
+ */
+export function DrawerHeaderCloseButton() {
+  return (
+    <form>
+      <Button
+        autoFocus
+        aria-label="Close"
+        formMethod="dialog"
+        iconLeft={<CloseIcon aria-hidden />}
+        size="large"
+        type="submit"
+        variant="tertiary"
+      />
+    </form>
+  )
+}

--- a/src/components/drawer/header/header.stories.tsx
+++ b/src/components/drawer/header/header.stories.tsx
@@ -1,0 +1,72 @@
+import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
+import { DrawerHeader } from './header'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/Drawer/Header',
+  component: DrawerHeader,
+  argTypes: {
+    action: {
+      control: 'radio',
+      mapping: {
+        Close: <DrawerHeader.CloseButton />,
+        None: null,
+      },
+      options: ['Close', 'None'],
+    },
+    children: {
+      control: 'text',
+    },
+    overline: {
+      control: 'text',
+    },
+    supplementaryInfo: {
+      control: 'text',
+    },
+    tabs: {
+      control: 'radio',
+      mapping: {
+        Tabs: 'TODO',
+        None: null,
+      },
+      options: ['Tabs', 'None'],
+    },
+  },
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+} satisfies Meta<typeof DrawerHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    action: 'Close',
+    overline: 'Optional text',
+    children: 'Drawer Title',
+    supplementaryInfo: 'Supplementary Info',
+  },
+}
+
+/**
+ * Like the body and footer, the drawer header will adjust it's layout based on the inline-size of its parent
+ * container. This story demonstrates the layout changes within containers that mimic the drawer's width within
+ * different breakpoints.
+ */
+export const DynamicLayout: StoryObj = {
+  decorators: [useDrawerBreakpointDecorator()],
+  render: () => (
+    <>
+      <Breakpoint breakpoint="XS-SM">
+        <DrawerHeader {...Example.args} action={<DrawerHeader.CloseButton />} />
+      </Breakpoint>
+      <Breakpoint breakpoint="MD-2XL">
+        <DrawerHeader {...Example.args} action={<DrawerHeader.CloseButton />} />
+      </Breakpoint>
+    </>
+  ),
+}

--- a/src/components/drawer/header/header.tsx
+++ b/src/components/drawer/header/header.tsx
@@ -1,0 +1,44 @@
+import { DrawerHeaderCloseButton } from './close-button'
+import {
+  ElDrawerHeader,
+  ElDrawerHeaderAction,
+  ElDrawerHeaderContentContainer,
+  ElDrawerHeaderOverline,
+  ElDrawerHeaderSupplementaryInfo,
+  ElDrawerHeaderTabsContainer,
+  ElDrawerHeaderTitle,
+} from './styles'
+import type { ComponentProps, ReactNode } from 'react'
+
+interface DrawerHeaderProps extends Omit<ComponentProps<typeof ElDrawerHeader>, 'title'> {
+  /** Optional close action for the drawer. Should not be used when the drawer contains a form. */
+  action?: ReactNode
+  /** Optional text to display above the title. */
+  overline?: ReactNode
+  /** Optional supplementary information. Typically a `SupplementaryInfo` component. */
+  supplementaryInfo?: ReactNode
+  /** Optional tabs. Typically a `Tabs` component. */
+  tabs?: ReactNode
+  /** The title of the drawer. */
+  children: ReactNode
+}
+
+/**
+ * A header for drawers. Contains the drawer's title, as well as an optional action (close button), category,
+ * supplementary info and/or tabs.
+ */
+export function DrawerHeader({ action, overline, children, supplementaryInfo, tabs, ...rest }: DrawerHeaderProps) {
+  return (
+    <ElDrawerHeader {...rest}>
+      <ElDrawerHeaderContentContainer>
+        {action && <ElDrawerHeaderAction>{action}</ElDrawerHeaderAction>}
+        {overline && <ElDrawerHeaderOverline>{overline}</ElDrawerHeaderOverline>}
+        <ElDrawerHeaderTitle>{children}</ElDrawerHeaderTitle>
+        {supplementaryInfo && <ElDrawerHeaderSupplementaryInfo>{supplementaryInfo}</ElDrawerHeaderSupplementaryInfo>}
+      </ElDrawerHeaderContentContainer>
+      {tabs && <ElDrawerHeaderTabsContainer>{tabs}</ElDrawerHeaderTabsContainer>}
+    </ElDrawerHeader>
+  )
+}
+
+DrawerHeader.CloseButton = DrawerHeaderCloseButton

--- a/src/components/drawer/header/index.ts
+++ b/src/components/drawer/header/index.ts
@@ -1,0 +1,2 @@
+export * from './header'
+export * from './styles'

--- a/src/components/drawer/header/styles.ts
+++ b/src/components/drawer/header/styles.ts
@@ -1,0 +1,71 @@
+import { font } from '../../text'
+import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { styled } from '@linaria/react'
+
+export const ElDrawerHeader = styled.div`
+  background: var(--fill-white);
+  border-bottom: var(--border-default) solid var(--outline-default);
+  display: grid;
+  grid-area: header;
+  grid-template-areas: 'main' 'tabs';
+  grid-template-columns: 1fr;
+  grid-template-rows: minmax(0, auto);
+
+  /* XS-SM container size */
+  padding-inline: var(--spacing-5) var(--spacing-3);
+
+  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding-inline: var(--spacing-8) var(--spacing-5);
+  }
+`
+
+export const ElDrawerHeaderContentContainer = styled.div`
+  display: grid;
+  grid-area: main;
+  grid-template-areas: 'overline close' 'title close' 'supplementary-info supplementary-info';
+  grid-template-columns: auto min-content;
+  grid-template-rows: minmax(0, auto) min-content min-content;
+  align-items: center;
+
+  /* XS-SM container size */
+  padding-block: var(--spacing-3);
+
+  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding-block: var(--spacing-5);
+  }
+`
+
+export const ElDrawerHeaderTabsContainer = styled.div`
+  grid-area: tabs;
+`
+
+export const ElDrawerHeaderAction = styled.div`
+  grid-area: close;
+  align-self: start;
+  color: var(--text-secondary);
+`
+
+export const ElDrawerHeaderOverline = styled.div`
+  grid-area: overline;
+
+  color: var(--text-secondary);
+  padding-block-end: var(--spacing-1);
+
+  ${font('xs', 'regular')}
+`
+
+export const ElDrawerHeaderTitle = styled.h2`
+  color: var(--text-primary);
+  grid-area: title;
+
+  ${font('lg', 'bold')}
+`
+
+export const ElDrawerHeaderSupplementaryInfo = styled.div`
+  grid-area: supplementary-info;
+
+  color: var(--text-secondary);
+  padding-block-start: var(--spacing-1);
+
+  ${font('base', 'regular')}
+`


### PR DESCRIPTION
### Context

- We're implementing new a `Drawer` component that will not be backwards-compatible with the existing one.
- The existing `Drawer` was deprecated and moved in #516
- The `DrawerBody` component was added in #518 
- The `DrawerFooter` component was added in #520 

### This PR

Part 4 of #145

- Implements the `DrawerHeader` subcomponent and a related `DrawerHeader.CloseButton` component.

<img width="936" alt="Screenshot 2025-06-18 at 4 38 14 pm" src="https://github.com/user-attachments/assets/a81d299d-fddb-41aa-aee8-5aad5c8febf1" />
<img width="928" alt="Screenshot 2025-06-18 at 4 38 22 pm" src="https://github.com/user-attachments/assets/43e9442d-5fb3-4c7d-bafd-5c1d753f0baa" />
<img width="931" alt="Screenshot 2025-06-18 at 4 38 29 pm" src="https://github.com/user-attachments/assets/3352a35b-54fa-42fd-aced-cb4929055b0a" />
