### PR TITLE
chore: move all v4 component docs to a "Deprecated" group in Storybook

### DIFF
--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -23,7 +23,7 @@ import { MediaStateProvider } from '../../hooks/use-media-query'
 import { DeprecatedAvatar } from '../deprecated-avatar'
 
 export default {
-  title: 'Card',
+  title: 'Deprecated/Card',
   component: Card,
 }
 

--- a/src/components/deprecated-accordion/accordion.stories.tsx
+++ b/src/components/deprecated-accordion/accordion.stories.tsx
@@ -14,7 +14,7 @@ import { Meta, StoryObj } from '@storybook/react-vite'
 import { figmaDesignUrls } from '../../storybook/figma'
 
 const meta: Meta<typeof DeprecatedAccordion> = {
-  title: 'DeprecatedAccordion',
+  title: 'Deprecated/DeprecatedAccordion',
   component: DeprecatedAccordion,
 }
 

--- a/src/components/deprecated-badge/badge.stories.tsx
+++ b/src/components/deprecated-badge/badge.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedBadge, DeprecatedBadgeGroup } from '.'
 
 export default {
-  title: 'DeprecatedBadge',
+  title: 'Deprecated/DeprecatedBadge',
   component: DeprecatedBadge,
 }
 

--- a/src/components/deprecated-breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/deprecated-breadcrumb/breadcrumb.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedBreadCrumb } from './index'
 
 export default {
-  title: 'DeprecatedBreadCrumb',
+  title: 'Deprecated/DeprecatedBreadCrumb',
   component: DeprecatedBreadCrumb,
 }
 

--- a/src/components/deprecated-chip/chip.stories.tsx
+++ b/src/components/deprecated-chip/chip.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedChip as Chip, DeprecatedChipGroup as ChipGroup } from '.'
 
 export default {
-  title: 'DeprecatedChip',
+  title: 'Deprecated/DeprecatedChip',
   component: Chip,
 }
 

--- a/src/components/deprecated-drawer/drawer.stories.tsx
+++ b/src/components/deprecated-drawer/drawer.stories.tsx
@@ -9,7 +9,7 @@ import { TextArea } from '../textarea'
 import { TextBase } from '../typography'
 
 export default {
-  title: 'DeprecatedDrawer',
+  title: 'Deprecated/DeprecatedDrawer',
   component: Drawer,
 }
 

--- a/src/components/deprecated-icon/icon.stories.tsx
+++ b/src/components/deprecated-icon/icon.stories.tsx
@@ -2,7 +2,7 @@ import { DeprecatedIcon } from './index'
 import { elMb5 } from '../../styles/spacing'
 
 export default {
-  title: 'Icon',
+  title: 'Deprecated/DeprecatedIcon',
   component: DeprecatedIcon,
 }
 

--- a/src/components/deprecated-label/label.stories.tsx
+++ b/src/components/deprecated-label/label.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedLabel } from './index'
 
 export default {
-  title: 'DeprecatedLabel',
+  title: 'Deprecated/DeprecatedLabel',
   component: DeprecatedLabel,
 }
 

--- a/src/components/deprecated-nav/nav.stories.tsx
+++ b/src/components/deprecated-nav/nav.stories.tsx
@@ -8,7 +8,7 @@ import { elMlAuto, elMr2 } from '../../styles/spacing'
 import { DeprecatedNavResponsive } from './nav-responsive'
 
 export default {
-  title: 'DeprecatedNav',
+  title: 'Deprecated/DeprecatedNav',
   component: DeprecatedNavResponsive,
 }
 

--- a/src/components/deprecated-pagination/pagination.stories.tsx
+++ b/src/components/deprecated-pagination/pagination.stories.tsx
@@ -9,7 +9,7 @@ import { elDeprecatedPaginationPrimary } from './__styles__'
 import { DeprecatedIcon } from '../deprecated-icon'
 
 export default {
-  title: 'DeprecatedPagination',
+  title: 'Deprecated/DeprecatedPagination',
   component: DeprecatedPagination,
 }
 

--- a/src/components/deprecated-status-indicator/status-indicator.stories.tsx
+++ b/src/components/deprecated-status-indicator/status-indicator.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedStatusIndicator } from '.'
 
 export default {
-  title: 'DeprecatedStatusIndicator',
+  title: 'Deprecated/DeprecatedStatusIndicator',
   component: DeprecatedStatusIndicator,
 }
 

--- a/src/components/deprecated-table/table.stories.tsx
+++ b/src/components/deprecated-table/table.stories.tsx
@@ -24,7 +24,7 @@ import { Input } from '../input'
 import { TextBase } from '../typography'
 
 export default {
-  title: 'DeprecatedTable',
+  title: 'Deprecated/DeprecatedTable',
   component: DeprecatedTable,
 }
 

