### PR TITLE
fix: #542 types are now built properly

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -67,13 +67,9 @@ jobs:
         run: |
           yarn version ${{ steps.tagName.outputs.version }}
 
-      - name: Build Lib
+      - name: Build
         run: |
-          yarn build:dist
-
-      - name: Build Storybook
-        run: |
-          yarn build:storybook
+          yarn build
 
       - name: Create Pull Request For Version
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -67,13 +67,9 @@ jobs:
         run: |
           yarn version ${{ steps.tagName.outputs.version }}
 
-      - name: Build Lib
+      - name: Build
         run: |
-          yarn build:dist
-
-      - name: Build Storybook
-        run: |
-          yarn build:storybook
+          yarn build
 
       - name: Create Pull Request For Version
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -53,10 +53,6 @@ jobs:
         run: |
           bash <(curl -Ls https://coverage.codacy.com/get.sh)
 
-      - name: Build Lib
+      - name: Build
         run: |
-          yarn build:dist
-
-      - name: Build Storybook
-        run: |
-          yarn build:storybook
+          yarn build

--- a/package.json
+++ b/package.json
@@ -42,22 +42,15 @@
   },
   "license": "MIT",
   "author": "Will McVay <wmcvay@reapit.com>",
-  "types": "./dist/js/index.d.ts",
-  "main": "index.ts",
-  "module": "index.ts",
-  "publishConfig": {
-    "main": "dist/js/index.cjs",
-    "module": "dist/js/index.js"
-  },
   "files": [
     "dist/",
     "assets/",
     "coverage/badges"
   ],
   "scripts": {
-    "build": "yarn build:storybook & yarn build:types & yarn build:dist",
+    "build": "yarn build:storybook & yarn build:types & yarn build:lib",
     "build:storybook": "rimraf public/dist && NODE_ENV=production storybook build -o public/dist",
-    "build:dist": "vite build",
+    "build:lib": "vite build",
     "build:types": "tsc --project tsconfig.build.json",
     "commit": "yarn test run --coverage --silent && yarn coverage:badges && yarn lint --fix && yarn check",
     "coverage:badges": "yarn make-badge branches && yarn make-badge functions && yarn make-badge lines && yarn make-badge statements",

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -20,6 +20,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 - **feat!:** Change default size of new icons to a new `100%` size option.
 - **feat!:** Add new `inherit` value as the default for the colour, size and weight props of the `Text` component. The related `font` CSS helper also supports `inherit`.
+- **fix:** Types are now built in CI correctly
 
 ### **5.0.0-beta.31 - 24/06/25**
 


### PR DESCRIPTION
### Context

- When a consumer tries to import a new icon from v5.0.0-beta.31, there are no types available. Looking at the installed package in the consumer's node_modules, there's no dist/types folder as we would expect.
- Looking at the release-prod and release-prerelease CI pipelines, they only run the build:dist script, not the build:types script.

### This PR

- Updates package manifest to remove old `main`, `module` and `types` fields. We want to rely solely on `exports`.
- Updates `build:dist` script to `build:lib`
- Updates CI pipelines to use `build` script instead of `build:dist` as the former builds everything, whereas the latter builds only the JS/CSS artefacts