### PR TITLE
chore: refactor bottom bar item as subcomponent of bottom bar

### DIFF
--- a/src/components/bottom-bar/item/__tests__/item-anchor.test.tsx
+++ b/src/components/bottom-bar/item/__tests__/item-anchor.test.tsx
@@ -1,0 +1,24 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+import * as stories from '../item-anchor.stories'
+
+const TopBarNavIconItemStories = composeStories(stories)
+
+test('renders as a link with an accessible name', () => {
+  render(<TopBarNavIconItemStories.Example aria-label="My Item" />)
+  expect(screen.getByRole('link', { name: 'My Item' })).toBeVisible()
+})
+
+test('forwards additional props to the link element', () => {
+  const testId = 'nav-icon-item'
+  render(<TopBarNavIconItemStories.Example data-testid={testId} />)
+
+  const item = screen.getByTestId(testId)
+  expect(item).toBeVisible()
+})
+
+test('can display a badge when `hasBadge` is `true`', () => {
+  render(<TopBarNavIconItemStories.WithBadge />)
+  const button = screen.getByRole('link', { name: 'Notifications' })
+  expect(button.querySelector('span')).toBeVisible()
+})

--- a/src/components/bottom-bar/item/__tests__/item-button.test.tsx
+++ b/src/components/bottom-bar/item/__tests__/item-button.test.tsx
@@ -1,0 +1,24 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+import * as stories from '../item-button.stories'
+
+const TopBarNavIconItemStories = composeStories(stories)
+
+test('renders as a button with an accessible name', () => {
+  render(<TopBarNavIconItemStories.Example aria-label="My Item" />)
+  expect(screen.getByRole('button', { name: 'My Item' })).toBeVisible()
+})
+
+test('forwards additional props to the button element', () => {
+  const testId = 'nav-icon-item'
+  render(<TopBarNavIconItemStories.Example data-testid={testId} />)
+
+  const item = screen.getByTestId(testId)
+  expect(item).toBeVisible()
+})
+
+test('can display a badge', () => {
+  render(<TopBarNavIconItemStories.WithBadge onClick={() => void 0} />)
+  const button = screen.getByRole('button', { name: 'Notifications' })
+  expect(button.querySelector('span')).toBeVisible()
+})

--- a/src/components/bottom-bar/item/index.ts
+++ b/src/components/bottom-bar/item/index.ts
@@ -1,0 +1,4 @@
+export * from './item-anchor'
+export * from './item-button'
+export * from './item-base'
+export * from './styles'

--- a/src/components/bottom-bar/item/item-anchor.stories.tsx
+++ b/src/components/bottom-bar/item/item-anchor.stories.tsx
@@ -1,0 +1,77 @@
+import { BottomBarItemAnchor } from './item-anchor'
+import { ContactIcon } from '#src/icons/contact'
+import { HelpIcon } from '#src/icons/help'
+import { NotificationIcon } from '#src/icons/notification'
+import { StarIcon } from '#src/icons/star'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/BottomBar/ItemAnchor',
+  component: BottomBarItemAnchor,
+  argTypes: {
+    'aria-current': {
+      control: 'radio',
+      // NOTE: This is necessary because a `false` value in a Story will otherwise not correctly pre-select the
+      // "false" option.
+      options: ['page', false],
+      mapping: {
+        page: 'page',
+        false: false,
+      },
+    },
+    icon: {
+      control: 'radio',
+      options: ['Contact', 'Help', 'Notification', 'Star'],
+      mapping: {
+        Contact: <ContactIcon />,
+        Help: <HelpIcon />,
+        Notification: <NotificationIcon />,
+        Star: <StarIcon />,
+      },
+    },
+  },
+} satisfies Meta<typeof BottomBarItemAnchor>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * Items in the bottom bar will typically navigate users to another page in the product. The `aria-current`
+ * attribute must be supplied to indicate visually and accessibly that the item represents the current page (or not).
+ */
+export const Example: Story = {
+  args: {
+    'aria-current': false,
+    children: 'Label',
+    hasBadge: false,
+    href: globalThis.top?.location.href!,
+    icon: 'Star',
+  },
+}
+
+/**
+ * When an item represents the current page, `aria-current="page"` should be supplied. This indicates to visual
+ * and accessible users that the item represents the current page.
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    'aria-current': 'page',
+  },
+}
+
+/**
+ * Items may need to visually indicate that something new has occurred that the user should be aware of. When
+ * this is the case, a badge can be displayed. A common example is a notification bell that shows a badge when one or
+ * more unread notifications are available.
+ */
+export const WithBadge: Story = {
+  args: {
+    ...Example.args,
+    children: 'Notifications',
+    hasBadge: true,
+    icon: 'Notification',
+  },
+}

