### PR TITLE
feat: #145 Add new `DrawerContext` and `ElDrawer` styled element

### DIFF
--- a/src/components/drawer/__story__/Pattern.tsx
+++ b/src/components/drawer/__story__/Pattern.tsx
@@ -1,0 +1,18 @@
+interface PatternProps {
+  height?: string
+}
+
+export function Pattern({ height = '100cqh' }: PatternProps) {
+  return (
+    <div
+      style={{
+        backgroundColor: '#ffffff',
+        backgroundSize: '11px 11px',
+        backgroundImage: 'repeating-linear-gradient(45deg, #ffffff 0, #ffffff 1.1px, #F2CCFF 0, #F2CCFF 50%)',
+        border: '4px solid #F2CCFF',
+        boxSizing: 'content-box',
+        height,
+      }}
+    />
+  )
+}

--- a/src/components/drawer/__story__/useDrawerBreakpointDecorator.tsx
+++ b/src/components/drawer/__story__/useDrawerBreakpointDecorator.tsx
@@ -48,7 +48,7 @@ export function Breakpoint({ breakpoint, children }: BreakpointProps) {
     <div
       style={{
         containerName: 'drawer',
-        containerType: 'inline-size',
+        containerType: 'size',
         display: 'grid',
         gridTemplateAreas: '"header" "body" "footer"',
         gridTemplateColumns: '1fr',

--- a/src/components/drawer/__story__/useDrawerContextDecorator.tsx
+++ b/src/components/drawer/__story__/useDrawerContextDecorator.tsx
@@ -1,0 +1,11 @@
+import { DrawerContextProvider } from '../context'
+
+import type { Decorator } from '@storybook/react'
+
+export function useDrawerContextDecorator(): Decorator {
+  return (Story) => (
+    <DrawerContextProvider dialogRef={{ current: null }} titleId="test-title-id">
+      <Story />
+    </DrawerContextProvider>
+  )
+}

--- a/src/components/drawer/body/body.stories.tsx
+++ b/src/components/drawer/body/body.stories.tsx
@@ -1,5 +1,7 @@
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
 import { DrawerBody } from './body'
+import { Pattern } from '../__story__/Pattern'
+
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
@@ -33,13 +35,7 @@ export const Example: Story = {
  */
 export const LongContent: Story = {
   args: {
-    children: (
-      <div style={{ color: '#FA00FF' }}>
-        ↓↓↓↓
-        <div style={{ height: '500px' }} />
-        ↑↑↑↑
-      </div>
-    ),
+    children: <Pattern height="200px" />,
   },
 }
 

--- a/src/components/drawer/context.tsx
+++ b/src/components/drawer/context.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useMemo } from 'react'
+
+import type { ReactNode, RefObject } from 'react'
+
+interface DrawerContext {
+  dialogRef: RefObject<HTMLDialogElement>
+  titleId: string
+}
+
+interface DrawerContextProviderProps extends DrawerContext {
+  children: ReactNode
+}
+
+/**
+ * The context available to a Drawer's descendants. Provides access to a single `close` function
+ * that can be used to imperatively close the parent drawer.
+ */
+const DrawerContext = createContext<DrawerContext | null>(null)
+
+/**
+ * Provides the given values over the `DrawerContext`. For internal Drawer use only.
+ */
+export function DrawerContextProvider({ children, dialogRef, titleId }: DrawerContextProviderProps) {
+  const value = useMemo<DrawerContext>(
+    () => ({
+      dialogRef,
+      titleId,
+    }),
+    [dialogRef, titleId],
+  )
+  return <DrawerContext.Provider value={value}>{children}</DrawerContext.Provider>
+}
+
+/**
+ * Returns the current `DrawerContext` value.
+ * @throws an error if the context is not defined.
+ */
+export function useDrawerContext(): DrawerContext | null {
+  const context = useContext(DrawerContext)
+  if (!context) {
+    throw new Error('DrawerContext not defined: useDrawerContext can only be used in a child of DrawerContext')
+  }
+  return context
+}
+
+export default DrawerContext

--- a/src/components/drawer/footer/footer.stories.tsx
+++ b/src/components/drawer/footer/footer.stories.tsx
@@ -1,6 +1,7 @@
 import { Button } from '../../button'
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
 import { DrawerFooter } from './footer'
+import { Pattern } from '../__story__/Pattern'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
@@ -67,7 +68,7 @@ export const Sticky: Story = {
           overflow: 'auto',
         }}
       >
-        <div style={{ color: '#FA00FF', height: '300px' }}>↓↓↓↓</div>
+        <Pattern />
         <Story />
       </div>
     ),

--- a/src/components/drawer/header/__test__/header.test.tsx
+++ b/src/components/drawer/header/__test__/header.test.tsx
@@ -1,32 +1,43 @@
 import { render, screen } from '@testing-library/react'
 import { DrawerHeader } from '../header'
+import { DrawerContextProvider } from '../../context'
+
+import type { ReactNode } from 'react'
 
 test('renders a header element with the expected content', () => {
-  render(<DrawerHeader>Test Title</DrawerHeader>)
+  render(<DrawerHeader>Test Title</DrawerHeader>, { wrapper })
   expect(screen.getByText('Test Title')).toBeVisible()
 })
 
 test('renders overline when provided', () => {
-  render(<DrawerHeader overline="Test Overline">Test Title</DrawerHeader>)
+  render(<DrawerHeader overline="Test Overline">Test Title</DrawerHeader>, { wrapper })
   expect(screen.getByText('Test Overline')).toBeVisible()
 })
 
 test('renders supplementary info when provided', () => {
-  render(<DrawerHeader supplementaryInfo="Test Info">Test Title</DrawerHeader>)
+  render(<DrawerHeader supplementaryInfo="Test Info">Test Title</DrawerHeader>, { wrapper })
   expect(screen.getByText('Test Info')).toBeVisible()
 })
 
 test('renders tabs when provided', () => {
-  render(<DrawerHeader tabs="Test Tabs">Test Title</DrawerHeader>)
+  render(<DrawerHeader tabs="Test Tabs">Test Title</DrawerHeader>, { wrapper })
   expect(screen.getByText('Test Tabs')).toBeVisible()
 })
 
 test('renders action when provided', () => {
-  render(<DrawerHeader action="Test Action">Test Title</DrawerHeader>)
+  render(<DrawerHeader action="Test Action">Test Title</DrawerHeader>, { wrapper })
   expect(screen.getByText('Test Action')).toBeVisible()
 })
 
 test('forwards additional props to the header element', () => {
-  render(<DrawerHeader data-testid="test-id">Test Title</DrawerHeader>)
+  render(<DrawerHeader data-testid="test-id">Test Title</DrawerHeader>, { wrapper })
   expect(screen.getByTestId('test-id')).toBeVisible()
 })
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <DrawerContextProvider dialogRef={{ current: null }} titleId="test-title-id">
+      {children}
+    </DrawerContextProvider>
+  )
+}

