### PR TITLE
fix: app switcher/nav icon item regressions

### DIFF
--- a/src/components/app-switcher/app-switcher.stories.tsx
+++ b/src/components/app-switcher/app-switcher.stories.tsx
@@ -36,8 +36,7 @@ export const Example: Story = {
       <AppSwitcher.YourAppsMenuGroup key="1">
         <AppSwitcher.ProductMenuItem href={href} productId="ireWeb" />
       </AppSwitcher.YourAppsMenuGroup>,
-      <AppSwitcher.Divider key="2" />,
-      <AppSwitcher.ExploreMenuGroup key="3">
+      <AppSwitcher.ExploreMenuGroup key="2">
         <AppSwitcher.ProductMenuItem href={href} productId="consoleCloud" />
         <AppSwitcher.ProductMenuItem href={href} productId="keywhere" />
       </AppSwitcher.ExploreMenuGroup>,

--- a/src/components/app-switcher/nav-icon-button/nav-icon-button.tsx
+++ b/src/components/app-switcher/nav-icon-button/nav-icon-button.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { AppSwitcherIcon } from '#src/icons/app-switcher'
 import { TopBarNavIconItemButton } from '../../top-bar'
 
 import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
@@ -8,11 +8,5 @@ interface AppSwitcherNavIconButtonProps extends ButtonHTMLAttributes<HTMLButtonE
 }
 
 export function AppSwitcherNavIconButton({ 'aria-label': ariaLabel, ...rest }: AppSwitcherNavIconButtonProps) {
-  return (
-    <TopBarNavIconItemButton
-      {...rest}
-      aria-label={ariaLabel ?? 'App Switcher'}
-      icon={<DeprecatedIcon icon="appSwitcher" />}
-    />
-  )
+  return <TopBarNavIconItemButton {...rest} aria-label={ariaLabel ?? 'App Switcher'} icon={<AppSwitcherIcon />} />
 }

--- a/src/components/top-bar/nav-icon-item/styles.ts
+++ b/src/components/top-bar/nav-icon-item/styles.ts
@@ -12,7 +12,7 @@ export const elTopBarNavIconItem = css`
   border-radius: var(--comp-navigation-border-radius-nav_icon);
   background: var(--comp-navigation-colour-fill-nav_icon-default);
   border: var(--border-none);
-  color: var(--comp-navigation-colour-icon-nav_icon-secondary);
+  color: var(--comp-navigation-colour-icon-nav_icon-default);
   outline: none;
 
   &:focus-visible {


### PR DESCRIPTION
### This PR

- Fixes duplicate menu group divider in app switcher menu (this regression occurred when Menu.MenuGroup was update to include a divider itself).
- Fixes invalid CSS variable usage in nav icon items.

**Before**
<img width="285" alt="Screenshot 2025-06-27 at 2 43 28 pm" src="https://github.com/user-attachments/assets/f5a69eec-e268-4b17-ae9a-1dfc32c51336" />

**After**
<img width="290" alt="Screenshot 2025-06-27 at 2 43 09 pm" src="https://github.com/user-attachments/assets/ed1a666a-af72-4ced-83a0-4ea58dd6b6cb" />
