### PR TITLE
chore: `TopBar` uses new icons and sizes them correctly

### DIFF
--- a/src/components/top-bar/__test__/__snapshots__/top-bar.test.tsx.snap
+++ b/src/components/top-bar/__test__/__snapshots__/top-bar.test.tsx.snap
@@ -3,40 +3,40 @@
 exports[`TopBar snapshot 1`] = `
 <DocumentFragment>
   <header
-    class="mocked-styled-35 el-top-bar"
+    class="mocked-styled-34 el-top-bar"
   >
     <div
-      class="mocked-styled-36 el-top-bar-app-switcher-container"
+      class="mocked-styled-35 el-top-bar-app-switcher-container"
     >
       App switcher
     </div>
     <div
-      class="mocked-styled-37 el-top-bar-logo-container"
+      class="mocked-styled-36 el-top-bar-logo-container"
     >
       Logo
     </div>
     <div
-      class="mocked-styled-39 el-top-bar-main-nav-container"
+      class="mocked-styled-38 el-top-bar-main-nav-container"
     >
       Main nav
     </div>
     <div
-      class="mocked-styled-41 el-top-bar-search-container"
+      class="mocked-styled-40 el-top-bar-search-container"
     >
       Search
     </div>
     <div
-      class="mocked-styled-40 el-top-bar-secondary-nav-container"
+      class="mocked-styled-39 el-top-bar-secondary-nav-container"
     >
       Secondary nav
     </div>
     <div
-      class="mocked-styled-42 el-top-bar-menu-container"
+      class="mocked-styled-41 el-top-bar-menu-container"
     >
       Mobile nav
     </div>
     <div
-      class="mocked-styled-38 el-top-bar-avatar-container"
+      class="mocked-styled-37 el-top-bar-avatar-container"
     >
       Profile
     </div>

--- a/src/components/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
+++ b/src/components/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
@@ -1,5 +1,5 @@
+import { ChevronDownIcon } from '#src/icons/chevron-down'
 import { ElTopBarNavDropdownButton, ElTopBarNavDropdownButtonIcon, ElTopBarNavDropdownButtonLabel } from './styles'
-import { DeprecatedIcon } from '../../deprecated-icon'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
@@ -33,8 +33,8 @@ export function TopBarNavDropdownButton({
   return (
     <ElTopBarNavDropdownButton {...rest} aria-expanded={ariaExpanded}>
       <ElTopBarNavDropdownButtonLabel>{children}</ElTopBarNavDropdownButtonLabel>
-      <ElTopBarNavDropdownButtonIcon>
-        <DeprecatedIcon aria-hidden="true" intent="default" icon="chevronDown" fontSize="1rem" />
+      <ElTopBarNavDropdownButtonIcon aria-hidden>
+        <ChevronDownIcon />
       </ElTopBarNavDropdownButtonIcon>
     </ElTopBarNavDropdownButton>
   )

--- a/src/components/top-bar/nav-dropdown-button/styles.ts
+++ b/src/components/top-bar/nav-dropdown-button/styles.ts
@@ -32,6 +32,7 @@ export const ElTopBarNavDropdownButton = styled.button`
     background: var(--comp-navigation-colour-fill-nav_item-hover);
   }
 