--- a/src/components/deprecated-tag/tag.stories.tsx
+++ b/src/components/deprecated-tag/tag.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedTag, DeprecatedTagGroup } from '.'
 
 export default {
-  title: 'DeprecatedTag',
+  title: 'Deprecated/DeprecatedTag',
   component: DeprecatedTag,
 }
 

--- a/src/components/deprecated-tool-tip/tooltip.stories.tsx
+++ b/src/components/deprecated-tool-tip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { DeprecatedToolTip } from './index'
 
 export default {
-  title: 'DeprecatedToolTip',
+  title: 'Deprecated/DeprecatedToolTip',
   component: DeprecatedToolTip,
 }
 

--- a/src/components/file-input/file-input.stories.tsx
+++ b/src/components/file-input/file-input.stories.tsx
@@ -5,7 +5,7 @@ import { FlexContainer } from '../layout'
 import { Button, DeprecatedButtonGroup } from '../button'
 
 export default {
-  title: 'FileInput',
+  title: 'Deprecated/FileInput',
   component: FileInput,
 }
 

--- a/src/components/form-layout/form-layout.stories.tsx
+++ b/src/components/form-layout/form-layout.stories.tsx
@@ -9,7 +9,7 @@ import { Select } from '../select'
 import { TextBase, TextSM } from '../typography'
 
 export default {
-  title: 'FormLayout',
+  title: 'Deprecated/FormLayout',
   component: FormLayout,
 }
 

