### PR TITLE
feat: use native color SVG attribute for icons

### DIFF
--- a/src/icons/__test__/__snapshots__/icons.test.tsx.snap
+++ b/src/icons/__test__/__snapshots__/icons.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`'AddIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -23,7 +23,7 @@ exports[`'AnnouncementIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -42,7 +42,7 @@ exports[`'AppSwitcherIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -61,7 +61,7 @@ exports[`'ArchiveIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -82,7 +82,7 @@ exports[`'ArrowDownIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -101,7 +101,7 @@ exports[`'ArrowLeftIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -120,7 +120,7 @@ exports[`'ArrowRightIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -139,7 +139,7 @@ exports[`'ArrowUpIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -158,7 +158,7 @@ exports[`'AsteriskIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -177,7 +177,7 @@ exports[`'AttachmentIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -196,7 +196,7 @@ exports[`'AutomationIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -223,7 +223,7 @@ exports[`'BathIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -242,7 +242,7 @@ exports[`'BedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -261,7 +261,7 @@ exports[`'BillBulkIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -287,7 +287,7 @@ exports[`'BillIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -308,7 +308,7 @@ exports[`'BookmarkBulkIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -329,7 +329,7 @@ exports[`'BookmarkIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -348,7 +348,7 @@ exports[`'BuyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -370,7 +370,7 @@ exports[`'CalculatorIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -394,7 +394,7 @@ exports[`'CalendarIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -413,7 +413,7 @@ exports[`'CalendarUserIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -432,7 +432,7 @@ exports[`'CameraIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -456,7 +456,7 @@ exports[`'CarIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -480,7 +480,7 @@ exports[`'CheckIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -501,7 +501,7 @@ exports[`'CheckOutlineIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -525,7 +525,7 @@ exports[`'CheckboxDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -544,7 +544,7 @@ exports[`'CheckboxIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -563,7 +563,7 @@ exports[`'CheckboxIndeterminateIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -587,7 +587,7 @@ exports[`'CheckboxSelectedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -606,7 +606,7 @@ exports[`'ChevronDownIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -625,7 +625,7 @@ exports[`'ChevronLeftIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -644,7 +644,7 @@ exports[`'ChevronRightIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -663,7 +663,7 @@ exports[`'ChevronUpIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -682,7 +682,7 @@ exports[`'CircularAddIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -706,7 +706,7 @@ exports[`'CircularAddSolidIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -727,7 +727,7 @@ exports[`'CircularRemoveIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -751,7 +751,7 @@ exports[`'CircularRemoveSolidIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -772,7 +772,7 @@ exports[`'CloseIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -791,7 +791,7 @@ exports[`'CloudIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -810,7 +810,7 @@ exports[`'ComplianceIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -834,7 +834,7 @@ exports[`'ConsolidateIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -853,7 +853,7 @@ exports[`'ContactIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -872,7 +872,7 @@ exports[`'ContactsAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -896,7 +896,7 @@ exports[`'ContactsIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -915,7 +915,7 @@ exports[`'CopyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -939,7 +939,7 @@ exports[`'DashboardIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -958,7 +958,7 @@ exports[`'DragIndicatorAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -977,7 +977,7 @@ exports[`'DragIndicatorIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -996,7 +996,7 @@ exports[`'DrawCloseIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1018,7 +1018,7 @@ exports[`'EditIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1037,7 +1037,7 @@ exports[`'ElipsisIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1056,7 +1056,7 @@ exports[`'EmailDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1075,7 +1075,7 @@ exports[`'EmailFillIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1097,7 +1097,7 @@ exports[`'EmailIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1116,7 +1116,7 @@ exports[`'EuroIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1135,7 +1135,7 @@ exports[`'ExitIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1154,7 +1154,7 @@ exports[`'ExpandIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1173,7 +1173,7 @@ exports[`'ExportIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1195,7 +1195,7 @@ exports[`'FavouriteIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1214,7 +1214,7 @@ exports[`'FeatherIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1233,7 +1233,7 @@ exports[`'FeedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1252,7 +1252,7 @@ exports[`'FileAttachedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1271,7 +1271,7 @@ exports[`'FileAudioIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1290,7 +1290,7 @@ exports[`'FileDocumentIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1309,7 +1309,7 @@ exports[`'FileDownloadIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1328,7 +1328,7 @@ exports[`'FileExcelIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1347,7 +1347,7 @@ exports[`'FileIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1366,7 +1366,7 @@ exports[`'FileImageIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1385,7 +1385,7 @@ exports[`'FilePdfIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1404,7 +1404,7 @@ exports[`'FilePowerpointIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1425,7 +1425,7 @@ exports[`'FileSpreadsheetIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1444,7 +1444,7 @@ exports[`'FileUploadIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1463,7 +1463,7 @@ exports[`'FileVideoIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1482,7 +1482,7 @@ exports[`'FileWordIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1501,7 +1501,7 @@ exports[`'FileZipIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1520,7 +1520,7 @@ exports[`'FilterIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1539,7 +1539,7 @@ exports[`'FolderIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1558,7 +1558,7 @@ exports[`'ForwardIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1577,7 +1577,7 @@ exports[`'FullscreenExitIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1596,7 +1596,7 @@ exports[`'FullscreenIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1615,7 +1615,7 @@ exports[`'HelpIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1639,7 +1639,7 @@ exports[`'InfoIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1658,7 +1658,7 @@ exports[`'InfoOutlineIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1682,7 +1682,7 @@ exports[`'InsightsIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1701,7 +1701,7 @@ exports[`'InspectionIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1725,7 +1725,7 @@ exports[`'InspectionTemplateIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1752,7 +1752,7 @@ exports[`'InsuranceIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1776,7 +1776,7 @@ exports[`'KeyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1795,7 +1795,7 @@ exports[`'KeyboardIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1819,7 +1819,7 @@ exports[`'LandSizeIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1843,7 +1843,7 @@ exports[`'LaptopIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1862,7 +1862,7 @@ exports[`'LinkIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1887,7 +1887,7 @@ exports[`'LocationAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1906,7 +1906,7 @@ exports[`'LocationDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1925,7 +1925,7 @@ exports[`'LocationIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1944,7 +1944,7 @@ exports[`'LockIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1963,7 +1963,7 @@ exports[`'LockOutlineIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -1987,7 +1987,7 @@ exports[`'MaintenanceAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2006,7 +2006,7 @@ exports[`'MaintenanceIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2025,7 +2025,7 @@ exports[`'MarketplaceIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2044,7 +2044,7 @@ exports[`'MenuAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2063,7 +2063,7 @@ exports[`'MenuIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2082,7 +2082,7 @@ exports[`'MessageAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2101,7 +2101,7 @@ exports[`'MessageDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2120,7 +2120,7 @@ exports[`'MessageIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2139,7 +2139,7 @@ exports[`'MessageTypingIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2158,7 +2158,7 @@ exports[`'MicOffIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2177,7 +2177,7 @@ exports[`'MicOnIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2196,7 +2196,7 @@ exports[`'MinusIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2215,7 +2215,7 @@ exports[`'MobileIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2239,7 +2239,7 @@ exports[`'MoneyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2258,7 +2258,7 @@ exports[`'MonitorIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2279,7 +2279,7 @@ exports[`'MoodHappyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2303,7 +2303,7 @@ exports[`'MoodNeutralIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2327,7 +2327,7 @@ exports[`'MoodUnhappyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2351,7 +2351,7 @@ exports[`'MoreIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2370,7 +2370,7 @@ exports[`'NoteIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2389,7 +2389,7 @@ exports[`'NotificationIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2408,7 +2408,7 @@ exports[`'PaymentIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2432,7 +2432,7 @@ exports[`'PeopleAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2459,7 +2459,7 @@ exports[`'PhoneDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2478,7 +2478,7 @@ exports[`'PhoneIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2497,7 +2497,7 @@ exports[`'PhotoIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2521,7 +2521,7 @@ exports[`'PinIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2540,7 +2540,7 @@ exports[`'PoundIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2559,7 +2559,7 @@ exports[`'PowerOnIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2578,7 +2578,7 @@ exports[`'PriorityHighIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2597,7 +2597,7 @@ exports[`'PriorityLowIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2616,7 +2616,7 @@ exports[`'PriorityMediumIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2635,7 +2635,7 @@ exports[`'PropertyCheckedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2659,7 +2659,7 @@ exports[`'PropertyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2678,7 +2678,7 @@ exports[`'RadioDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2697,7 +2697,7 @@ exports[`'RadioIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2716,7 +2716,7 @@ exports[`'RadioSelectedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2740,7 +2740,7 @@ exports[`'RefreshIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2759,7 +2759,7 @@ exports[`'RentIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2780,7 +2780,7 @@ exports[`'RepeatIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2799,7 +2799,7 @@ exports[`'ReplyAllIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2818,7 +2818,7 @@ exports[`'ReplyIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2837,7 +2837,7 @@ exports[`'ReportIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2856,7 +2856,7 @@ exports[`'RestoreIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2875,7 +2875,7 @@ exports[`'SaleIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2899,7 +2899,7 @@ exports[`'SearchIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2918,7 +2918,7 @@ exports[`'SendIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2939,7 +2939,7 @@ exports[`'SeparatorDotIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2958,7 +2958,7 @@ exports[`'SeparatorLineIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2977,7 +2977,7 @@ exports[`'SettingsAltIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -2998,7 +2998,7 @@ exports[`'SettingsIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3017,7 +3017,7 @@ exports[`'ShareIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3036,7 +3036,7 @@ exports[`'SortAscendIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3055,7 +3055,7 @@ exports[`'SortDescendIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3074,7 +3074,7 @@ exports[`'SortIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3095,7 +3095,7 @@ exports[`'SproutIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3114,7 +3114,7 @@ exports[`'StarIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3133,7 +3133,7 @@ exports[`'StatusBadIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3152,7 +3152,7 @@ exports[`'StatusGoodIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3171,7 +3171,7 @@ exports[`'StatusIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3192,7 +3192,7 @@ exports[`'StatusPausedIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3211,7 +3211,7 @@ exports[`'StatusUnknownIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3230,7 +3230,7 @@ exports[`'TagIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3254,7 +3254,7 @@ exports[`'TaskIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3273,7 +3273,7 @@ exports[`'TimeIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3297,7 +3297,7 @@ exports[`'TrashIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3316,7 +3316,7 @@ exports[`'UnarchiveIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3338,7 +3338,7 @@ exports[`'UserIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3364,7 +3364,7 @@ exports[`'VideoIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3383,7 +3383,7 @@ exports[`'ViewDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3410,7 +3410,7 @@ exports[`'ViewIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3429,7 +3429,7 @@ exports[`'W3wIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3453,7 +3453,7 @@ exports[`'WalkingIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3472,7 +3472,7 @@ exports[`'WandIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3504,7 +3504,7 @@ exports[`'WarningIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3523,7 +3523,7 @@ exports[`'WarningOutlineIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"
@@ -3547,7 +3547,7 @@ exports[`'WorkflowIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg
     class="el-icon"
-    data-colour="inherit"
+    color="inherit"
     data-size="100%"
     fill="currentColor"
     height="24"

--- a/src/icons/docs/All Icons.mdx
+++ b/src/icons/docs/All Icons.mdx
@@ -49,7 +49,7 @@ All icons available for use through Elements are listed below.
             padding: 'var(--spacing-2)',
           }}
         >
-          <Icon colour="primary" size="lg" />
+          <Icon color="primary" size="lg" />
         </div>
         <Text style={{ color: 'inherit' }} size="sm">
           {iconName}

--- a/src/icons/docs/icon.stories.tsx
+++ b/src/icons/docs/icon.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
   title: 'Icons/Icon',
   component: StarIcon,
   argTypes: {
-    colour: {
+    color: {
       control: 'select',
       options: iconColours,
       description: 'The colour of the icon.',
@@ -49,7 +49,7 @@ type Story = StoryObj<typeof meta>
 
 export const Example: Story = {
   args: {
-    colour: 'primary',
+    color: 'primary',
     size: 'lg',
   },
 }
@@ -64,7 +64,7 @@ export const Colours: StoryObj = {
     size: 'lg',
   },
   argTypes: {
-    colour: {
+    color: {
       control: false,
     },
   },
@@ -80,7 +80,7 @@ export const Colours: StoryObj = {
           gap: 'var(--spacing-6)',
         }}
       >
-        {iconColours.map((colour) => [colour, <StarIcon key={colour} {...args} colour={colour} />])}
+        {iconColours.map((colour) => [colour, <StarIcon key={colour} {...args} color={colour} />])}
       </div>
     )
   },
@@ -93,7 +93,7 @@ export const Colours: StoryObj = {
 export const Sizes: Story = {
   args: {
     ...Example.args,
-    colour: 'primary',
+    color: 'primary',
   },
   argTypes: {
     size: {

--- a/src/icons/make-icon/__test__/make-icon.test.tsx
+++ b/src/icons/make-icon/__test__/make-icon.test.tsx
@@ -8,14 +8,14 @@ function FakeSvg(props: SVGProps<SVGSVGElement>) {
   return <svg data-testid="mock-svg" {...props} />
 }
 
-test('icon renders an svg with default colour and size', () => {
+test('icon renders an svg with default color and size', () => {
   const Icon = makeIcon('FakeIcon', FakeSvg)
   render(<Icon />)
 
   const svg = screen.getByTestId('mock-svg')
   expect(svg).toBeVisible()
   expect(svg.tagName).toBe('svg')
-  expect(svg).toHaveAttribute('data-colour', 'inherit')
+  expect(svg).toHaveAttribute('color', 'inherit')
   expect(svg).toHaveAttribute('data-size', '100%')
 })
 
@@ -24,12 +24,12 @@ test('icon has correct displayName', () => {
   expect(Icon.displayName).toBe('FakeIcon')
 })
 
-test('icon accepts colour prop', () => {
+test('icon accepts color prop', () => {
   const Icon = makeIcon('FakeIcon', FakeSvg)
-  render(<Icon colour="primary" />)
+  render(<Icon color="primary" />)
 
   const svg = screen.getByTestId('mock-svg')
-  expect(svg).toHaveAttribute('data-colour', 'primary')
+  expect(svg).toHaveAttribute('color', 'primary')
 })
 
 test('icon accepts size prop', () => {

--- a/src/icons/make-icon/make-icon.tsx
+++ b/src/icons/make-icon/make-icon.tsx
@@ -5,13 +5,13 @@ import type { IconColour, IconSize } from './types'
 import type { FunctionComponent, SVGProps } from 'react'
 
 export interface IconProps extends SVGProps<SVGSVGElement> {
-  colour?: IconColour
+  color?: IconColour
   size?: IconSize
 }
 
 export function makeIcon(name: string, Svg: FunctionComponent<SVGProps<SVGSVGElement>>) {
-  function Icon({ className, colour = 'inherit', size = '100%', ...rest }: IconProps) {
-    return <Svg {...rest} className={cx(elIcon, className)} data-colour={colour} data-size={size} />
+  function Icon({ className, color = 'inherit', size = '100%', ...rest }: IconProps) {
+    return <Svg {...rest} className={cx(elIcon, className)} color={color} data-size={size} />
   }
 
   Icon.displayName = name

--- a/src/icons/make-icon/styles.ts
+++ b/src/icons/make-icon/styles.ts
@@ -4,43 +4,43 @@ export const elIcon = css`
   fill: currentColor;
 
   &,
-  &[data-colour='primary'] {
+  &[color='primary'] {
     color: var(--colour-icon-primary);
   }
-  &[data-colour='secondary'] {
+  &[color='secondary'] {
     color: var(--colour-icon-secondary);
   }
-  &[data-colour='disabled'] {
+  &[color='disabled'] {
     color: var(--colour-icon-disabled);
   }
-  &[data-colour='white'] {
+  &[color='white'] {
     color: var(--colour-icon-white);
   }
-  &[data-colour='action'] {
+  &[color='action'] {
     color: var(--colour-icon-action);
   }
-  &[data-colour='pending'] {
+  &[color='pending'] {
     color: var(--colour-icon-pending);
   }
-  &[data-colour='warning'] {
+  &[color='warning'] {
     color: var(--colour-icon-warning);
   }
-  &[data-colour='error'] {
+  &[color='error'] {
     color: var(--colour-icon-error);
   }
-  &[data-colour='success'] {
+  &[color='success'] {
     color: var(--colour-icon-success);
   }
-  &[data-colour='info'] {
+  &[color='info'] {
     color: var(--colour-icon-info);
   }
-  &[data-colour='accent_1'] {
+  &[color='accent_1'] {
     color: var(--colour-icon-accent_1);
   }
-  &[data-colour='accent_2'] {
+  &[color='accent_2'] {
     color: var(--colour-icon-accent_2);
   }
-  &[data-colour='inherit'] {
+  &[color='inherit'] {
     color: inherit;
   }
 

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -21,6 +21,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat!:** Change default size of new icons to a new `100%` size option.
 - **feat!:** Add new `inherit` value as the default for the colour, size and weight props of the `Text` component. The related `font` CSS helper also supports `inherit`.
 - **fix:** Types are now built in CI correctly
+- **feat!:** Icon `colour` prop replaced with native `color` SVG attribute
 
 ### **5.0.0-beta.31 - 24/06/25**
 


### PR DESCRIPTION
### Context

- New icons were added in #531.
- Icons can be coloured using a `colour` prop.
- SVG elements have a native `color` prop which means there's two "colour" related props on the icon's interface 🤮 

### This PR

- Replace `colour` with the native `color` attribute for icons.


