### PR TITLE
feat: Add `generate:icons` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/js/index.js",
       "require": "./dist/js/index.cjs"
     },
+    "./icons/*": {
+      "types": "./dist/types/icons/*.d.ts",
+      "import": "./dist/js/icons/*.js",
+      "require": "./dist/js/icons/*.cjs"
+    },
     "./styles.css": "./dist/js/style.css",
     "./dist/index.css": "./dist/js/style.css"
   },
@@ -53,12 +58,13 @@
     "build": "yarn build:storybook & yarn build:types & yarn build:dist",
     "build:storybook": "rimraf public/dist && NODE_ENV=production storybook build -o public/dist",
     "build:dist": "vite build",
-    "build:tokens": "yarn build:tokens:preprocess && yarn build:tokens:css",
-    "build:tokens:css": "yarn node ./src/tokens/build.mjs",
-    "build:tokens:preprocess": "yarn node ./src/tokens/preprocess.js",
     "build:types": "tsc --project tsconfig.build.json",
     "commit": "yarn test run --coverage --silent && yarn coverage:badges && yarn lint --fix && yarn check",
     "coverage:badges": "yarn make-badge branches && yarn make-badge functions && yarn make-badge lines && yarn make-badge statements",
+    "generate:icons": "yarn node --experimental-strip-types src/icons/bin/generate-icons.ts",
+    "generate:tokens": "yarn build:tokens:preprocess && yarn build:tokens:css",
+    "generate:tokens:css": "yarn node ./src/tokens/build.mjs",
+    "generate:tokens:preprocess": "yarn node ./src/tokens/preprocess.js",
     "lint": "eslint --cache --ext=ts,tsx,js src",
     "check": "tsc --noEmit",
     "make-badge": "coverage-badges --type ${0} --source coverage/report/coverage-summary.json --output coverage/badges/badge-${0}.svg --jsonPath total.${0}.pct",
@@ -90,7 +96,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/babel__core": "^7",
-    "@types/node": "^18.19.31",
+    "@types/node": "22.15.32",
     "@types/postcss-flexbugs-fixes": "^5.0.3",
     "@types/react": "^18.2.75",
     "@types/react-dom": "^18.2.24",

--- a/src/icons/bin/generate-icons.ts
+++ b/src/icons/bin/generate-icons.ts
@@ -1,0 +1,71 @@
+// README: This script generates icon files from the SVG files in the `svgs` directory, as well as
+// a barrel file that exports all icons (this barrel file is primarily used for the Storybook docs).
+//
+// To run it, use `yarn generate:icons`. You will need to have Node.js 22.x or higher installed.
+
+import { basename, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readdirSync, writeFileSync } from 'node:fs'
+import { styleText } from 'node:util'
+
+// We read from `src/icons/svgs`
+const iconsDir = join(dirname(fileURLToPath(import.meta.url)), '../svgs')
+
+// We write to `src/icons`
+const outputDir = join(dirname(fileURLToPath(import.meta.url)), '../')
+
+function kebabToPascalCase(kebab: string): string {
+  return kebab
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')
+}
+
+/** Create a file for a specific icon */
+function generateIconFile(svgFileName: string): void {
+  const baseName = basename(svgFileName, '.svg')
+  const pascalCaseName = kebabToPascalCase(baseName)
+  const svgImportPath = `./svgs/${baseName}.svg?react`
+
+  const fileContent = `import ${pascalCaseName}Svg from '${svgImportPath}'
+import { makeIcon } from './make-icon'
+
+export const ${pascalCaseName}Icon = makeIcon('${pascalCaseName}Icon', ${pascalCaseName}Svg)
+`
+
+  const outputPath = join(outputDir, `${baseName}.tsx`)
+  writeFileSync(outputPath, fileContent)
+}
+
+/** Create a barrel file for all icons */
+function writeBarrelFile(svgFiles: string[]): void {
+  const fileContent = svgFiles
+    .map((file) => {
+      const baseName = basename(file, '.svg')
+      return `export * from './${baseName}'`
+    })
+    .join('\n')
+
+  writeFileSync(join(outputDir, 'index.ts'), `${fileContent}\n`)
+}
+
+/** Main script execution */
+function main() {
+  const svgFiles = readdirSync(iconsDir).filter((file) => file.endsWith('.svg'))
+
+  // Generate icon files for all SVG files
+  svgFiles.forEach(generateIconFile)
+  console.log(styleText('green', `✔️ Generated ${svgFiles.length} icon files`))
+
+  // Create a barrel file for all icons
+  writeBarrelFile(svgFiles)
+  console.log(styleText('green', '✔️ Generated icon barrel file'))
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(styleText('red', '❌ An error occurred during icon generation:'))
+  console.error(error)
+  process.exit(1)
+}