--- a/src/components/bottom-bar/item/item-anchor.tsx
+++ b/src/components/bottom-bar/item/item-anchor.tsx
@@ -1,0 +1,27 @@
+import { BottomBarItemBase } from './item-base'
+
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+
+interface BottomBarItemAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Whether the item represents the current page. */
+  'aria-current': 'page' | false
+  /** The visible name of the item. */
+  children: string
+  /** Optional badge to be displayed on the nav item */
+  hasBadge?: boolean
+  /** The URL to navigate to when the item is clicked. */
+  href: string
+  /** The item's icon. */
+  icon: ReactNode
+}
+
+/**
+ * A simple navigation item for use in the Bottom Bar's secondary navigation region. Is always an anchor element
+ * because Bottom Bar navigation items should always navigate users to another page in the product.
+ *
+ * **Important:** ⚠️ Typically you will use this component via `BottomBar.Item` as it wraps the anchor element in a
+ * list item (`<li>`) to ensure good semantics and accessibility when used with `BottomBar`.
+ */
+export function BottomBarItemAnchor(props: BottomBarItemAnchorProps) {
+  return <BottomBarItemBase {...props} as="a" />
+}

--- a/src/components/bottom-bar/item/item-base.tsx
+++ b/src/components/bottom-bar/item/item-base.tsx
@@ -1,0 +1,45 @@
+import { cx } from '@linaria/core'
+import { ElBottomBarItemBadge, ElBottomBarItemIcon, ElBottomBarItemLabel, elBottomBarItem } from './styles'
+
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react'
+
+interface BottomBarItemCommonProps {
+  hasBadge?: boolean
+  icon: ReactNode
+}
+
+export interface BottomBarItemAsAnchorProps extends BottomBarItemCommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+  as: 'a'
+  children: ReactNode
+}
+
+export interface BottomBarItemAsButtonProps extends BottomBarItemCommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
+  as: 'button'
+  children: ReactNode
+}
+
+export type BottomBarItemBaseProps = BottomBarItemAsAnchorProps | BottomBarItemAsButtonProps
+
+/**
+ * A simple polymorphic item that can render as a button or link. It is used internally by the `BottomBar.ItemAnchor`
+ * and `BottomBar.ItemButton` components and should not be used directly by consumers.
+ */
+export function BottomBarItemBase({
+  as: Element,
+  children,
+  className,
+  icon,
+  hasBadge,
+  ...rest
+}: BottomBarItemBaseProps) {
+  return (
+    // NOTE: We use a type assertion here to avoid having to narrow the type of `rest` to the specific `Element` type.
+    <Element {...(rest as HTMLAttributes<HTMLElement>)} className={cx(elBottomBarItem, className)}>
+      <ElBottomBarItemIcon aria-hidden="true">
+        {hasBadge && <ElBottomBarItemBadge />}
+        {icon}
+      </ElBottomBarItemIcon>
+      <ElBottomBarItemLabel>{children}</ElBottomBarItemLabel>
+    </Element>
+  )
+}