+  /* TODO: Remove this when DeprecatedIcon is removed. */
   ${ElDeprecatedIcon} {
     pointer-events: none;
     margin-left: 0;
@@ -46,6 +47,11 @@ export const ElTopBarNavDropdownButtonLabel = styled.span`
 `
 
 export const ElTopBarNavDropdownButtonIcon = styled.span`
+  color: var(--comp-navigation-colour-icon-nav_button-default);
+
+  width: var(--icon_size-s);
+  height: var(--icon_size-s);
+
   [aria-expanded='true'] & {
     transform: rotate(180deg);
   }

--- a/src/components/top-bar/nav-icon-item/nav-icon-item-anchor.stories.tsx
+++ b/src/components/top-bar/nav-icon-item/nav-icon-item-anchor.stories.tsx
@@ -1,4 +1,7 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { ContactIcon } from '#src/icons/contact'
+import { HelpIcon } from '#src/icons/help'
+import { NotificationIcon } from '#src/icons/notification'
+import { StarIcon } from '#src/icons/star'
 import { TopBarNavIconItemAnchor } from './nav-icon-item-anchor'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
@@ -21,10 +24,10 @@ const meta = {
       control: 'radio',
       options: ['contact', 'help', 'notification', 'star'],
       mapping: {
-        contact: <DeprecatedIcon icon="contact" />,
-        help: <DeprecatedIcon icon="help" />,
-        notification: <DeprecatedIcon icon="notification" />,
-        star: <DeprecatedIcon icon="star" />,
+        contact: <ContactIcon />,
+        help: <HelpIcon />,
+        notification: <NotificationIcon />,
+        star: <StarIcon />,
       },
     },
   },
@@ -72,6 +75,6 @@ export const WithBadge: Story = {
     ...Example.args,
     'aria-label': 'Notifications',
     hasBadge: true,
-    icon: <DeprecatedIcon icon="notification" />,
+    icon: 'notification',
   },
 }

--- a/src/components/top-bar/nav-icon-item/nav-icon-item-button.stories.tsx
+++ b/src/components/top-bar/nav-icon-item/nav-icon-item-button.stories.tsx
@@ -1,4 +1,7 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { ContactIcon } from '#src/icons/contact'
+import { HelpIcon } from '#src/icons/help'
+import { NotificationIcon } from '#src/icons/notification'
+import { StarIcon } from '#src/icons/star'
 import { Menu } from '../../menu'
 import { TopBarNavIconItemButton } from './nav-icon-item-button'
 
@@ -12,10 +15,10 @@ const meta = {
       control: 'radio',
       options: ['contact', 'help', 'notification', 'star'],
       mapping: {
-        contact: <DeprecatedIcon icon="contact" />,
-        help: <DeprecatedIcon icon="help" />,
-        notification: <DeprecatedIcon icon="notification" />,
-        star: <DeprecatedIcon icon="star" />,
+        contact: <ContactIcon />,
+        help: <HelpIcon />,
+        notification: <NotificationIcon />,
+        star: <StarIcon />,
       },
     },
   },
@@ -34,7 +37,7 @@ export const Example: Story = {
   args: {
     'aria-label': 'Nav icon item',
     hasBadge: false,
-    icon: <DeprecatedIcon icon="star" />,
+    icon: 'star',
     onClick: () => void 0,
   },
 }
@@ -49,7 +52,7 @@ export const WithBadge: Story = {
     ...Example.args,
     'aria-label': 'Notifications',
     hasBadge: true,
-    icon: <DeprecatedIcon icon="notification" />,
+    icon: 'notification',
   },
 }
 
@@ -59,7 +62,7 @@ export const WithBadge: Story = {
 export const WithMenu: Story = {
   args: {
     'aria-label': 'Help menu',
-    icon: <DeprecatedIcon icon="help" />,
+    icon: 'help',
     onClick: () => void 0,
   },
   decorators: [

--- a/src/components/top-bar/nav-icon-item/styles.ts
+++ b/src/components/top-bar/nav-icon-item/styles.ts
@@ -33,13 +33,13 @@ export const elTopBarNavIconItem = css`
 
 export const ElTopBarNavIconItemIcon = styled.span`
   color: inherit;
-  font-size: var(--icon_size-l);
   width: var(--icon_size-l);
   height: var(--icon_size-l);
 
+  /* TODO: Remove this when DeprecatedIcon is removed. */
   ${ElDeprecatedIcon} {
     color: inherit;
-    font-size: inherit;
+    font-size: var(--icon_size-l);
     width: inherit;
     height: inherit;
   }

--- a/src/components/top-bar/nav-search-button/styles.ts
+++ b/src/components/top-bar/nav-search-button/styles.ts
@@ -29,8 +29,8 @@ export const ElTopBarNavSearchButton = styled.button`
 `
 
 export const ElTopBarNavSearchButtonIcon = styled(SearchIcon)`
-  width: var(--icon-sm);
-  height: var(--icon-sm);
+  width: var(--icon_size-s);
+  height: var(--icon_size-s);
   flex-shrink: 0;
   color: var(--comp-navigation-colour-icon-nav_search);
 `

--- a/src/components/top-bar/nav-search-icon-item/nav-search-icon-item.tsx
+++ b/src/components/top-bar/nav-search-icon-item/nav-search-icon-item.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { SearchIcon } from '#src/icons/search'
 import { TopBarNavIconItemBase } from '../nav-icon-item'
 
 import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
@@ -13,12 +13,5 @@ interface TopBarNavSearchIconItemProps extends ButtonHTMLAttributes<HTMLButtonEl
  * for use on mobile devices. For tablet devices and wider, `TopBar.NavSearchButton` should be used instead.
  */
 export function TopBarNavSearchIconItem({ 'aria-label': ariaLabel, ...rest }: TopBarNavSearchIconItemProps) {
-  return (
-    <TopBarNavIconItemBase
-      {...rest}
-      aria-label={ariaLabel ?? 'Search'}
-      as="button"
-      icon={<DeprecatedIcon icon="search" />}
-    />
-  )
+  return <TopBarNavIconItemBase {...rest} aria-label={ariaLabel ?? 'Search'} as="button" icon={<SearchIcon />} />
 }

--- a/src/components/top-bar/secondary-nav/__test__/secondary-nav-list-item.test.tsx
+++ b/src/components/top-bar/secondary-nav/__test__/secondary-nav-list-item.test.tsx
@@ -1,5 +1,6 @@
+import { NotificationIcon } from '#src/icons/notification'
 import { render, screen } from '@testing-library/react'
-import { DeprecatedIcon } from '../../../deprecated-icon'
+import { StarIcon } from '#src/icons/star'
 import { TopBarSecondaryNavListItem } from '../secondary-nav-list-item'
 
 test('renders as a list item containing a navigation link', () => {
@@ -8,7 +9,7 @@ test('renders as a list item containing a navigation link', () => {
       href="https://example.com"
       aria-current={false}
       aria-label="My nav item"
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
     />,
   )
 
@@ -25,7 +26,7 @@ test('forwards props to the underlying nav icon item', () => {
       href="https://example.com"
       aria-current={false}
       aria-label="My nav item"
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
       data-testid="nav-icon-item"
     />,
   )
@@ -40,7 +41,7 @@ test('has `aria-current="false"` when `aria-current={false}`', () => {
       href="https://example.com"
       aria-current={false}
       aria-label="My nav item"
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
     />,
   )
 
@@ -54,7 +55,7 @@ test('has `aria-current="page"` when `aria-current="page"`', () => {
       href="https://example.com"
       aria-current="page"
       aria-label="My nav item"
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
     />,
   )
 
@@ -68,7 +69,7 @@ test('renders the correct href attribute', () => {
       href="https://custom-url.com"
       aria-current={false}
       aria-label="My nav item"
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
     />,
   )
 
@@ -82,7 +83,7 @@ test('can display a badge when `hasBadge` is `true`', () => {
       href="https://example.com"
       aria-current={false}
       aria-label="Notifications"
-      icon={<DeprecatedIcon icon="notification" />}
+      icon={<NotificationIcon />}
       hasBadge={true}
     />,
   )

--- a/src/components/top-bar/secondary-nav/__test__/secondary-nav-menu-list-item.test.tsx
+++ b/src/components/top-bar/secondary-nav/__test__/secondary-nav-menu-list-item.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { Menu } from '#src/components/menu'
+import { StarIcon } from '#src/icons/star'
 import { TopBarSecondaryNavMenuListItem } from '../secondary-nav-menu-list-item'
-import { DeprecatedIcon } from '#src/components/deprecated-icon/index'
 
 test('renders as a list item containing a button', () => {
   render(
-    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<DeprecatedIcon icon="star" />}>
+    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<StarIcon />}>
       More
     </TopBarSecondaryNavMenuListItem>,
   )
@@ -19,7 +19,7 @@ test('renders as a list item containing a button', () => {
 
 test('forwards props to the underlying nav item', () => {
   render(
-    <TopBarSecondaryNavMenuListItem data-testid="nav-item" aria-label="More" icon={<DeprecatedIcon icon="star" />}>
+    <TopBarSecondaryNavMenuListItem data-testid="nav-item" aria-label="More" icon={<StarIcon />}>
       Fake child
     </TopBarSecondaryNavMenuListItem>,
   )
@@ -30,7 +30,7 @@ test('forwards props to the underlying nav item', () => {
 
 test('opens the menu when clicked', () => {
   render(
-    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<DeprecatedIcon icon="star" />}>
+    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<StarIcon />}>
       <Menu.Item label="Item 1" />
       <Menu.Item label="Item 2" />
       <Menu.Item label="Item 3" />

--- a/src/components/top-bar/secondary-nav/secondary-nav.stories.tsx
+++ b/src/components/top-bar/secondary-nav/secondary-nav.stories.tsx
@@ -1,4 +1,5 @@
-import { DeprecatedIcon } from '../../deprecated-icon'
+import { StarIcon } from '#src/icons/star'
+import { HelpIcon } from '#src/icons/help'
 import { Menu } from '../../menu'
 import { TopBarSecondaryNav } from './secondary-nav'
 
@@ -63,19 +64,19 @@ function buildNav(type: 'No selected item' | 'Selected item' | 'With menu') {
     <TopBarSecondaryNav.Item
       key="1"
       href={href}
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
       aria-label="Nav icon item 1"
       aria-current={type === 'Selected item' ? 'page' : false}
     />,
     <TopBarSecondaryNav.Item
       key="2"
       href={href}
-      icon={<DeprecatedIcon icon="star" />}
+      icon={<StarIcon />}
       aria-label="Nav icon item 2"
       aria-current={false}
     />,
     type === 'With menu' && (
-      <TopBarSecondaryNav.MenuItem key="3" icon={<DeprecatedIcon icon="help" />} aria-label="Help menu">
+      <TopBarSecondaryNav.MenuItem key="3" icon={<HelpIcon />} aria-label="Help menu">
         <Menu.Item label="Menu item 1" />
         <Menu.Item label="Menu item 2" />
         <Menu.Item label="Menu item 3" />

--- a/src/components/top-bar/top-bar.stories.tsx
+++ b/src/components/top-bar/top-bar.stories.tsx
@@ -1,8 +1,10 @@
 import { AppSwitcher } from '../app-switcher'
 import { elTopBarMenuPopover } from './styles'
-import { DeprecatedIcon } from '../deprecated-icon'
+import { HelpIcon } from '#src/icons/help'
 import { Menu } from '../menu'
 import { MenuAltIcon } from '#src/icons/menu-alt'
+import { NotificationIcon } from '#src/icons/notification'
+import { StarIcon } from '#src/icons/star'
 import { supportedAppNames } from './brand-logo'
 import { TopBar } from './top-bar'
 import { TopBarNavIconItemButton } from './nav-icon-item'
@@ -145,7 +147,7 @@ const meta = {
         None: null,
         Some: (
           <TopBar.SecondaryNav>
-            <TopBar.NavIconMenuItem aria-label="Nav icon item 1" icon={<DeprecatedIcon icon="help" />}>
+            <TopBar.NavIconMenuItem aria-label="Nav icon item 1" icon={<HelpIcon />}>
               <Menu.Item label="Menu item 1" />
               <Menu.Item label="Menu item 2" />
               <Menu.Item label="Menu item 3" />
@@ -154,14 +156,9 @@ const meta = {
               aria-current={false}
               aria-label="Nav icon item 2"
               href={href}
-              icon={<DeprecatedIcon icon="notification" />}
+              icon={<NotificationIcon />}
             />
-            <TopBar.NavIconItem
-              aria-current={false}
-              aria-label="Nav icon item 3"
-              href={href}
-              icon={<DeprecatedIcon icon="star" />}
-            />
+            <TopBar.NavIconItem aria-current={false} aria-label="Nav icon item 3" href={href} icon={<StarIcon />} />
           </TopBar.SecondaryNav>
         ),
       },

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -21,6 +21,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore:** Added CSS linting for Elements components.
 - **chore:** Added basic icon migration guide. See [Icons / Migrating to v5](?path=/docs/icons-migrating-to-v5--docs) for details.
 - **chore:** Updated `SideBar` to support and use new icons.
+- **chore:** Updated `TopBar` to support and use new icons.
 
 ### **5.0.0-beta.33 - 27/06/25**
 


### PR DESCRIPTION
What it says on the tin.

**Before**

<img width="1031" alt="Screenshot 2025-06-30 at 11 21 48 am" src="https://github.com/user-attachments/assets/3def6377-e388-4724-9fce-cb21e5e35f2f" />


**After**

<img width="1065" alt="Screenshot 2025-06-30 at 11 20 33 am" src="https://github.com/user-attachments/assets/cc009ad4-9234-4128-b97a-5583a7ec4d63" />