--- a/src/icons/make-icon/__test__/make-icon.test.tsx
+++ b/src/icons/make-icon/__test__/make-icon.test.tsx
@@ -1,0 +1,56 @@
+import { elIcon } from '../styles'
+import { makeIcon } from '../make-icon'
+import { render, screen } from '@testing-library/react'
+
+import type { SVGProps } from 'react'
+
+function FakeSvg(props: SVGProps<SVGSVGElement>) {
+  return <svg data-testid="mock-svg" {...props} />
+}
+
+test('icon renders an svg with default colour and size', () => {
+  const Icon = makeIcon('FakeIcon', FakeSvg)
+  render(<Icon />)
+
+  const svg = screen.getByTestId('mock-svg')
+  expect(svg).toBeVisible()
+  expect(svg.tagName).toBe('svg')
+  expect(svg).toHaveAttribute('data-colour', 'inherit')
+  expect(svg).toHaveAttribute('data-size', 'lg')
+})
+
+test('icon has correct displayName', () => {
+  const Icon = makeIcon('FakeIcon', FakeSvg)
+  expect(Icon.displayName).toBe('FakeIcon')
+})
+
+test('icon accepts colour prop', () => {
+  const Icon = makeIcon('FakeIcon', FakeSvg)
+  render(<Icon colour="primary" />)
+
+  const svg = screen.getByTestId('mock-svg')
+  expect(svg).toHaveAttribute('data-colour', 'primary')
+})
+
+test('icon accepts size prop', () => {
+  const Icon = makeIcon('FakeIcon', FakeSvg)
+  render(<Icon size="sm" />)
+
+  const svg = screen.getByTestId('mock-svg')
+  expect(svg).toHaveAttribute('data-size', 'sm')
+})
+
+test('icon can accept a custom className', () => {
+  const Icon = makeIcon('FakeIcon', FakeSvg)
+  render(<Icon className="custom-class" />)
+
+  const svg = screen.getByTestId('mock-svg')
+  expect(svg).toHaveClass(`${elIcon} custom-class`)
+})
+
+test('icon forwards additional props to the svg element', () => {
+  const Icon = makeIcon('FakeIcon', FakeSvg)
+  render(<Icon data-testid="alt-id" width="24" height="24" fill="red" />)
+
+  expect(screen.getByTestId('alt-id')).toBeVisible()
+})

--- a/src/icons/make-icon/index.ts
+++ b/src/icons/make-icon/index.ts
@@ -1,0 +1,3 @@
+export * from './make-icon'
+export * from './styles'
+export * from './types'

--- a/src/icons/make-icon/make-icon.tsx
+++ b/src/icons/make-icon/make-icon.tsx
@@ -1,0 +1,20 @@
+import { cx } from '@linaria/core'
+import { elIcon } from './styles'
+
+import type { IconColour, IconSize } from './types'
+import type { FunctionComponent, SVGProps } from 'react'
+
+export interface IconProps extends SVGProps<SVGSVGElement> {
+  colour?: IconColour
+  size?: IconSize
+}
+
+export function makeIcon(name: string, Svg: FunctionComponent<SVGProps<SVGSVGElement>>) {
+  function Icon({ className, colour = 'inherit', size = 'lg', ...rest }: IconProps) {
+    return <Svg {...rest} className={cx(elIcon, className)} data-colour={colour} data-size={size} />
+  }
+
+  Icon.displayName = name
+
+  return Icon
+}

--- a/src/icons/make-icon/styles.ts
+++ b/src/icons/make-icon/styles.ts
@@ -1,0 +1,64 @@
+import { css } from '@linaria/core'
+
+export const elIcon = css`
+  fill: currentColor;
+
+  &,
+  &[data-colour='primary'] {
+    color: var(--colour-icon-primary);
+  }
+  &[data-colour='secondary'] {
+    color: var(--colour-icon-secondary);
+  }
+  &[data-colour='disabled'] {
+    color: var(--colour-icon-disabled);
+  }
+  &[data-colour='white'] {
+    color: var(--colour-icon-white);
+  }
+  &[data-colour='action'] {
+    color: var(--colour-icon-action);
+  }
+  &[data-colour='pending'] {
+    color: var(--colour-icon-pending);
+  }
+  &[data-colour='warning'] {
+    color: var(--colour-icon-warning);
+  }
+  &[data-colour='error'] {
+    color: var(--colour-icon-error);
+  }
+  &[data-colour='success'] {
+    color: var(--colour-icon-success);
+  }
+  &[data-colour='info'] {
+    color: var(--colour-icon-info);
+  }
+  &[data-colour='accent_1'] {
+    color: var(--colour-icon-accent_1);
+  }
+  &[data-colour='accent_2'] {
+    color: var(--colour-icon-accent_2);
+  }
+  &[data-colour='inherit'] {
+    color: inherit;
+  }
+
+  &,
+  &[data-size='lg'] {
+    width: var(--icon_size-l);
+    height: var(--icon_size-l);
+  }
+  &[data-size='xs'] {
+    width: var(--icon_size-xs);
+    height: var(--icon_size-xs);
+  }
+  &[data-size='sm'] {
+    width: var(--icon_size-s);
+    height: var(--icon_size-s);
+  }
+  &[data-size='md'] {
+    width: var(--icon_size-m);
+    height: var(--icon_size-m);
+  }
+`