--- a/src/components/bottom-bar/item/item-button.stories.tsx
+++ b/src/components/bottom-bar/item/item-button.stories.tsx
@@ -1,0 +1,88 @@
+import { BottomBarItemButton } from './item-button'
+import { ContactIcon } from '#src/icons/contact'
+import { HelpIcon } from '#src/icons/help'
+import { NotificationIcon } from '#src/icons/notification'
+import { StarIcon } from '#src/icons/star'
+import { Menu } from '../../menu'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/BottomBar/ItemButton',
+  component: BottomBarItemButton,
+  argTypes: {
+    icon: {
+      control: 'radio',
+      options: ['Contact', 'Help', 'Notification', 'Star'],
+      mapping: {
+        Contact: <ContactIcon />,
+        Help: <HelpIcon />,
+        Notification: <NotificationIcon />,
+        Star: <StarIcon />,
+      },
+    },
+  },
+} satisfies Meta<typeof BottomBarItemButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * Button-based items are typically used to group a number of related items within a dropdown menu. Unlike link-based
+ * items, button-based items do not have the concept of representing the current page.
+ */
+export const Example: Story = {
+  args: {
+    children: 'Label',
+    hasBadge: false,
+    icon: 'Star',
+    onClick: () => void 0,
+  },
+}
+
+/**
+ * Items may need to visually indicate that something new has occurred that the user should be aware of. When
+ * this is the case, a badge can be displayed. A common exmaple is a notification bell that shows a badge when one or
+ * more unread notifications are available.
+ */
+export const WithBadge: Story = {
+  args: {
+    ...Example.args,
+    children: 'Notifications',
+    hasBadge: true,
+    icon: 'Notification',
+  },
+}
+
+/**
+ * Button-based items are typically used to group a number of related items within a dropdown menu.
+ */
+export const WithMenu: Story = {
+  args: {
+    children: 'Help menu',
+    icon: 'Help',
+    onClick: () => void 0,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '200px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => {
+    return (
+      <Menu>
+        <Menu.Trigger>{({ getTriggerProps }) => <BottomBarItemButton {...args} {...getTriggerProps()} />}</Menu.Trigger>
+        <Menu.Popover>
+          <Menu.List>
+            <Menu.Item label="Menu Item 1" />
+            <Menu.Item label="Menu Item 2" />
+            <Menu.Item label="Menu Item 3" />
+          </Menu.List>
+        </Menu.Popover>
+      </Menu>
+    )
+  },
+}

--- a/src/components/bottom-bar/item/item-button.tsx
+++ b/src/components/bottom-bar/item/item-button.tsx
@@ -1,0 +1,25 @@
+import { BottomBarItemBase } from './item-base'
+
+import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+
+export interface BottomBarItemButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** The accessible name of the nav icon item. */
+  children: ReactNode
+  /** Optional badge to be displayed on the nav item */
+  hasBadge?: boolean
+  /** The nav item's icon. */
+  icon: ReactNode
+  /** The click handler for the nav item. */
+  onClick: MouseEventHandler<HTMLButtonElement>
+}
+
+/**
+ * A simple navigation item for use in the Bottom Bar's secondary navigation region. It will typically be used
+ * with a `Menu` to facilitate a grouping of related items.
+ *
+ * **Important:** ⚠️ Typically you will use this component via `BottomBar.MenuItem` as it wraps the button element
+ * in a list item (`<li>`) to ensure good semantics and accessibility when used with `BottomBar`.
+ */
+export function BottomBarItemButton(props: BottomBarItemButtonProps) {
+  return <BottomBarItemBase as="button" {...props} />
+}

