### PR TITLE
chore: Update drawer to use new `overlay/50` variable

### DIFF
--- a/src/components/drawer/header/close-button.tsx
+++ b/src/components/drawer/header/close-button.tsx
@@ -13,7 +13,7 @@ export function DrawerHeaderCloseButton() {
         autoFocus
         aria-label="Close"
         formMethod="dialog"
-        iconLeft={<CloseIcon aria-hidden />}
+        iconLeft={<CloseIcon size="lg" aria-hidden />}
         size="large"
         type="submit"
         variant="tertiary"

--- a/src/components/drawer/styles.ts
+++ b/src/components/drawer/styles.ts
@@ -54,7 +54,7 @@ export const ElDrawer = styled.dialog`
     transform: translateX(0);
 
     &::backdrop {
-      background-color: rgb(0 0 0 / 25%);
+      background-color: var(--overlay-50);
     }
   }
 
@@ -69,7 +69,7 @@ export const ElDrawer = styled.dialog`
       &[open] {
         transform: translateX(100%);
         &::backdrop {
-          background-color: rgb(0 0 0 / 0%);
+          background-color: transparent;
         }
       }
     }


### PR DESCRIPTION
### This PR

- Updates drawer to use new `overlay/50` variable added in #541 for it's backdrop
- Works around a bug in the button + new icon combination. The button is not correctly controlling the size that the new icons should have, so the close icon in the drawer header's close button was rendering too large. The work around is to simply set an explicit size on the icon rather than rely on the button to size the icon's container correctly.

### Before
<img width="866" alt="Screenshot 2025-06-26 at 12 57 42 pm" src="https://github.com/user-attachments/assets/93ea4210-5726-4603-a5fa-2d48a37ab159" />

### After
<img width="950" alt="Screenshot 2025-06-26 at 12 57 47 pm" src="https://github.com/user-attachments/assets/386b6201-4ede-411c-a675-68be081af108" />