--- a/src/icons/make-icon/types.ts
+++ b/src/icons/make-icon/types.ts
@@ -1,0 +1,20 @@
+// TODO: Ideally we can derive or generate these from the token files in future.
+export const iconSizes = ['xs', 'sm', 'md', 'lg'] as const
+export const iconColours = [
+  'inherit',
+  'primary',
+  'secondary',
+  'disabled',
+  'white',
+  'action',
+  'pending',
+  'warning',
+  'error',
+  'success',
+  'info',
+  'accent_1',
+  'accent_2',
+] as const
+
+export type IconSize = (typeof iconSizes)[number]
+export type IconColour = (typeof iconColours)[number]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,20 @@ import react from '@vitejs/plugin-react'
 import svgr from 'vite-plugin-svgr'
 import wyw from '@wyw-in-js/vite'
 import packageManifest from './package.json'
+import path from 'node:path'
+import { readdirSync } from 'node:fs'
+
+// We dynamically discover all icons in the `src/icons` directory and add them as individual entry points
+// for our build.
+const icons = Object.fromEntries(
+  readdirSync('src/icons')
+    .filter((file) => file.endsWith('.tsx') && !file.includes('index'))
+    .map((file) => [
+      // `src/icons/add.tsx` -> `icons/add`
+      path.join('icons', path.basename(file, path.extname(file))),
+      path.join('src/icons', file),
+    ]),
+)
 
 export default defineConfig({
   build: {
@@ -14,6 +28,7 @@ export default defineConfig({
       cssFileName: 'style',
       entry: {
         index: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+        ...icons,
       },
       formats: ['es', 'cjs'],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,7 +2645,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
     "@types/babel__core": "npm:^7"
-    "@types/node": "npm:^18.19.31"
+    "@types/node": "npm:22.15.32"
     "@types/postcss-flexbugs-fixes": "npm:^5.0.3"
     "@types/react": "npm:^18.2.75"
     "@types/react-dom": "npm:^18.2.24"
@@ -3621,12 +3621,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.19.31":
-  version: 18.19.31
-  resolution: "@types/node@npm:18.19.31"
+"@types/node@npm:22.15.32":
+  version: 22.15.32
+  resolution: "@types/node@npm:22.15.32"
   dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10/654194d4f3cc5867e5525a39647773a12c0c7175972bc4d288cdc74991fc969be2a9689267a3dc1cc5c5c7617e8f7c4769ac4829525726cd3e2f60eb238c1ff4
+    undici-types: "npm:~6.21.0"
+  checksum: 10/10b4c106d0c512a1d35ec08142bd7fb5cf2e1df93fc5627b3c69dd843dec4be07a47f1fa7ede232ad84762d75a372ea35028b79ee1e753b6f2adecd0b2cb2f71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context

- We have a bunch of new icons we need to support;
- The existing `Icon` component also has some issues with it's implementation:
  - the Icon SVG does not inherit the current colour, which makes it hard to control the colour of the icon via CSS in consumers; and, 
  - the Icon component causes all SVGs to be included in the consumer's bundle, even if they only use one.
- We want to deprecate the existing component and create a new icons that can be individually imported by consumers and whose colours are easier to control.
- The old Icon component and SVGs were deprecated in #528 
- The new icon SVGs were added in #529 

### This PR

Part 3 of #281 

- Adds a new `generate:icons` package script. This script runs a Node.js module, `generate-icons.ts`, that generates icon component modules for each icon SVG in `src/icons/svgs`.
- Adds a new `makeIcon` utility that accepts an SVG React component and wraps it in a new function component that accepts `colour` and `size` props.

**note:** The next PR will run the `generate:icons` script and add new storybook docs for the icons.