### PR TITLE
chore: add new bottom bar menu list as subcomponent of bottom bar

### DIFF
--- a/src/components/bottom-bar/item/styles.ts
+++ b/src/components/bottom-bar/item/styles.ts
@@ -11,7 +11,7 @@ export const elBottomBarItem = css`
   justify-content: center;
   align-items: center;
   gap: var(--spacing-half);
-  background-color: var(--comp-navigation-colour-fill-bottom_bar-default);
+  background-color: var(--comp-navigation-colour-fill-bottom_bar);
   border: var(--border-none);
   border-radius: var(--border-radius-none);
   color: var(--comp-navigation-colour-text-bottom_bar-default);
@@ -20,6 +20,8 @@ export const elBottomBarItem = css`
   width: 100%;
 
   &:focus-visible {
+    /* NOTE: z-index is required to ensure the focus ring is visible above other items */
+    z-index: 1;
     outline: var(--border-width-double) solid var(--colour-border-focus);
   }
 

--- a/src/components/bottom-bar/menu-list/__test__/menu-list-item.test.tsx
+++ b/src/components/bottom-bar/menu-list/__test__/menu-list-item.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { BottomBarListItem } from '../menu-list-item'
+
+test('renders an <a> element as child of a <li>', () => {
+  render(
+    <BottomBarListItem aria-current={false} href="/" icon="😎">
+      Item
+    </BottomBarListItem>,
+  )
+  const listItem = screen.getByRole('listitem')
+  const anchor = screen.getByRole('link', { name: 'Item' })
+
+  expect(listItem).toBeVisible()
+  expect(anchor).toBeVisible()
+  expect(listItem.firstChild).toBe(anchor)
+})
+
+test('forwards additional props to the underlying `SideBarMenuItem`', () => {
+  render(
+    <BottomBarListItem aria-current="page" href="/" icon="😎">
+      Item
+    </BottomBarListItem>,
+  )
+  expect(screen.getByRole('link', { name: 'Item' })).toHaveAttribute('aria-current', 'page')
+})

--- a/src/components/bottom-bar/menu-list/__test__/menu-list-menu-item.test.tsx
+++ b/src/components/bottom-bar/menu-list/__test__/menu-list-menu-item.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { BottomBarMenuListItem } from '../menu-list-menu-item'
+import { StarIcon } from '#src/icons/star'
+import { Menu } from '#src/components/menu/menu'
+
+test('renders as a list item containing a button', () => {
+  render(
+    <BottomBarMenuListItem aria-label="More" icon={<StarIcon />}>
+      More
+    </BottomBarMenuListItem>,
+  )
+
+  const listItem = screen.getByRole('listitem')
+  expect(listItem).toBeVisible()
+
+  const button = screen.getByRole('button', { name: 'More' })
+  expect(button).toBeVisible()
+})
+
+test('forwards props to the underlying nav item', () => {
+  render(
+    <BottomBarMenuListItem data-testid="nav-item" aria-label="More" icon={<StarIcon />}>
+      Fake child
+    </BottomBarMenuListItem>,
+  )
+
+  const button = screen.getByTestId('nav-item')
+  expect(button).toBeVisible()
+})
+
+test('opens the menu when clicked', () => {
+  render(
+    <BottomBarMenuListItem aria-label="More" icon={<StarIcon />}>
+      <Menu.Item label="Item 1" />
+      <Menu.Item label="Item 2" />
+      <Menu.Item label="Item 3" />
+    </BottomBarMenuListItem>,
+  )
+
+  const button = screen.getByRole('button')
+
+  fireEvent.click(button)
+
+  expect(button).toHaveAttribute('aria-expanded', 'true')
+  expect(screen.getByText('Item 1')).toBeVisible()
+  expect(screen.getByText('Item 2')).toBeVisible()
+  expect(screen.getByText('Item 3')).toBeVisible()
+})

--- a/src/components/bottom-bar/menu-list/__test__/menu-list.test.tsx
+++ b/src/components/bottom-bar/menu-list/__test__/menu-list.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { BottomBarMenuList } from '../menu-list'
+
+test('renders a list element', () => {
+  render(<BottomBarMenuList>Children</BottomBarMenuList>)
+  expect(screen.getByRole('list')).toBeVisible()
+})
+
+test('all children are rendered', async () => {
+  render(
+    <BottomBarMenuList>
+      <li>Item 1</li>
+      <li>Item 2</li>
+    </BottomBarMenuList>,
+  )
+  const items = await screen.findAllByRole('listitem')
+
+  expect(items).toHaveLength(2)
+})

