### PR TITLE
feat: Add inherit option for text colour

### DIFF
--- a/src/components/text/styles.ts
+++ b/src/components/text/styles.ts
@@ -34,7 +34,7 @@ function generateElTextColourStyles() {
   return textColours
     .map((colour) => {
       return `&[data-colour='${colour}'] {
-      color: var(--colour-text-${colour});
+      color: ${colour === 'inherit' ? 'inherit' : `var(--colour-text-${colour})`};
     }`
     })
     .join('\n')

--- a/src/components/text/text.stories.tsx
+++ b/src/components/text/text.stories.tsx
@@ -69,7 +69,8 @@ export const Element: Story = {
 }
 
 /**
- * The `colour` prop controls the text color. The available values are defined by the design system.
+ * The `colour` prop controls the text color. The available values are defined by the design system with the exception
+ * of `inherit`, which is a special value utility value that allows the text to inherit the colour of its parent.
  */
 export const Colour: Story = {
   args: {
@@ -97,4 +98,24 @@ export const Weight: Story = {
     as: 'strong',
     weight: 'bold',
   },
+}
+
+/**
+ * Usage of Text can be nested within other Text components. This can be useful when you need to prototype spans
+ * of differently coloured text within a larger block of text.
+ *
+ * **Important:** The size and weight of the nested text do **NOT** inherit from the parent.
+ */
+export const Nesting: Story = {
+  args: {
+    ...Example.args,
+  },
+  render: (args) => (
+    <Text {...args}>
+      This is a span of text that includes a{' '}
+      <Text as="strong" colour="action">
+        nested span of text.
+      </Text>
+    </Text>
+  ),
 }

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -64,6 +64,6 @@ type TextProps =
  * elements focused on inline text semantics. This is because we want this component to be minimally
  * useful.
  */
-export function Text({ as = 'span', colour = 'primary', size = 'base', weight = 'regular', ...props }: TextProps) {
+export function Text({ as = 'span', colour = 'inherit', size = 'base', weight = 'regular', ...props }: TextProps) {
   return <ElText as={as} data-colour={colour} data-font-size={size} data-font-weight={weight} {...props} />
 }

--- a/src/components/text/types.ts
+++ b/src/components/text/types.ts
@@ -15,6 +15,7 @@ export const textColours = [
   'accent_1',
   'accent_2',
   'action',
+  'inherit',
 ] as const
 
 export type FontSize = (typeof fontSizes)[number]

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -19,6 +19,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 ### **5.0.0-beta.32 - ??/??/25**
 
 - **feat!:** Change default size of new icons to a new `100%` size option.
+- **feat!:** Add new `inherit` value as the default for the colour, size and weight props of the `Text` component. The related `font` CSS helper also supports `inherit`.
 
 ### **5.0.0-beta.31 - 24/06/25**
 


### PR DESCRIPTION
Adds a new `inherit` colour option to the new Text utility component and makes it the default prop value. This will mostly be useful in Storybook docs.

<img width="1028" alt="Screenshot 2025-06-25 at 4 47 08 pm" src="https://github.com/user-attachments/assets/06b46743-a964-4988-ae47-c2100fb38f4e" />
