### PR TITLE
chore: `SideBar` uses new icons and sizes them correctly

### DIFF
--- a/src/components/side-bar/menu-group/menu-group-summary.tsx
+++ b/src/components/side-bar/menu-group/menu-group-summary.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon } from '#src/icons/chevron-down'
 import { cx } from '@linaria/core'
 import {
   elSideBarMenuGroup,
@@ -7,7 +8,6 @@ import {
   ElSideBarMenuGroupSummaryDropdownIcon,
 } from './styles'
 import { elSideBarMenuItem } from '../menu-item'
-import { DeprecatedIcon } from '../../deprecated-icon'
 import { useCallback } from 'react'
 import { useSideBarMenuGroupLabelIdContext } from './menu-group-label-id-context'
 
@@ -70,7 +70,7 @@ export function SideBarMenuGroupSummary({
       <ElSideBarMenuGroupSummaryIcon aria-hidden>{icon}</ElSideBarMenuGroupSummaryIcon>
       <ElSideBarMenuGroupSummaryLabel>{children}</ElSideBarMenuGroupSummaryLabel>
       <ElSideBarMenuGroupSummaryDropdownIcon aria-hidden>
-        <DeprecatedIcon icon="chevronDown" />
+        <ChevronDownIcon />
       </ElSideBarMenuGroupSummaryDropdownIcon>
     </summary>
   )

--- a/src/components/side-bar/menu-group/menu-group.stories.tsx
+++ b/src/components/side-bar/menu-group/menu-group.stories.tsx
@@ -1,8 +1,8 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { PropertyIcon } from '#src/icons/property'
 import { SideBarMenuGroup } from './menu-group'
 import { SideBarSubmenu } from '../submenu'
-import { useArgs } from 'storybook/preview-api'
 import * as SideBarSubmenuItemStories from '../submenu-item/submenu-item.stories'
+import { useArgs } from 'storybook/preview-api'
 import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
 import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
 
@@ -58,7 +58,7 @@ export const Example: Story = {
   args: {
     children: 'No selected item',
     isActive: false,
-    summary: <SideBarMenuGroup.Summary icon={<DeprecatedIcon icon="property" />}>Menu group</SideBarMenuGroup.Summary>,
+    summary: <SideBarMenuGroup.Summary icon={<PropertyIcon />}>Menu group</SideBarMenuGroup.Summary>,
   },
 }
 

--- a/src/components/side-bar/menu-group/styles.ts
+++ b/src/components/side-bar/menu-group/styles.ts
@@ -43,11 +43,18 @@ export const ElSideBarMenuGroupSummaryDropdownIcon = styled.span`
 
   color: var(--comp-navigation-colour-icon-sidebar-default);
 
+  /* NOTE: We don't want the padding to reduce the content size as we want the icons to be
+   * exactly --icon_size-s */
+  box-sizing: content-box;
   padding: var(--spacing-1);
 
+  width: var(--icon_size-s);
+  height: var(--icon_size-s);
+
+  /* TODO: remove this when DeprecatedIcon is removed. */
   ${ElDeprecatedIcon} {
-    width: var(--icon_size-xs);
-    height: var(--icon_size-xs);
+    width: inherit;
+    height: inherit;
   }
 
   details:open & {

--- a/src/components/side-bar/menu-item/menu-item.stories.tsx
+++ b/src/components/side-bar/menu-item/menu-item.stories.tsx
@@ -1,5 +1,8 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { DashboardIcon } from '#src/icons/dashboard'
+import { PropertyIcon } from '#src/icons/property'
+import { SettingsIcon } from '#src/icons/settings'
 import { SideBarMenuItem } from './menu-item'
+import { UserIcon } from '#src/icons/user'
 import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
 import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
 
@@ -16,10 +19,10 @@ const meta = {
       control: 'radio',
       options: ['Property', 'Dashboard', 'Settings', 'User'],
       mapping: {
-        Property: <DeprecatedIcon icon="property" />,
-        Dashboard: <DeprecatedIcon icon="dashboard" />,
-        Settings: <DeprecatedIcon icon="settings" />,
-        User: <DeprecatedIcon icon="user" />,
+        Property: <PropertyIcon />,
+        Dashboard: <DashboardIcon />,
+        Settings: <SettingsIcon />,
+        User: <UserIcon />,
       },
     },
   },

--- a/src/components/side-bar/menu-item/styles.ts
+++ b/src/components/side-bar/menu-item/styles.ts
@@ -50,20 +50,23 @@ export const ElSideBarMenuItemLabel = styled.span`
 export const ElSideBarMenuItemIcon = styled.span`
   grid-area: icon;
 
+  /* NOTE: We don't want the padding to reduce the content size as we want the icons to be
+   * exactly --icon_size-m */
+  box-sizing: content-box;
+  padding: var(--spacing-half);
+
+  width: var(--icon_size-m);
+  height: var(--icon_size-m);
+
   color: var(--comp-navigation-colour-icon-sidebar-default);
   [aria-current='page'] > & {
     color: var(--comp-navigation-colour-icon-sidebar-select);
   }
 
-  /* TODO: remove this when our Icon component inherits by default and
-   * can be sized via props correctly. */
+  /* TODO: remove this when DeprecatedIcon is removed. */
   ${ElDeprecatedIcon} {
     color: inherit;
-    width: var(--icon_size-m);
-    height: var(--icon_size-m);
+    width: inherit;
+    height: inherit;
   }
-
-  display: flex;
-  place-items: center;
-  padding: var(--spacing-half);
 `

--- a/src/components/side-bar/menu-list/menu-list.stories.tsx
+++ b/src/components/side-bar/menu-list/menu-list.stories.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { PropertyIcon } from '#src/icons/property'
 import { SideBarMenuList } from './menu-list'
 import { useSideBarContextDecorator } from '../__story__/use-side-bar-context-decorator'
 import { useSideBarWidthDecorator } from '../__story__/use-side-bar-width-decorator'
@@ -95,17 +95,13 @@ function buildMenu(type: 'No selected item' | 'Selected item' | 'Selected submen
       key="1"
       aria-current={type === 'Selected item' ? 'page' : false}
       href={href}
-      icon={<DeprecatedIcon icon="property" />}
+      icon={<PropertyIcon />}
     >
       Menu item 1
     </SideBarMenuList.Item>,
     <SideBarMenuList.Group
       key="2"
-      summary={
-        <SideBarMenuList.GroupSummary icon={<DeprecatedIcon icon="property" />}>
-          Menu item 2
-        </SideBarMenuList.GroupSummary>
-      }
+      summary={<SideBarMenuList.GroupSummary icon={<PropertyIcon />}>Menu item 2</SideBarMenuList.GroupSummary>}
     >
       <SideBarMenuList.Submenu>
         <SideBarMenuList.SubmenuItem aria-current={type === 'Selected submenu item' ? 'page' : false} href={href}>

--- a/src/components/side-bar/side-bar.stories.tsx
+++ b/src/components/side-bar/side-bar.stories.tsx
@@ -1,4 +1,7 @@
-import { DeprecatedIcon } from '../deprecated-icon'
+import { DashboardIcon } from '#src/icons/dashboard'
+import { ContactIcon } from '#src/icons/contact'
+import { PropertyIcon } from '#src/icons/property'
+import { SettingsIcon } from '#src/icons/settings'
 import { SideBar } from './side-bar'
 import { useViewportHeightDecorator } from './__story__/use-viewport-height-decorator'
 
@@ -84,22 +87,20 @@ function buildMenu(
 ) {
   return (
     <SideBar.MenuList>
-      <SideBar.MenuItem aria-current={false} key="1" href={href} icon={<DeprecatedIcon icon="dashboard" />}>
+      <SideBar.MenuItem aria-current={false} key="1" href={href} icon={<DashboardIcon />}>
         Menu item 1
       </SideBar.MenuItem>
       <SideBar.MenuItem
         key="2"
         aria-current={type === 'Menu Item 2 selected' ? 'page' : false}
         href={href}
-        icon={<DeprecatedIcon icon="contact" />}
+        icon={<ContactIcon />}
       >
         Menu item 2
       </SideBar.MenuItem>
       <SideBar.MenuGroup
         key="3"
-        summary={
-          <SideBar.MenuGroupSummary icon={<DeprecatedIcon icon="property" />}>Menu item 3</SideBar.MenuGroupSummary>
-        }
+        summary={<SideBar.MenuGroupSummary icon={<PropertyIcon />}>Menu item 3</SideBar.MenuGroupSummary>}
       >
         <SideBar.Submenu>
           <SideBar.SubmenuItem aria-current={false} href={href}>
@@ -113,9 +114,7 @@ function buildMenu(
       <SideBar.MenuGroup
         key="4"
         isActive={type === 'Menu Item 4 active'}
-        summary={
-          <SideBar.MenuGroupSummary icon={<DeprecatedIcon icon="settings" />}>Menu item 4</SideBar.MenuGroupSummary>
-        }
+        summary={<SideBar.MenuGroupSummary icon={<SettingsIcon />}>Menu item 4</SideBar.MenuGroupSummary>}
       >
         <SideBar.Submenu>
           <SideBar.SubmenuItem aria-current={false} href={href}>

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -20,6 +20,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 - **chore:** Added CSS linting for Elements components.
 - **chore:** Added basic icon migration guide. See [Icons / Migrating to v5](?path=/docs/icons-migrating-to-v5--docs) for details.
+- **chore:** Updated `SideBar` to support and use new icons.
 
 ### **5.0.0-beta.33 - 27/06/25**
 


### PR DESCRIPTION
What it says on the tin.

**Before**

<img width="1034" alt="Screenshot 2025-06-30 at 11 05 42 am" src="https://github.com/user-attachments/assets/74826a18-5793-4b3d-9a49-3f011bf15052" />

**After**

<img width="1043" alt="Screenshot 2025-06-30 at 11 04 19 am" src="https://github.com/user-attachments/assets/eba1b07e-111e-4f0f-b617-e0fbd780693a" />