--- a/src/components/bottom-bar/menu-list/index.ts
+++ b/src/components/bottom-bar/menu-list/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './menu-list'

--- a/src/components/bottom-bar/menu-list/menu-list-item.tsx
+++ b/src/components/bottom-bar/menu-list/menu-list-item.tsx
@@ -1,0 +1,20 @@
+import { BottomBarItemAnchor } from '../item'
+import { ElBottomBarMenuListItem } from './styles'
+
+import type { ComponentProps } from 'react'
+
+interface BottomBarListItemProps extends ComponentProps<typeof BottomBarItemAnchor> {}
+
+/**
+ * A thin wrapper around `BottomBarMenuItem` that ensures it is contained within a list item (`<li>`) for
+ * correct semantics and accessibility when used with `BottomBar.MenuList`.
+ *
+ * All props are passed through to `BottomBarMenuItem`.
+ */
+export function BottomBarListItem({ children, ...props }: BottomBarListItemProps) {
+  return (
+    <ElBottomBarMenuListItem>
+      <BottomBarItemAnchor {...props}>{children}</BottomBarItemAnchor>
+    </ElBottomBarMenuListItem>
+  )
+}

--- a/src/components/bottom-bar/menu-list/menu-list-menu-item.tsx
+++ b/src/components/bottom-bar/menu-list/menu-list-menu-item.tsx
@@ -1,0 +1,44 @@
+import { BottomBarItemButton } from '../item'
+import { ElBottomBarMenuListItem, ElBottomBarMenu } from './styles'
+import { Menu } from '../../menu'
+import { MoreIcon } from '#src/icons/more'
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+interface BottomBarMenuListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode
+  icon?: ReactNode
+  label?: string
+  maxWidth?: `--size-${string}`
+  maxHeight?: `--size-${string}`
+}
+
+/**
+ * A combination of a `BottomBar.ItemButton` and `Menu` that is contained within a list item (`<li>`) for
+ * correct semantics and accessibility when used with `BottomBar.MenuList`.
+ *
+ * All props are passed through to `BottomBar.ItemButton`.
+ */
+export function BottomBarMenuListItem({
+  children,
+  icon = <MoreIcon />,
+  label = 'More',
+  ...rest
+}: BottomBarMenuListItemProps) {
+  return (
+    <ElBottomBarMenuListItem>
+      <ElBottomBarMenu data-alignment="right">
+        <Menu.Trigger>
+          {({ getTriggerProps }) => (
+            <BottomBarItemButton {...getTriggerProps(rest)} icon={icon}>
+              {label}
+            </BottomBarItemButton>
+          )}
+        </Menu.Trigger>
+        <Menu.Popover>
+          <Menu.List>{children}</Menu.List>
+        </Menu.Popover>
+      </ElBottomBarMenu>
+    </ElBottomBarMenuListItem>
+  )
+}