--- a/src/components/bottom-bar/item/styles.ts
+++ b/src/components/bottom-bar/item/styles.ts
@@ -1,0 +1,75 @@
+import { css } from '@linaria/core'
+import { font } from '#src/components/text'
+import { styled } from '@linaria/react'
+import { ElDeprecatedIcon } from '../../deprecated-icon'
+
+export const elBottomBarItem = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-half) var(--spacing-none);
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-half);
+  background-color: var(--comp-navigation-colour-fill-bottom_bar-default);
+  border: var(--border-none);
+  border-radius: var(--border-radius-none);
+  color: var(--comp-navigation-colour-text-bottom_bar-default);
+  outline: none;
+
+  width: 100%;
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+export const ElBottomBarItemIcon = styled.span`
+  /* NOTE: Required for the badge to position correctly */
+  position: relative;
+
+  color: var(--comp-navigation-colour-icon-bottom_bar-default);
+  font-size: var(--icon_size-l);
+  width: var(--icon_size-l);
+  height: var(--icon_size-l);
+
+  ${ElDeprecatedIcon} {
+    color: inherit;
+    font-size: inherit;
+    width: inherit;
+    height: inherit;
+  }
+
+  /* NOTE: we only apply the current page styles to anchor-based items. */
+  :is(a)[aria-current='page'] & {
+    color: var(--comp-navigation-colour-icon-bottom_bar-select);
+  }
+`
+
+export const ElBottomBarItemLabel = styled.span`
+  color: var(--comp-navigation-colour-text-bottom_bar-default);
+  text-align: center;
+
+  ${font('3xs', 'medium')}
+
+  /* NOTE: we only apply the current page styles to anchor-based items. */
+  :is(a)[aria-current='page'] & {
+    color: var(--comp-navigation-colour-text-bottom_bar-select);
+  }
+`
+
+// TODO: This should be handled by a Badge component. All our NavIconItem should be responsible for is
+// positioning the badge correctly.
+export const ElBottomBarItemBadge = styled.span`
+  position: absolute;
+  /* NOTE: this positions the badge so that it is centered on the icon's right edge */
+  right: calc(-1 * var(--size-2) / 2);
+  width: var(--size-2);
+  height: var(--size-2);
+  background-color: var(--comp-navigation-colour-fill-notification_badge);
+  border-radius: 100%;
+`

--- a/src/components/top-bar/nav-icon-item/nav-icon-item-button.stories.tsx
+++ b/src/components/top-bar/nav-icon-item/nav-icon-item-button.stories.tsx
@@ -54,21 +54,7 @@ export const WithBadge: Story = {
 }
 
 /**
- * Nav icon items can also be rendered as a button. This is typically used to group a number of related items within a
- * dropdown menu. The code snippet below demonstrates how to use `TopBar.NavIconItem` with the `Menu` component.
- *
- * ```tsx
- * <Menu.Trigger>
- *  {({ getTriggerProps }) => (
- *    <TopBar.NavIconItem
- *      {...getTriggerProps()}
- *      as="button"
- *      aria-label="Help menu"
- *      icon={<Icon icon="help" />}
- *    />
- *  )}
- * </Menu.Trigger>
- * ```
+ * Button-based items are typically used to group a number of related items within a dropdown menu.
  */
 export const WithMenu: Story = {
   args: {

--- a/src/components/top-bar/nav-icon-item/styles.ts
+++ b/src/components/top-bar/nav-icon-item/styles.ts
@@ -12,7 +12,7 @@ export const elTopBarNavIconItem = css`
   border-radius: var(--comp-navigation-border-radius-nav_icon);
   background: var(--comp-navigation-colour-fill-nav_icon-default);
   border: var(--border-none);
-  color: var(--icon-app_bar-default);
+  color: var(--comp-navigation-colour-icon-nav_icon-secondary);
   outline: none;
 
   &:focus-visible {


### PR DESCRIPTION
### Context

- We've recently refactored the TopBar and SideBar components so they have a similar structure and consistent application of the compound component pattern.
- We want to do the same for BottomBar.

### This PR

- Creates a new item component for the bottom bar based on the existing implementation. However, this new implementation takes a similar approach to the top bar's nav icon item components.

<img width="920" alt="Screenshot 2025-06-26 at 11 26 52 am" src="https://github.com/user-attachments/assets/408a1a2f-7661-42b9-bd2e-039b2939dd2f" />
<img width="917" alt="Screenshot 2025-06-26 at 11 27 08 am" src="https://github.com/user-attachments/assets/cecaf05f-0ffa-4815-8e5e-5a6f461dc592" />
<img width="918" alt="Screenshot 2025-06-26 at 11 27 20 am" src="https://github.com/user-attachments/assets/38ed5110-fd13-4e96-ace4-22256077a38c" />
<img width="917" alt="Screenshot 2025-06-26 at 11 27 28 am" src="https://github.com/user-attachments/assets/723b149b-5c23-4fbd-a54f-8ec1a793d99a" />
<img width="916" alt="Screenshot 2025-06-26 at 11 27 43 am" src="https://github.com/user-attachments/assets/eca8f72a-563a-417b-83d0-7d91602bef37" />