--- a/src/components/grid/grid.stories.tsx
+++ b/src/components/grid/grid.stories.tsx
@@ -6,7 +6,7 @@ import { cx } from '@linaria/core'
 import { elColGap2, elRowGap3, elSpan12, elSpan8, elSpan4, elOffset4, elOffset8 } from './__styles__/units'
 
 export default {
-  title: 'Grid',
+  title: 'Deprecated/Grid',
 }
 
 export const BasicUsage = {

--- a/src/components/input-add-on/input-add-on.stories.tsx
+++ b/src/components/input-add-on/input-add-on.stories.tsx
@@ -2,7 +2,7 @@ import { InputAddOn } from './index'
 import { DeprecatedIcon } from '../deprecated-icon'
 
 export default {
-  title: 'InputAddOn',
+  title: 'Deprecated/InputAddOn',
   component: InputAddOn,
 }
 

--- a/src/components/input-error/input-error.stories.tsx
+++ b/src/components/input-error/input-error.stories.tsx
@@ -2,7 +2,7 @@ import { InputError } from './index'
 import { InputGroup } from '../input-group'
 
 export default {
-  title: 'InputError',
+  title: 'Deprecated/InputError',
   component: InputError,
 }
 

--- a/src/components/input-group/input-group.stories.tsx
+++ b/src/components/input-group/input-group.stories.tsx
@@ -5,7 +5,7 @@ import { DeprecatedLabel } from '../deprecated-label'
 import { InputAddOn } from '../input-add-on'
 
 export default {
-  title: 'InputGroup',
+  title: 'Deprecated/InputGroup',
   component: InputGroup,
 }
 

--- a/src/components/input/input.stories.tsx
+++ b/src/components/input/input.stories.tsx
@@ -2,7 +2,7 @@ import { StoryObj } from '@storybook/react-vite'
 import { Input } from './index'
 
 export default {
-  title: 'Input',
+  title: 'Deprecated/Input',
   component: Input,
 }
 

--- a/src/components/key-value-list/key-value-list.stories.tsx
+++ b/src/components/key-value-list/key-value-list.stories.tsx
@@ -1,7 +1,7 @@
 import { KeyValueList } from '.'
 
 export default {
-  title: 'KeyValueList',
+  title: 'Deprecated/KeyValueList',
   component: KeyValueList,
 }
 

--- a/src/components/layout/layout.stories.tsx
+++ b/src/components/layout/layout.stories.tsx
@@ -3,7 +3,7 @@ import { GridDemoBlock } from '../../storybook/demo-block'
 import { Grid, Col } from '../grid'
 
 export default {
-  title: 'Components/Layouts',
+  title: 'Deprecated/Layouts',
 }
 
 export const MainContainerUsage = {

--- a/src/components/loader/loader.stories.tsx
+++ b/src/components/loader/loader.stories.tsx
@@ -1,7 +1,7 @@
 import { Loader } from './index'
 
 export default {
-  title: 'Loader',
+  title: 'Deprecated/Loader',
   component: Loader,
 }
 

--- a/src/components/mobile-controls/mobile-controls.stories.tsx
+++ b/src/components/mobile-controls/mobile-controls.stories.tsx
@@ -1,7 +1,7 @@
 import { MobileControls } from './index'
 
 export default {
-  title: 'MobileControls',
+  title: 'Deprecated/MobileControls',
   component: MobileControls,
 }
 

--- a/src/components/modal/modal.stories.tsx
+++ b/src/components/modal/modal.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { Button } from '../button'
 
 export default {
-  title: 'Components/Modal',
+  title: 'Deprecated/Modal',
   component: Modal,
 }
 

--- a/src/components/multi-select/multi-select.stories.tsx
+++ b/src/components/multi-select/multi-select.stories.tsx
@@ -1,7 +1,7 @@
 import { MultiSelect, MultiSelectChip, MultiSelectInput, elHasGreyChips } from './index'
 
 export default {
-  title: 'MultiSelect',
+  title: 'Deprecated/MultiSelect',
   component: MultiSelect,
 }
 

--- a/src/components/page-header/page-header.stories.tsx
+++ b/src/components/page-header/page-header.stories.tsx
@@ -1,7 +1,7 @@
 import { PageHeader } from '.'
 
 export default {
-  title: 'PageHeader',
+  title: 'Deprecated/PageHeader',
   component: PageHeader,
 }
 

--- a/src/components/persistent-notification/persistent-notification.stories.tsx
+++ b/src/components/persistent-notification/persistent-notification.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { PersistentNotification } from './index'
 
 export default {
-  title: 'PersistentNotification',
+  title: 'Deprecated/PersistentNotification',
   component: PersistentNotification,
 }
 

--- a/src/components/placeholder-image/placeholder-image.stories.tsx
+++ b/src/components/placeholder-image/placeholder-image.stories.tsx
@@ -1,7 +1,7 @@
 import { PlaceholderImage } from './index'
 
 export default {
-  title: 'PlaceholderImage',
+  title: 'Deprecated/PlaceholderImage',
   component: PlaceholderImage,
 }
 

--- a/src/components/progress-bar/progress-bar.stories.tsx
+++ b/src/components/progress-bar/progress-bar.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { elProgressBarLabelRight, elProgressBarLabelLeft } from './__styles__'
 
 export default {
-  title: 'ProgressBar',
+  title: 'Deprecated/ProgressBar',
   component: ProgressBarSteps,
 }
 

--- a/src/components/searchable-dropdown/searchable-dropdown.stories.tsx
+++ b/src/components/searchable-dropdown/searchable-dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import { SearchableDropdown, ControlledSearchableDropdown, SearchableDropdownSearchLabel } from './index'
 
 export default {
-  title: 'SearchableDropdown',
+  title: 'Deprecated/SearchableDropdown',
   component: SearchableDropdown,
 }
 

--- a/src/components/secondary-nav/secondary-nav.stories.tsx
+++ b/src/components/secondary-nav/secondary-nav.stories.tsx
@@ -3,7 +3,7 @@ import { SecondaryNav, SecondaryNavItem } from './index'
 import { SecondaryNavContainer } from '../layout'
 
 export default {
-  title: 'SecondaryNav',
+  title: 'Deprecated/SecondaryNav',
   component: SecondaryNav,
 }
 

--- a/src/components/select/select.stories.tsx
+++ b/src/components/select/select.stories.tsx
@@ -1,7 +1,7 @@
 import { Select } from './index'
 
 export default {
-  title: 'Select',
+  title: 'Deprecated/Select',
   component: Select,
 }
 

--- a/src/components/snack/snack.stories.tsx
+++ b/src/components/snack/snack.stories.tsx
@@ -3,7 +3,7 @@ import { SnackProvider } from '../../hooks/use-snack'
 import { Snack } from './snack'
 
 export default {
-  title: 'Snack',
+  title: 'Deprecated/Snack',
   component: Snack,
 }
 

--- a/src/components/steps/steps.stories.tsx
+++ b/src/components/steps/steps.stories.tsx
@@ -3,7 +3,7 @@ import { Steps, StepsVertical } from './index'
 import { Button, DeprecatedButtonGroup } from '../button'
 
 export default {
-  title: 'Steps',
+  title: 'Deprecated/Steps',
   component: Steps,
 }
 

--- a/src/components/tabs/tabs.stories.tsx
+++ b/src/components/tabs/tabs.stories.tsx
@@ -14,7 +14,7 @@ import { TextBase } from '../typography'
 import { InputGroup } from '../input-group'
 
 export default {
-  title: 'Components/Tabs',
+  title: 'Deprecated/Tabs',
 }
 
 export const StylesOnlyUsage = {

--- a/src/components/tile/tile.stories.tsx
+++ b/src/components/tile/tile.stories.tsx
@@ -4,7 +4,7 @@ import { Grid, Col, ColSplitThird, ColSplitTwoThirds, GridThirds } from '../grid
 import { elMb7 } from '../../styles/spacing'
 
 export default {
-  title: 'Tile',
+  title: 'Deprecated/Tile',
   component: Tile,
 }
 

--- a/src/components/toggle/toggle.stories.tsx
+++ b/src/components/toggle/toggle.stories.tsx
@@ -2,7 +2,7 @@ import { Toggle, ToggleRadio } from './index'
 import { ElToggleItem } from './__styles__'
 
 export default {
-  title: 'Toggle',
+  title: 'Deprecated/Toggle',
   component: Toggle,
 }
 

--- a/src/components/typography/typography.stories.tsx
+++ b/src/components/typography/typography.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from './typography'
 
 export default {
-  title: 'Typography',
+  title: 'Deprecated/Typography',
   component: TextBase,
 }
 

--- a/src/hooks/use-media-query/media.stories.tsx
+++ b/src/hooks/use-media-query/media.stories.tsx
@@ -2,7 +2,7 @@ import { MediaStateProvider } from '.'
 import { MediaMobileExample, AllBreakPointExample } from './media.story-component'
 
 export default {
-  title: 'MediaStateProvider',
+  title: 'Deprecated/MediaStateProvider',
   component: MediaStateProvider,
 }
 

--- a/src/hooks/use-modal/modal.stories.tsx
+++ b/src/hooks/use-modal/modal.stories.tsx
@@ -3,7 +3,7 @@ import { Button, DeprecatedButtonGroup } from '../../components/button'
 import { TextBase } from '../../components/typography'
 
 export default {
-  title: 'Hooks/useModal',
+  title: 'Deprecated/useModal',
 }
 
 export const BasicUsage = {

--- a/src/hooks/use-portal/use-portal.stories.tsx
+++ b/src/hooks/use-portal/use-portal.stories.tsx
@@ -1,7 +1,7 @@
 import { Portal } from '.'
 
 export default {
-  title: 'Portal',
+  title: 'Deprecated/Portal',
   component: Portal,
 }
 

--- a/src/patterns/layout.stories.tsx
+++ b/src/patterns/layout.stories.tsx
@@ -9,7 +9,7 @@ import { DeprecatedNavResponsive as NavResponsive } from '../components/deprecat
 import { Grid, Col, ColSplitThird, ColSplitTwoThirds, GridThirds } from '../components/grid'
 
 export default {
-  title: 'Patterns/Layouts',
+  title: 'Deprecated/Layout Patterns',
 }
 
 export const CompleteCombinedExample = {

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -20,6 +20,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 - **chore!:** Deprecated `Accordion` component. It is still available, but is now called `DeprecatedAccordion`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix.
 - **feat:** Add new `Accordion` component. See [Accordion](?path=/docs/components-accordion--docs) for details.
+- **chore:** All v4 component docs have been grouped under the `Deprecated` section in Elements' Storybook. Consumers of these components should consider all these components to be implicitly deprecated. Explicit deprecation will come in a future beta version.
 
 ### **5.0.0-beta.34 - 30/06/25**
 

--- a/src/styles/deprecated-theming.stories.tsx
+++ b/src/styles/deprecated-theming.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../components/button'
 import { DeprecatedElementsThemeProvider } from './deprecated-theme-provider'
 
 export default {
-  title: 'DeprecatedTheming',
+  title: 'Deprecated/DeprecatedTheming',
 }
 
 export const DeprecatedThemingProvider = {

--- a/src/styles/flexbox.stories.tsx
+++ b/src/styles/flexbox.stories.tsx
@@ -1,7 +1,7 @@
 import { GridDemoBlockWithMargin } from '../storybook/demo-block'
 
 export default {
-  title: 'Flexbox',
+  title: 'Deprecated/Flexbox',
 }
 
 export const Flex = {

--- a/src/styles/utilities.stories.tsx
+++ b/src/styles/utilities.stories.tsx
@@ -5,7 +5,7 @@ import { elH6, elHScreen, elW6, elWScreen } from './sizing'
 import { elBorderPurple, elBorderGrey, elBorderGreyL, elBorderRadius, elBorderRadiusR, elBoxShadow } from './borders'
 
 export default {
-  title: 'Utilities',
+  title: 'Deprecated/Utilities',
 }
 
 export const Margin = {


### PR DESCRIPTION
What it says on the tin.

Currently, all non-v5 components can be found at the top of the Storybook side bar. This isn't great given we want to discourage use of these components.

This PR groups all non-v5 components within a new "Deprecated" side bar group.

| Before | After |
| ------- | ---- |
| <img width="552" alt="Screenshot 2025-06-30 at 4 48 55 pm" src="https://github.com/user-attachments/assets/2bb2d396-c8c4-4e08-bf68-09120c3e5aee" /> | <img width="512" alt="Screenshot 2025-06-30 at 4 49 42 pm" src="https://github.com/user-attachments/assets/ce834d12-34cb-4d66-845d-25b3cb3e4b4e" /> |