--- a/src/components/drawer/header/header.stories.tsx
+++ b/src/components/drawer/header/header.stories.tsx
@@ -1,5 +1,6 @@
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
 import { DrawerHeader } from './header'
+import { useDrawerContextDecorator } from '../__story__/useDrawerContextDecorator'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
@@ -38,6 +39,7 @@ const meta = {
       value: 'light',
     },
   },
+  decorators: [useDrawerContextDecorator()],
 } satisfies Meta<typeof DrawerHeader>
 
 export default meta

--- a/src/components/drawer/header/header.tsx
+++ b/src/components/drawer/header/header.tsx
@@ -1,3 +1,4 @@
+import { useDrawerContext } from '../context'
 import { DrawerHeaderCloseButton } from './close-button'
 import {
   ElDrawerHeader,
@@ -28,12 +29,13 @@ interface DrawerHeaderProps extends Omit<ComponentProps<typeof ElDrawerHeader>, 
  * supplementary info and/or tabs.
  */
 export function DrawerHeader({ action, overline, children, supplementaryInfo, tabs, ...rest }: DrawerHeaderProps) {
+  const { titleId } = useDrawerContext() ?? {}
   return (
     <ElDrawerHeader {...rest}>
       <ElDrawerHeaderContentContainer>
         {action && <ElDrawerHeaderAction>{action}</ElDrawerHeaderAction>}
         {overline && <ElDrawerHeaderOverline>{overline}</ElDrawerHeaderOverline>}
-        <ElDrawerHeaderTitle>{children}</ElDrawerHeaderTitle>
+        <ElDrawerHeaderTitle id={titleId}>{children}</ElDrawerHeaderTitle>
         {supplementaryInfo && <ElDrawerHeaderSupplementaryInfo>{supplementaryInfo}</ElDrawerHeaderSupplementaryInfo>}
       </ElDrawerHeaderContentContainer>
       {tabs && <ElDrawerHeaderTabsContainer>{tabs}</ElDrawerHeaderTabsContainer>}

--- a/src/components/drawer/styles.ts
+++ b/src/components/drawer/styles.ts
@@ -1,0 +1,92 @@
+import { DRAWER_WIDTH_MD_2XL, DRAWER_WIDTH_XS_SM } from './constants'
+import { isDesktop } from '#src/styles/media'
+import { styled } from '@linaria/react'
+
+export const ElDrawer = styled.dialog`
+  position: fixed;
+
+  container-name: drawer;
+  container-type: size;
+
+  background: var(--fill-white);
+  border: none;
+  padding: 0;
+
+  /* Size the drawer */
+  max-width: ${DRAWER_WIDTH_XS_SM};
+  min-width: ${DRAWER_WIDTH_XS_SM};
+
+  ${isDesktop} {
+    max-width: ${DRAWER_WIDTH_MD_2XL};
+    min-width: ${DRAWER_WIDTH_MD_2XL};
+  }
+
+  /* Position the drawer on the right side of the screen and make it full height */
+  inset-inline: auto 0;
+  inset-block: 0;
+  height: 100%;
+  max-height: 100vh;
+  min-height: 100vh;
+  overflow: auto;
+
+  /* Initially transform the drawer's position so it is off-screen */
+  transform: translateX(100%);
+
+  /* Fully transparent when the drawer is closed */
+  &::backdrop {
+    background-color: rgb(0 0 0 / 0%);
+  }
+
+  /* Open state of the dialog */
+  &:open,
+  &[open] {
+    /* NOTE: We deliberately only apply a display property when the drawer is open because if we apply it to
+     * the drawer when it is closed, it will override the browser's default "display: none" behaviour for closed
+     * dialog elements. */
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+      'header'
+      'body'
+      'footer';
+
+    transform: translateX(0);
+
+    &::backdrop {
+      background-color: rgb(0 0 0 / 25%);
+    }
+  }
+
+  /* We only apply transition styles if the user has no "reduced motion" preference. By matching against
+   * "no-preference," we're taking a reduced-motion-first approach to our styling. See
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion. */
+  @media (prefers-reduced-motion: no-preference) {
+    /* Starting styles for the drawer and backdrop. These are applied at the start of the drawer's
+     * "open" transition. See https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style. */
+    @starting-style {
+      &:open,
+      &[open] {
+        transform: translateX(100%);
+        &::backdrop {
+          background-color: rgb(0 0 0 / 0%);
+        }
+      }
+    }
+
+    /* See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#transitioning_dialog_elements
+     * for details on why we transition the display and overlay properties, and what the allow-discrete
+     * transition behaviour is all about */
+    transition:
+      transform 0.2s ease-out,
+      display 0.2s ease-out allow-discrete,
+      overlay 0.2s ease-in-out allow-discrete;
+
+    &::backdrop {
+      transition:
+        background-color 0.2s ease-out,
+        display 0.2s ease-out allow-discrete,
+        overlay 0.2s ease-in-out allow-discrete;
+    }
+  }
+`


### PR DESCRIPTION
### Context

- We're implementing new a `Drawer` component that will not be backwards-compatible with the existing one.
- The existing `Drawer` was deprecated and moved in #516
- The `DrawerBody` component was added in #518 
- The `DrawerFooter` component was added in #520 
- The `DrawerHeader` component was added in #521 

### This PR

Part 5 of #145

- Implements the `ElDrawer` styled element
- Implements the `DrawerContext` object and related provider
- Makes some minor docs improvements in the existing drawer components
