### PR TITLE
fix: #582 visual regression in deprecated `MobileControls`

### DIFF
--- a/src/components/deprecated-button/styles.ts
+++ b/src/components/deprecated-button/styles.ts
@@ -216,7 +216,7 @@ const baseButtonStyles = `
     outline: 0;
   }
   
-  // TO DO: no the token variable names not updated, since no design guide in figma
+  /* TODO: no the token variable names not updated, since no design guide in figma */
   &.${elDeprecatedFloatingButton} {
     border-radius: 100%;
     height: 3.75rem;

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -19,6 +19,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 ### **5.0.0-beta.37 - ??/??/25**
 
 - **feat:** Add new `CompactSelectNative` component. See [CompactSelectNative](?path=/docs/components-compact-select-native--docs) for details.
+- **fix:** #502 introduced a visual regression in the `MobileControls` component. This has now been fixed.
 
 ### **5.0.0-beta.36 - 04/07/25**
 


### PR DESCRIPTION
Commit d995dcade02ef5f0f021ccc58fa387f846340ddb from #502 added a "single-line" CSS comment immediately prior to the floating button-specific CSS on line 210:

```diff
L210 +  // TO DO: no the token variable names not updated, since no design guide in figma
L211    &.${elFloatingButton} {
```

Unfortunately, the `//` does not act as a single-line comment; rather, it acts as a "disable the next CSS construct" syntax. This means the "comment text" is ignored (because it's not a CSS construct) and the `&.${elFloatingButton}` construct is disabled/"commented out". This results in the visual regression highlighted by #582. See [Single Line Comments in CSS](https://www.xanthir.com/b4U10) for a more detailed explanation of this behaviour.

While we now have CSS linting that "should" prevent the `//` syntax from being used (because of this non-obvious behaviour), this block of CSS is a plain template literal, it's not part of a `css` or `styled` declaration. This means our CSS linting ignores the template literal (it doesn't know it's meant to check it because it only looks for `css` and `styled` declarations) and therefore doesn't flag this invalid use of `//`.

This PR resolves the issue by using a proper CSS block comment `/* */`.