### PR TITLE
feat: Update `SideBar.MenuGroup` behaviour when the current page changes

### DIFF
--- a/src/components/side-bar/__story__/use-viewport-height-decorator.tsx
+++ b/src/components/side-bar/__story__/use-viewport-height-decorator.tsx
@@ -6,7 +6,7 @@ export const useViewportHeightDecorator: Decorator = (Story) => {
       style={{
         border: '1px solid #FA00FF',
         boxSizing: 'content-box',
-        height: '300px',
+        height: '400px',
       }}
     >
       <Story />

--- a/src/components/side-bar/__test__/use-side-bar-controller.test.tsx
+++ b/src/components/side-bar/__test__/use-side-bar-controller.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { useRef } from 'react'
+import { useSideBarController } from '../use-side-bar-controller'
+
+test('collapses open menu groups when aria-current changes', async () => {
+  const { rerender } = render(<TestComponent currentPage="none" />)
+  rerender(<TestComponent currentPage="menu-item-1" />)
+
+  await waitFor(() => expect(screen.getByTestId('menu-group-1')).not.toBeVisible())
+  await waitFor(() => expect(screen.getByTestId('menu-group-2')).not.toBeVisible())
+})
+
+test('cleans up observer on unmount', () => {
+  const disconnectSpy = vi.spyOn(MutationObserver.prototype, 'disconnect')
+  const { unmount } = render(<TestComponent />)
+  unmount()
+
+  expect(disconnectSpy).toHaveBeenCalled()
+})
+
+test('handles null ref gracefully', () => {
+  const TestComponentWithNullRef = () => {
+    const ref = useRef<HTMLDivElement>(null)
+    useSideBarController(ref)
+    return <div>Test</div>
+  }
+
+  expect(() => render(<TestComponentWithNullRef />)).not.toThrow()
+})
+
+interface TestComponentProps {
+  currentPage?: 'none' | 'menu-item-1'
+}
+
+function TestComponent({ currentPage = 'none' }: TestComponentProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  useSideBarController(ref)
+
+  return (
+    <div ref={ref}>
+      <a href="#" aria-current={currentPage === 'menu-item-1' ? 'page' : undefined}>
+        Menu Item 1
+      </a>
+      <details data-testid="menu-group-1" open>
+        <summary>Menu Group 1</summary>
+        <a href="#" aria-current={false}>
+          Menu Item 2
+        </a>
+      </details>
+      <details data-testid="menu-group-2" open>
+        <summary>Menu Group 2</summary>
+        <a href="#" aria-current={false}>
+          Menu Item 3
+        </a>
+      </details>
+    </div>
+  )
+}

--- a/src/components/side-bar/menu-group/index.ts
+++ b/src/components/side-bar/menu-group/index.ts
@@ -1,3 +1,4 @@
-export * from './styles'
 export * from './menu-group'
 export * from './menu-group-summary'
+export * from './should-be-open'
+export * from './styles'

--- a/src/components/side-bar/side-bar.stories.tsx
+++ b/src/components/side-bar/side-bar.stories.tsx
@@ -13,11 +13,12 @@ export default {
   argTypes: {
     children: {
       control: 'radio',
-      options: ['No selected item', 'Selected item', 'Selected submenu item'],
+      options: ['No selected item', 'Menu Item 2 selected', 'Submenu Item 2 selected', 'Menu Item 4 active'],
       mapping: {
-        'No selected item': buildMenu('No slected item'),
-        'Selected item': buildMenu('Selected item'),
-        'Selected submenu item': buildMenu('Selected submenu item'),
+        'No selected item': buildMenu('No selected item'),
+        'Menu Item 2 selected': buildMenu('Menu Item 2 selected'),
+        'Submenu Item 2 selected': buildMenu('Submenu Item 2 selected'),
+        'Menu Item 4 active': buildMenu('Menu Item 4 active'),
       },
     },
     footer: {
@@ -48,7 +49,7 @@ export const Example: Story = {
 export const SelectedItem: Story = {
   args: {
     ...Example.args,
-    children: 'Selected item',
+    children: 'Menu Item 2 selected',
   },
 }
 
@@ -60,7 +61,7 @@ export const SelectedItem: Story = {
 export const SelectedSubmenuItem: Story = {
   args: {
     ...Example.args,
-    children: 'Selected submenu item',
+    children: 'Submenu Item 2 selected',
   },
 }
 
@@ -73,13 +74,14 @@ export const SelectedSubmenuItem: Story = {
  */
 export const Sizing: Story = {
   args: {
-    ...Example.args,
-    children: 'Selected submenu item',
+    ...SelectedItem.args,
     width: '--size-52',
   },
 }
 
-function buildMenu(type: 'No slected item' | 'Selected item' | 'Selected submenu item') {
+function buildMenu(
+  type: 'No selected item' | 'Menu Item 2 selected' | 'Submenu Item 2 selected' | 'Menu Item 4 active',
+) {
   return (
     <SideBar.MenuList>
       <SideBar.MenuItem aria-current={false} key="1" href={href} icon={<DeprecatedIcon icon="dashboard" />}>
@@ -87,7 +89,7 @@ function buildMenu(type: 'No slected item' | 'Selected item' | 'Selected submenu
       </SideBar.MenuItem>
       <SideBar.MenuItem
         key="2"
-        aria-current={type === 'Selected item' ? 'page' : false}
+        aria-current={type === 'Menu Item 2 selected' ? 'page' : false}
         href={href}
         icon={<DeprecatedIcon icon="contact" />}
       >
@@ -103,13 +105,14 @@ function buildMenu(type: 'No slected item' | 'Selected item' | 'Selected submenu
           <SideBar.SubmenuItem aria-current={false} href={href}>
             Submenu item 1
           </SideBar.SubmenuItem>
-          <SideBar.SubmenuItem aria-current={type === 'Selected submenu item' ? 'page' : false} href={href}>
+          <SideBar.SubmenuItem aria-current={type === 'Submenu Item 2 selected' ? 'page' : false} href={href}>
             Submenu item 2
           </SideBar.SubmenuItem>
         </SideBar.Submenu>
       </SideBar.MenuGroup>
       <SideBar.MenuGroup
         key="4"
+        isActive={type === 'Menu Item 4 active'}
         summary={
           <SideBar.MenuGroupSummary icon={<DeprecatedIcon icon="settings" />}>Menu item 4</SideBar.MenuGroupSummary>
         }

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -3,8 +3,9 @@ import { ElSideBar, ElSideBarBody, ElSideBarFooter } from './styles'
 import { SideBarCollapseButton } from './collapse-button'
 import { SideBarMenuList } from './menu-list'
 import { SideBarContextPublisher } from './side-bar-context'
-import { useId } from 'react'
+import { useId, useRef } from 'react'
 import { useSideBar } from './use-side-bar'
+import { useSideBarController } from './use-side-bar-controller'
 import { useSideBarKeyboardNavigation } from './use-keyboard-navigation'
 
 import type { ComponentProps, ReactNode } from 'react'
@@ -36,10 +37,12 @@ export function SideBar({
   width = '--size-64',
   ...props
 }: SideBarProps) {
+  const sideBarBodyRef = useRef<HTMLDivElement>(null)
   const sideBarId = id ?? useId()
   const sideBar = useSideBar(() => determineSideBarStateFromViewport())
   const handleKeyboardNavigation = useSideBarKeyboardNavigation()
 
+  useSideBarController(sideBarBodyRef)
   useSideBarMatchMediaEffect(sideBar)
 
   return (
@@ -51,7 +54,7 @@ export function SideBar({
       style={{ '--side-bar-width': `var(${width})` }}
     >
       <SideBarContextPublisher id={sideBarId} {...sideBar}>
-        <ElSideBarBody onClick={sideBar.expand} onKeyDown={handleKeyboardNavigation}>
+        <ElSideBarBody ref={sideBarBodyRef} onClick={sideBar.expand} onKeyDown={handleKeyboardNavigation}>
           {children}
         </ElSideBarBody>
         <ElSideBarFooter>{footer}</ElSideBarFooter>

--- a/src/components/side-bar/use-side-bar-controller.ts
+++ b/src/components/side-bar/use-side-bar-controller.ts
@@ -1,0 +1,38 @@
+import { shouldBeOpen } from './menu-group'
+import { useEffect } from 'react'
+
+import type { RefObject } from 'react'
+
+/**
+ * A simple effect that observes changes to which item represents the current page and ensures all menu groups
+ * are closed.
+ */
+export function useSideBarController(ref: RefObject<HTMLDivElement>) {
+  useEffect(
+    function closeAllMenuGroupsWhenAriaCurrentChanges() {
+      if (!ref.current) return
+
+      const element = ref.current
+
+      const observer = new MutationObserver(() => {
+        const allMenuGroups = element.querySelectorAll('details')
+        allMenuGroups.forEach((menuGroup) => {
+          // We update the menu group's `open` state to match what the `shouldBeOpen` function returns. For most
+          // menu groups, this will be `false` because it will not be the current page. However, it's possible for a
+          // menu group to have become the parent of the current page, in which case we don't close it.
+          menuGroup.open = shouldBeOpen(menuGroup)
+        })
+      })
+
+      observer.observe(element, {
+        attributeFilter: ['aria-current'],
+        subtree: true,
+      })
+
+      return () => {
+        observer.disconnect()
+      }
+    },
+    [ref],
+  )
+}

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -31,6 +31,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Added `width` prop to main SideBar component. This allows products to more easily set the desired width of their side bar based on their unique menu items.
 - **feat:** Add new Drawer component
 - **chore:** Update design tokens to match latest changes in Figma
+- **feat:** Updated Side Bar menu group's to now close automatically when the current page changes
 
 ### **5.0.0-beta.30 - 16/06/25**
 


### PR DESCRIPTION
### Context

- Feedback from SideBar usage in Reapit PM surfaced a misunderstanding regarding the expected behaviour of menu groups within the side bar.
- Currently, menu groups only close automatically if they "lose" the current page (i.e. one of their submenu items was the current page, but no longer is), or if the side bar is collapsed.
- This means manually opened groups remain open, even when other items become the current page (see video below). **This is incorrect.**

https://github.com/user-attachments/assets/c54f2f6d-21d9-48bf-a6af-97485efa0364

### This PR

- Updates the SideBar component to manually update all menu group's `open` states based on whether they should/should not be open when it observes a change to which item, if any, is marked as the current page. This behaviour still allows more than one menu group to be manually opened, but as soon as a navigation occurs that impacts which item in the side bar is considered to the current page, all those groups will be closed.

#### Design clarification

https://github.com/user-attachments/assets/8f3af984-1cad-4777-b05c-02451b5f3efe

#### New SideBar behaviour

![sidebar group behaviour update](https://github.com/user-attachments/assets/32ebcf5d-f6df-470e-a697-8e007b4641dd)