--- a/src/components/bottom-bar/menu-list/menu-list.stories.tsx
+++ b/src/components/bottom-bar/menu-list/menu-list.stories.tsx
@@ -1,0 +1,89 @@
+import { BottomBarMenuList } from './menu-list'
+import { Menu } from '#src/components/menu'
+import { Pattern } from '#src/components/drawer/__story__/Pattern'
+import { StarIcon } from '#src/icons/star'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+// Common href for all menu items that links to the current storybook page.
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Components/BottomBar/MenuList',
+  component: BottomBarMenuList,
+  argTypes: {
+    children: {
+      control: 'radio',
+      options: ['No selected item', 'Selected item'],
+      mapping: {
+        'No selected item': buildMenu('No selected item'),
+        'Selected item': buildMenu('Selected item'),
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+        }}
+      >
+        <Pattern height="120px" />
+        <Story />
+      </div>
+    ),
+  ],
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+} satisfies Meta<typeof BottomBarMenuList>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'No selected item',
+  },
+}
+
+/**
+ * If a menu item represents the current page, it should be marked as "selected". See the `BottomBar.Item`
+ * documentation for details on how.
+ */
+export const SelectedItem: Story = {
+  args: {
+    children: 'Selected item',
+  },
+}
+
+function buildMenu(type: 'No selected item' | 'Selected item') {
+  return [
+    <BottomBarMenuList.Item
+      key="1"
+      aria-current={type === 'Selected item' ? 'page' : false}
+      href={href}
+      icon={<StarIcon />}
+    >
+      Menu item 1
+    </BottomBarMenuList.Item>,
+    <BottomBarMenuList.Item key="2" aria-current={false} href={href} icon={<StarIcon />}>
+      Menu item 2
+    </BottomBarMenuList.Item>,
+    <BottomBarMenuList.Item key="3" aria-current={false} href={href} icon={<StarIcon />}>
+      Menu item 3
+    </BottomBarMenuList.Item>,
+    <BottomBarMenuList.Item key="4" aria-current={false} href={href} icon={<StarIcon />}>
+      Menu item 4
+    </BottomBarMenuList.Item>,
+    <BottomBarMenuList.MenuItem key="5">
+      <Menu.Item label="Menu item 5" />
+      <Menu.Item label="Menu item 6" />
+      <Menu.Item label="Menu item 7" />
+    </BottomBarMenuList.MenuItem>,
+  ]
+}

--- a/src/components/bottom-bar/menu-list/menu-list.tsx
+++ b/src/components/bottom-bar/menu-list/menu-list.tsx
@@ -1,0 +1,23 @@
+import { BottomBarListItem } from './menu-list-item'
+import { BottomBarMenuListItem } from './menu-list-menu-item'
+import { ElBottomBarMenuList } from './styles'
+
+import type { ComponentProps } from 'react'
+
+interface BottomBarMenuListProps extends ComponentProps<typeof ElBottomBarMenuList> {}
+
+/**
+ * The menu list for the `BottomBar`. Typically provided a collection of `BottomBar.Item` and `BottomBar.MenuItem`
+ * components as children. Should only contain a maximum of five (5) items. If more are needed, the fifth item
+ * in the list should a `BottomBar.MenuItem` that provides access to the remaining items via a dropdown menu.
+ *
+ * Note: There are limitations with the `Menu` component which prevent us from always placing it above its trigger
+ * button. Further, it's automatic placement logic relies on the menu being close to the viewport's edge, which means
+ * it always has room on Storybook docs pages to render below its trigger.
+ */
+export function BottomBarMenuList({ children, ...rest }: BottomBarMenuListProps) {
+  return <ElBottomBarMenuList {...rest}>{children}</ElBottomBarMenuList>
+}
+
+BottomBarMenuList.Item = BottomBarListItem
+BottomBarMenuList.MenuItem = BottomBarMenuListItem

--- a/src/components/bottom-bar/menu-list/styles.ts
+++ b/src/components/bottom-bar/menu-list/styles.ts
@@ -1,0 +1,24 @@
+import { Menu } from '#src/components/menu/menu'
+import { styled } from '@linaria/react'
+
+export const ElBottomBarMenuList = styled.menu`
+  list-style: none;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: stretch;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-block: 0;
+  padding-inline: 0;
+  width: 100%;
+`
+
+export const ElBottomBarMenuListItem = styled.li`
+  display: block;
+  flex-grow: 1;
+`
+
+export const ElBottomBarMenu = styled(Menu)`
+  width: 100%;
+`


### PR DESCRIPTION
### Context

- We've recently refactored the TopBar and SideBar components so they have a similar structure and consistent application of the compound component pattern.
- We want to do the same for BottomBar.
- New bottom bar item components were added in #545 

### This PR

- Adds a new menu list component for the bottom bar. This is used to help ensure good a11y for the bottom bar items.

<img width="915" alt="Screenshot 2025-06-26 at 11 50 00 am" src="https://github.com/user-attachments/assets/5ca27e5f-09f6-4bcd-a103-4ae411fbd8e3" />
<img width="917" alt="Screenshot 2025-06-26 at 11 50 04 am" src="https://github.com/user-attachments/assets/b9d27365-5b70-4f24-b319-f0739d7633a6" />
