### PR TITLE
fix: #581 visual regression in `DeprecatedButton` focus styles

### DIFF
--- a/src/components/deprecated-button/styles.ts
+++ b/src/components/deprecated-button/styles.ts
@@ -82,10 +82,6 @@ const baseButtonStyles = `
     }
   }
 
-  &:focus {
-    border: var(--border-width-double) solid var(--colour-border-focus);
-  }
-
   &.${elDeprecatedButtonIconOnly} {
     padding: 0px;
     width: var(--size-9);

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -20,6 +20,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 - **feat:** Add new `CompactSelectNative` component. See [CompactSelectNative](?path=/docs/components-compact-select-native--docs) for details.
 - **fix:** #502 introduced a visual regression in the `MobileControls` component. This has now been fixed.
+- **fix:** #502 introduced a visual regression in the `DeprecatedButton` component. This has now been fixed.
 
 ### **5.0.0-beta.36 - 04/07/25**
 


### PR DESCRIPTION
fixes: #581

Commit d995dcade02ef5f0f021ccc58fa387f846340ddb from #502 added additional, incorrect focus styling to the button:

```diff
L76 +  &:focus {
L77 +    border: var(--border-width-double) solid var(--colour-border-focus);
L78 +  }
```

Firstly, focus styles should not be implemented using `border`. This is a workaround used by designers in Figma because Figma does not support the [outline](https://developer.mozilla.org/en-US/docs/Web/CSS/outline) CSS property.

Secondly, there were already `:focus-visible` styles in place for the button, which means these changes were not adequately tested before being raised for PR.