### PR TITLE
feat: Add new `Accordion.Summary` component

### DIFF
--- a/src/components/accordion/accordion-label-id-context.ts
+++ b/src/components/accordion/accordion-label-id-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * Simple context object to allow the Accordion to automatically wire-up an `aria-labelledby` attribute
+ * on the `<details>` element that references the `id` attribute of the `<summary>` element's title text.
+ */
+export const AccordionLabelIdContext = createContext<string | null>(null)
+
+export function useAccordionLabelIdContext(): string {
+  const accordionLabelId = useContext(AccordionLabelIdContext)
+  if (!accordionLabelId) {
+    throw new Error('useAccordionLabelIdContext must be used within a AccordionLabelIdContext.Provider')
+  }
+  return accordionLabelId
+}

--- a/src/components/accordion/summary/__tests__/summary.test.tsx
+++ b/src/components/accordion/summary/__tests__/summary.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { AccordionLabelIdContext } from '../../accordion-label-id-context'
+import { AccordionSummary } from '../summary'
+
+import type { ReactNode } from 'react'
+
+test('renders a <summary> element', () => {
+  render(<AccordionSummary data-testid="summary">Accordion Title</AccordionSummary>, { wrapper })
+
+  // NOTE: <summary> elements have no implicit role, so we cannot use `getByRole` here to select <summary> element
+  // See https://w3c.github.io/html-aria/#el-summary. While the spec suggests some user agents apply an implicit
+  // button role, this does not appear to the case for React Testing Library
+  const summary = screen.getByTestId('summary')
+  expect(summary.tagName).toBe('SUMMARY')
+})
+
+test('right info is visible when provided', () => {
+  render(<AccordionSummary rightInfo="Right Info">Accordion Title</AccordionSummary>, { wrapper })
+  expect(screen.getByText('Right Info')).toBeVisible()
+})
+
+test('forwards additional props to the summary element', async () => {
+  render(<AccordionSummary data-testid="summary">Accordion Title</AccordionSummary>, { wrapper })
+  expect(screen.getByTestId('summary')).toBeVisible()
+})
+
+test('icon is visible, but hidden from the accessibility tree', () => {
+  const { container } = render(<AccordionSummary>Accordion Title</AccordionSummary>, { wrapper })
+
+  const icon = container.querySelector('[aria-hidden="true"] > svg')
+  expect(icon).toBeInTheDocument()
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AccordionLabelIdContext.Provider value="test-label-id">{children}</AccordionLabelIdContext.Provider>
+}

--- a/src/components/accordion/summary/index.ts
+++ b/src/components/accordion/summary/index.ts
@@ -1,0 +1,2 @@
+export * from './summary'
+export * from './styles'

--- a/src/components/accordion/summary/styles.ts
+++ b/src/components/accordion/summary/styles.ts
@@ -1,0 +1,53 @@
+import { font } from '#src/components/text'
+import { styled } from '@linaria/react'
+
+export const ElAccordionSummary = styled.summary`
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: var(--spacing-3);
+  width: 100%;
+
+  padding-inline: 0 var(--spacing-2);
+  padding-block: var(--spacing-4);
+
+  cursor: pointer;
+
+  color: var(--comp-accordion-colour-text);
+  ${font('base', 'medium')}
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+`
+
+export const ElAccordionSummaryTitle = styled.div`
+  flex: 1;
+  min-width: 0;
+`
+
+export const ElAccordionSummaryRightInfo = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: end;
+
+  color: var(--comp-accordion-colour-text);
+  ${font('xs', 'regular')}
+`
+
+export const ElAccordionSummaryIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: var(--icon_size-m);
+  height: var(--icon_size-m);
+
+  color: var(--comp-accordion-colour-icon);
+
+  details:open &,
+  details[open] & {
+    transform: rotate(180deg);
+  }
+`

--- a/src/components/accordion/summary/summary.stories.tsx
+++ b/src/components/accordion/summary/summary.stories.tsx
@@ -1,0 +1,113 @@
+import { AccordionLabelIdContext } from '../accordion-label-id-context'
+import { AccordionSummary } from './summary'
+import { BathIcon } from '#src/icons/bath'
+import { Button } from '#src/components/button/button'
+import { BedIcon } from '#src/icons/bed'
+import { CarIcon } from '#src/icons/car'
+import { Features } from '#src/components/features'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/Accordion/Summary',
+  component: AccordionSummary,
+  argTypes: {
+    rightInfo: {
+      control: 'radio',
+      options: ['None', 'Features', 'Value', 'Clear Button'],
+      mapping: {
+        None: undefined,
+        Features: (
+          <Features>
+            <Features.Item icon={<BedIcon />} aria-label="3">
+              3
+            </Features.Item>
+            <Features.Item icon={<BathIcon />} aria-label="3">
+              2
+            </Features.Item>
+            <Features.Item icon={<CarIcon />} aria-label="3">
+              2
+            </Features.Item>
+          </Features>
+        ),
+        Value: '2',
+        'Clear Button': (
+          <Button variant="tertiary" hasNoPadding>
+            Clear
+          </Button>
+        ),
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <AccordionLabelIdContext.Provider value="test-label-id">
+        <details>
+          <Story />
+        </details>
+      </AccordionLabelIdContext.Provider>
+    ),
+    (Story, { parameters: { width } }) => {
+      if (width) {
+        return (
+          <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width }}>
+            <Story />
+          </div>
+        )
+      } else {
+        return <Story />
+      }
+    },
+  ],
+} satisfies Meta<typeof AccordionSummary>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'Accordion Title',
+    rightInfo: 'None',
+  },
+}
+
+/**
+ * The `rightInfo` prop allows for additional summary information to be displayed. For example, the `Features`
+ * component can be used to display useful information about the property to which the accordion is related.
+ */
+export const WithFeatures: Story = {
+  args: {
+    ...Example.args,
+    rightInfo: 'Features',
+  },
+}
+
+/**
+ * The `rightInfo` prop also allows for an action to be displayed. This is typically used when the accordion
+ * represents a filter. The action in this case is typically a clear button that allows the user to clear any
+ * currently active filters related to the accordion.
+ *
+ * **Note:** ⚠️ Our `Button` component does not currently support the Design System's `linkStyle` property, so
+ * the visual outcome in this story is not as expected.
+ */
+export const WithClearButton: Story = {
+  args: {
+    ...Example.args,
+    rightInfo: 'Clear Button',
+  },
+}
+
+/**
+ * Titles should typically be concise for better scannability, but if they exceed the available space, they will wrap
+ * to another line
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    children: 'This is a very long title that wraps to a second line',
+  },
+  parameters: {
+    width: '330px',
+  },
+}

--- a/src/components/accordion/summary/summary.tsx
+++ b/src/components/accordion/summary/summary.tsx
@@ -1,0 +1,42 @@
+import { ChevronDownIcon } from '../../../icons/chevron-down'
+import { useAccordionLabelIdContext } from '../accordion-label-id-context'
+import {
+  ElAccordionSummary,
+  ElAccordionSummaryTitle,
+  ElAccordionSummaryRightInfo,
+  ElAccordionSummaryIcon,
+} from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface AccordionSummaryProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * The accordion's title. This will also serve as the accessible label for the accordion.
+   */
+  children: ReactNode
+  /**
+   * Optional information to display on the right side of the summary
+   */
+  rightInfo?: ReactNode
+}
+
+/**
+ * A summary component designed to be used within an Accordion. It displays a title with optional right-aligned
+ * information and a chevron icon that visually indicates the accordion's open state. It is explicitly designed for
+ * use within a `<details>` element, with its `open` state remaining uncontrolled.
+ *
+ * ⚠️ **Important**: `<summary>` elements are not interactive outside of a parent `<details>` element.
+ * This component should only be used as the summary for an Accordion component.
+ */
+export function AccordionSummary({ children, rightInfo, ...rest }: AccordionSummaryProps) {
+  const labelId = useAccordionLabelIdContext()
+  return (
+    <ElAccordionSummary {...rest}>
+      <ElAccordionSummaryTitle id={labelId}>{children}</ElAccordionSummaryTitle>
+      {rightInfo && <ElAccordionSummaryRightInfo>{rightInfo}</ElAccordionSummaryRightInfo>}
+      <ElAccordionSummaryIcon aria-hidden>
+        <ChevronDownIcon />
+      </ElAccordionSummaryIcon>
+    </ElAccordionSummary>
+  )
+}


### PR DESCRIPTION
### Context

- We're rebuilding our Accordion component for v5
- [Accordion designs](https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=2330-2973&m=dev) are ready for dev. 
- The new work will be staged over a number of PRs:
  - Part 1: #564
  - Part 2: Implement Accordion summary component **(this PR)**
  - Part 3: Implement Accordion component

### This PR

- Adds a new `Accordion.Summary` component.

<img width="816" alt="Screenshot 2025-06-30 at 1 28 50 pm" src="https://github.com/user-attachments/assets/2fd7730e-9465-48ec-9284-1125ad0a84bb" />
<img width="817" alt="Screenshot 2025-06-30 at 1 28 56 pm" src="https://github.com/user-attachments/assets/68b7f590-43ba-4a75-854d-12903064e8c4" />
<img width="815" alt="Screenshot 2025-06-30 at 3 55 47 pm" src="https://github.com/user-attachments/assets/aebadffa-2ab3-461c-8bfd-8654c37d0034" />
