### PR TITLE
feat: Add new `ButtonBase` component

### DIFF
--- a/src/components/button/__tests__/button-base.test.tsx
+++ b/src/components/button/__tests__/button-base.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { StarIcon } from '#src/icons/star'
+import { ButtonBase } from '../button-base'
+
+test('renders as a button element when `as="button"`', () => {
+  render(
+    <ButtonBase as="button" variant="primary" size="medium">
+      Button
+    </ButtonBase>,
+  )
+  expect(screen.getByRole('button', { name: 'Button' })).toBeVisible()
+})
+
+test('renders as a link element when `as="a"`', () => {
+  render(
+    <ButtonBase as="a" href="https://fake.url" size="medium" variant="primary">
+      Link
+    </ButtonBase>,
+  )
+  expect(screen.getByRole('link', { name: 'Link' })).toBeVisible()
+})
+
+test('is ARIA disabled when `isBusy` is true', () => {
+  render(
+    <ButtonBase as="button" isBusy size="medium" variant="primary">
+      Button
+    </ButtonBase>,
+  )
+  expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+})
+
+test('is ARIA disabled when `disabled` is true', () => {
+  render(
+    <ButtonBase as="button" disabled size="medium" variant="primary">
+      Button
+    </ButtonBase>,
+  )
+  expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+})
+
+describe('when `aria-disabled="true"`', () => {
+  test('does not call the consumer-supplied `onClick` handler', () => {
+    const onClick = vi.fn()
+
+    render(
+      <ButtonBase as="button" aria-disabled="true" onClick={onClick} size="medium" variant="primary">
+        Button
+      </ButtonBase>,
+    )
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  test("prevents the event's default action", () => {
+    // NOTE: we have to spy on the `preventDefault` method on the `Event` prototype because our onClick handler
+    // will not be called when `aria-disabled` is true.
+    const preventDefaultSpy = vi.spyOn(Event.prototype, 'preventDefault')
+
+    render(
+      <ButtonBase as="button" aria-disabled="true" size="medium" variant="primary">
+        Button
+      </ButtonBase>,
+    )
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  test("stops the event's propagation", () => {
+    const parentOnClick = vi.fn()
+
+    render(
+      // NOTE: we attach the onClick handler to the parent div AND the button itself, to allow us to assert the
+      <div onClick={parentOnClick}>
+        <ButtonBase as="button" aria-disabled="true" size="medium" variant="primary">
+          Button
+        </ButtonBase>
+      </div>,
+    )
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(parentOnClick).not.toHaveBeenCalled()
+  })
+})
+
+test('applies correct data-* attributes', () => {
+  render(
+    <ButtonBase as="button" isDestructive hasNoPadding size="large" useLinkStyle variant="secondary">
+      Test Button
+    </ButtonBase>,
+  )
+
+  const button = screen.getByRole('button')
+  expect(button).toHaveAttribute('data-variant', 'secondary')
+  expect(button).toHaveAttribute('data-size', 'large')
+  expect(button).toHaveAttribute('data-is-destructive', 'true')
+  expect(button).toHaveAttribute('data-has-no-padding', 'true')
+  expect(button).toHaveAttribute('data-use-link-style', 'true')
+})
+
+test('forwards additional props to the underlying element', () => {
+  render(
+    <ButtonBase as="button" data-testid="my-button" size="medium" variant="primary">
+      Test Button
+    </ButtonBase>,
+  )
+  expect(screen.getByTestId('my-button')).toBeVisible()
+})
+
+test('can display an icon on the left', () => {
+  render(
+    <ButtonBase as="button" iconLeft={<StarIcon data-testid="left-icon" />} size="medium" variant="primary">
+      Test Button
+    </ButtonBase>,
+  )
+  expect(screen.getByTestId('left-icon')).toBeVisible()
+})
+
+test('can display an icon on the right', () => {
+  render(
+    <ButtonBase as="button" iconRight={<StarIcon data-testid="right-icon" />} size="medium" variant="primary">
+      Test Button
+    </ButtonBase>,
+  )
+  expect(screen.getByTestId('right-icon')).toBeVisible()
+})
+
+test('can display icons on both the left and right', () => {
+  render(
+    <ButtonBase
+      as="button"
+      iconLeft={<StarIcon data-testid="left-icon" />}
+      iconRight={<StarIcon data-testid="right-icon" />}
+      size="medium"
+      variant="primary"
+    >
+      Test Button
+    </ButtonBase>,
+  )
+  expect(screen.getByTestId('left-icon')).toBeVisible()
+  expect(screen.getByTestId('right-icon')).toBeVisible()
+})
+
+test('does not display icons when busy', () => {
+  render(
+    <ButtonBase
+      as="button"
+      iconLeft={<StarIcon data-testid="left-icon" />}
+      iconRight={<StarIcon data-testid="right-icon" />}
+      isBusy
+      size="medium"
+      variant="primary"
+    >
+      Test Button
+    </ButtonBase>,
+  )
+  expect(screen.queryByTestId('left-icon')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('right-icon')).not.toBeInTheDocument()
+})
+
+test('shows a spinner when busy', () => {
+  render(
+    <ButtonBase
+      as="button"
+      iconLeft={<StarIcon data-testid="left-icon" />}
+      iconRight={<StarIcon data-testid="right-icon" />}
+      isBusy
+      size="medium"
+      variant="primary"
+    >
+      Test Button
+    </ButtonBase>,
+  )
+  expect(screen.queryByTestId('left-icon')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('right-icon')).not.toBeInTheDocument()
+})

--- a/src/components/button/button-base.tsx
+++ b/src/components/button/button-base.tsx
@@ -1,0 +1,119 @@
+import { cx } from '@linaria/core'
+import { elButton, elButtonSpinner, ElButtonIconContainer } from './styles'
+import Spinner from './spinner.svg?react'
+import { useCallback } from 'react'
+
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+
+export interface CommonButtonBaseProps {
+  /**
+   * Whether the button is disabled. This can be used to make the button appear disabled to users, but still be
+   * focusable and available in the a11y tree. ARIA disabled buttons, whether they are button or anchor DOM elements,
+   * will ignore click events. Using `aria-disabled` is preferred when the button should still be focusable while it's
+   * disabled; for example, to allow a tooltip to be displayed that explains why the button is disabled.
+   */
+  'aria-disabled'?: boolean | 'true' | 'false'
+  /** The button's label */
+  children?: ReactNode
+  /** Remove default padding. Only applies to tertiary buttons. */
+  hasNoPadding?: boolean
+  /** Icon to display on the left side */
+  iconLeft?: ReactNode
+  /** Icon to display on the right side */
+  iconRight?: ReactNode
+  /**
+   * Whether the button is in a busy state. A busy button will be `aria-disabled`, so will be focusable. However,
+   * click events will be ignored while it is busy.
+   */
+  isBusy?: boolean
+  /** Whether the button represents a destructive action */
+  isDestructive?: boolean
+  /** The size of the button */
+  size: 'small' | 'medium' | 'large'
+  /** Whether to use link-style appearance. Only applies to tertiary buttons. */
+  useLinkStyle?: boolean
+  /** The visual variant of the button */
+  variant: 'primary' | 'secondary' | 'tertiary'
+}
+
+export interface ButtonAsButtonProps extends CommonButtonBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
+  as: 'button'
+}
+
+export interface ButtonAsAnchorProps extends CommonButtonBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+  as: 'a'
+  href: string
+}
+
+export type ButtonBaseProps = ButtonAsButtonProps | ButtonAsAnchorProps
+
+/**
+ * A polymorphic button foundation that can render as either a button or anchor element.
+ * This component is used internally by the `Button` and `AnchorButton` components and
+ * should not be used directly by consumers.
+ */
+export function ButtonBase({
+  'aria-disabled': ariaDisabled,
+  as: Element,
+  className,
+  children,
+  hasNoPadding,
+  iconLeft,
+  iconRight,
+  isBusy,
+  isDestructive,
+  onClick,
+  size,
+  useLinkStyle,
+  variant,
+  ...rest
+}: ButtonBaseProps) {
+  // It's an icon-only button if there's no label text and only one icon
+  const isIconOnly = !children && (iconLeft || iconRight) && !(iconLeft && iconRight)
+
+  const handleClick = useCallback<MouseEventHandler<HTMLElement>>(
+    (event) => {
+      const element = event.currentTarget
+      // NOTE: Anchor elements CANNOT be disabled using the native `disabled` attribute, so we allow the
+      // `aria-disabled` attribute to disable them instead. Since click events will still be fired when
+      // `aria-disabled='true'`, we need to prevent any default action for the button from occuring, stop it
+      // propagating to ancestors and avoid calling the consumer-supplied `onClick` callback.
+      if (element.getAttribute('aria-disabled') === 'true') {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+
+      // NOTE: We use a type assertion here to avoid having to narrow the type of `event` based on the specific
+      // `Element` type.
+      onClick?.(event as any)
+    },
+    [onClick],
+  )
+
+  return (
+    // NOTE: We use a type assertion here to avoid having to narrow the type of `rest` to the specific `Element` type.
+    <Element
+      {...(rest as HTMLAttributes<HTMLElement>)}
+      className={cx(elButton, className)}
+      aria-disabled={!!isBusy || !!rest['disabled'] || !!ariaDisabled}
+      data-variant={variant}
+      data-size={size}
+      data-has-no-padding={hasNoPadding}
+      data-is-destructive={isDestructive}
+      data-is-icon-only={isIconOnly}
+      data-use-link-style={useLinkStyle}
+      onClick={handleClick}
+    >
+      {isBusy ? (
+        <ElButtonIconContainer aria-hidden className={elButtonSpinner}>
+          <Spinner />
+        </ElButtonIconContainer>
+      ) : (
+        iconLeft && <ElButtonIconContainer aria-hidden>{iconLeft}</ElButtonIconContainer>
+      )}
+      {children}
+      {!isBusy && iconRight && <ElButtonIconContainer aria-hidden>{iconRight}</ElButtonIconContainer>}
+    </Element>
+  )
+}

--- a/src/components/button/spinner.svg
+++ b/src/components/button/spinner.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M9.081 1.388a.667.667 0 0 1 .817-.472 7.333 7.333 0 1 1-7.083 12.27.667.667 0 1 1 .942-.944A6 6 0 1 0 9.553 2.204a.667.667 0 0 1-.472-.816Z" clip-rule="evenodd"/>
+</svg>

--- a/src/components/button/styles.ts
+++ b/src/components/button/styles.ts
@@ -1,0 +1,268 @@
+import { css } from '@linaria/core'
+import { styled } from '@linaria/react'
+import { font } from '../text'
+
+export const elButton = css`
+  display: inline-flex;
+  place-items: center;
+  place-content: center;
+  gap: var(--spacing-1);
+
+  border: none;
+  border-radius: var(--comp-button-border-radius-default);
+
+  text-decoration: none;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+
+  &:disabled,
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+  }
+
+  /* Sizes */
+  &[data-size='small'] {
+    height: var(--size-8);
+    padding-inline: var(--spacing-3);
+
+    ${font('sm', 'medium')}
+
+    &[data-is-icon-only='true'] {
+      padding: 0;
+      width: var(--size-8);
+    }
+  }
+
+  &[data-size='medium'] {
+    height: var(--size-9);
+    padding-inline: var(--spacing-4);
+
+    ${font('sm', 'medium')}
+
+    &[data-is-icon-only='true'] {
+      padding: 0;
+      width: var(--size-9);
+    }
+  }
+
+  &[data-size='large'] {
+    height: var(--size-10);
+    padding-inline: var(--spacing-4);
+
+    ${font('base', 'medium')}
+
+    &[data-is-icon-only='true'] {
+      padding: 0;
+      width: var(--size-10);
+    }
+  }
+
+  /* Variants */
+  &[data-variant='primary'] {
+    background: var(--comp-button-colour-fill-primary-default);
+    color: var(--comp-button-colour-text-primary-default);
+
+    &:hover {
+      background: var(--comp-button-colour-fill-primary-hover);
+      color: var(--comp-button-colour-text-primary-hover);
+    }
+
+    &[data-is-destructive='true'] {
+      background: var(--comp-button-colour-fill-primary-destructive-default);
+      color: var(--comp-button-colour-text-primary-destructive-default);
+
+      &:hover {
+        background: var(--comp-button-colour-fill-primary-destructive-hover);
+        color: var(--comp-button-colour-text-primary-destructive-hover);
+      }
+    }
+
+    &:disabled,
+    &:disabled:hover,
+    &[aria-disabled='true'],
+    &[aria-disabled='true']:hover {
+      background: var(--comp-button-colour-fill-primary-disabled);
+      color: var(--comp-button-colour-text-primary-disabled);
+    }
+  }
+
+  &[data-variant='secondary'] {
+    border: var(--comp-button-border-width-default) solid var(--comp-button-colour-border-secondary-default);
+    background: var(--comp-button-colour-fill-secondary-default);
+    color: var(--comp-button-colour-text-secondary-default);
+
+    &:hover {
+      border: var(--comp-button-border-width-default) solid var(--comp-button-colour-border-secondary-hover);
+      background: var(--comp-button-colour-fill-secondary-hover);
+      color: var(--comp-button-colour-text-secondary-hover);
+    }
+
+    &[data-is-destructive='true'] {
+      border: var(--comp-button-border-width-default) solid
+        var(--comp-button-colour-border-secondary-destructive-default);
+      background: var(--comp-button-colour-fill-secondary-destructive-default);
+      color: var(--comp-button-colour-text-secondary-destructive-default);
+
+      &:hover {
+        border: var(--comp-button-border-width-default) solid
+          var(--comp-button-colour-border-secondary-destructive-hover);
+        background: var(--comp-button-colour-fill-secondary-destructive-hover);
+        color: var(--comp-button-colour-text-secondary-destructive-hover);
+      }
+    }
+
+    &:disabled,
+    &:disabled:hover,
+    &[aria-disabled='true'],
+    &[aria-disabled='true']:hover {
+      border-color: transparent;
+      background: var(--comp-button-colour-fill-secondary-disabled);
+      color: var(--comp-button-colour-text-secondary-disabled);
+    }
+  }
+
+  &[data-variant='tertiary'] {
+    background: var(--comp-button-colour-fill-tertiary-default);
+    color: var(--comp-button-colour-text-tertiary-default);
+
+    &:hover {
+      background: var(--comp-button-colour-fill-tertiary-hover);
+      color: var(--comp-button-colour-text-tertiary-hover);
+    }
+
+    &[data-has-no-padding='true'] {
+      height: auto;
+      padding: 0;
+
+      &[data-is-icon-only='true'] {
+        width: auto;
+      }
+    }
+
+    &[data-use-link-style='true'] {
+      color: var(--comp-button-colour-text-tertiary-link);
+
+      &:hover {
+        color: var(--comp-button-colour-text-tertiary-link_hover);
+      }
+    }
+
+    /* NOTE: data-is-destructive must come after data-use-link-style to be consistent with the specificity of the same
+    * attributes on the icon container. */
+    &[data-is-destructive='true'] {
+      background: var(--comp-button-colour-fill-tertiary-destructive-default);
+      color: var(--comp-button-colour-text-tertiary-destructive-default);
+
+      &:hover {
+        background: var(--comp-button-colour-fill-tertiary-destructive-hover);
+        color: var(--comp-button-colour-text-tertiary-destructive-hover);
+      }
+    }
+
+    /* NOTE: disabled styles come last so they override the other styles. This is necessary because they have the
+    * same specificity as the other styles. */
+    &:disabled,
+    &:disabled:hover,
+    &[aria-disabled='true'],
+    &[aria-disabled='true']:hover {
+      background: var(--comp-button-colour-fill-tertiary-disabled);
+      color: var(--comp-button-colour-text-tertiary-disabled);
+    }
+  }
+`
+
+export const ElButtonIconContainer = styled.span`
+  box-sizing: content-box;
+
+  display: flex;
+  place-items: center;
+  place-content: center;
+
+  /* Sizes */
+  [data-size='small'] & {
+    padding: var(--spacing-half);
+    width: var(--icon_size-s);
+    height: var(--icon_size-s);
+  }
+
+  [data-size='medium'] & {
+    padding: var(--spacing-half);
+    width: var(--icon_size-s);
+    height: var(--icon_size-s);
+  }
+
+  [data-size='large'] & {
+    padding: var(--spacing-half);
+    width: var(--icon_size-m);
+    height: var(--icon_size-m);
+  }
+
+  /* Variants */
+  ${generateElButtonIconContainerVariantStyles('primary')}
+
+  ${generateElButtonIconContainerVariantStyles('secondary')}
+
+  ${generateElButtonIconContainerVariantStyles('tertiary')}
+`
+
+function generateElButtonIconContainerVariantStyles(variant: 'primary' | 'secondary' | 'tertiary') {
+  return `
+  [data-variant='${variant}'] & {
+    color: var(--comp-button-colour-icon-${variant}-default);
+  }
+
+  [data-variant='${variant}']:hover & {
+    color: var(--comp-button-colour-icon-${variant}-hover);
+  }
+
+  /* NOTE: data-use-link-style is only supported by tertiary buttons. */
+  ${
+    variant === 'tertiary'
+      ? `
+  [data-variant='tertiary'][data-use-link-style='true'] & {
+    color: var(--comp-button-colour-icon-tertiary-link);
+  }
+
+  [data-variant='tertiary'][data-use-link-style='true']:hover & {
+    color: var(--comp-button-colour-icon-tertiary-link_hover);
+  }`
+      : ''
+  }
+
+  /* NOTE: data-is-destructive must come after data-use-link-style to be consistent with the specificity of the same
+   * attributes on the parent element. */
+  [data-variant='${variant}'][data-is-destructive='true'] & {
+    color: var(--comp-button-colour-icon-${variant}-destructive-default);
+  }
+
+  [data-variant='${variant}'][data-is-destructive='true']:hover & {
+    color: var(--comp-button-colour-icon-${variant}-destructive-hover);
+  }
+
+  /* NOTE: disabled styles come last so they override the other styles. This is necessary because they have the
+   * same specificity as the other styles. */
+  [data-variant='${variant}']:disabled &,
+  [data-variant='${variant}']:disabled:hover &,
+  [data-variant='${variant}'][aria-disabled='true'] &,
+  [data-variant='${variant}'][aria-disabled='true']:hover & {
+    color: var(--comp-button-colour-icon-${variant}-disabled);
+  }
+  `
+}
+
+export const elButtonSpinner = css`
+  animation: spin 1s linear infinite;
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`


### PR DESCRIPTION
### Context

- The existing v5 Elements button has been deprecated in Figma and a new Button designed.
- To align Elements, we're going to do the same thing: deprecated the current Button and implement a new replacement.
- This work will be done in the following stages:
  - Part 1: #572 
  - **Part 2: Add new foundational ButtonBase component (this PR)**
  - Part 3: Add new Button and AnchorButton components

### This PR

- Adds a new ButtonBase component. This will be the foundation of the new Button and AnchorButton components that will be added in Part 3.

The following images show the storybook docs added for Button in Part 3 (#574):

<img width="819" alt="Screenshot 2025-07-02 at 12 17 29 pm" src="https://github.com/user-attachments/assets/51383e8e-c87a-401b-baa1-0c9dd56f94b8" />
<img width="818" alt="Screenshot 2025-07-02 at 12 13 12 pm" src="https://github.com/user-attachments/assets/1e81ff88-7430-4c5b-8ad2-4ac9160a5596" />
<img width="824" alt="Screenshot 2025-07-02 at 12 13 19 pm" src="https://github.com/user-attachments/assets/49ffadf4-fd85-4ae3-a09b-ac4e9e01d663" />
<img width="816" alt="Screenshot 2025-07-02 at 12 13 26 pm" src="https://github.com/user-attachments/assets/8b09f6b7-8a61-480f-87d4-8f40995eb97a" />
<img width="818" alt="Screenshot 2025-07-02 at 12 13 33 pm" src="https://github.com/user-attachments/assets/0bb261e7-bbf4-48d5-9f79-ceee8668804e" />
<img width="818" alt="Screenshot 2025-07-02 at 12 13 44 pm" src="https://github.com/user-attachments/assets/ae0e915c-d17b-40fe-9a77-58318247c78e" />
