### PR TITLE
chore: align Chip with Button and tweak styles in other components

### DIFF
--- a/src/components/badge/styles.ts
+++ b/src/components/badge/styles.ts
@@ -29,6 +29,9 @@ export const ElBadge = styled.span<ElBadgeProps>`
   gap: var(--spacing-half);
   border-radius: var(--comp-badge-border-radius);
 
+  /* NOTE: necessary when used in an inline or inline-block layout */
+  vertical-align: middle;
+
   ${badgeColours.map((colour) => generateElBadgeColourStyles(colour)).join('\n')};
 `
 

--- a/src/components/button/button-base.tsx
+++ b/src/components/button/button-base.tsx
@@ -8,9 +8,9 @@ import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, MouseE
 export interface CommonButtonBaseProps {
   /**
    * Whether the button is disabled. This can be used to make the button appear disabled to users, but still be
-   * focusable and available in the a11y tree. ARIA disabled buttons, whether they are button or anchor DOM elements,
-   * will ignore click events. Using `aria-disabled` is preferred when the button should still be focusable while it's
-   * disabled; for example, to allow a tooltip to be displayed that explains why the button is disabled.
+   * focusable. ARIA disabled buttons, whether they are button or anchor DOM elements, will ignore click events.
+   * Using `aria-disabled` is preferred when the button should still be focusable while it's disabled; for example,
+   * to allow a tooltip to be displayed that explains why the button is disabled.
    */
   'aria-disabled'?: boolean | 'true' | 'false'
   /** The button's label */

--- a/src/components/button/styles.ts
+++ b/src/components/button/styles.ts
@@ -14,6 +14,9 @@ export const elButton = css`
   text-decoration: none;
   cursor: pointer;
 
+  /* NOTE: we don't want the button's label to wrap */
+  white-space: nowrap;
+
   &:focus-visible {
     outline: var(--border-width-double) solid var(--colour-border-focus);
     outline-offset: var(--border-width-default);

--- a/src/components/chip-group/chip-group.stories.tsx
+++ b/src/components/chip-group/chip-group.stories.tsx
@@ -86,7 +86,7 @@ export const Default: Story = {
 /**
  * By default, chips will wrap to other lines if they would otherwise overflow the group's bounding box.
  */
-export const Wrapping: Story = {
+export const Overflow: Story = {
   args: {
     ...Default.args,
     overflow: 'wrap',
@@ -99,7 +99,7 @@ export const Wrapping: Story = {
  */
 export const Scrolling: Story = {
   args: {
-    ...Wrapping.args,
+    ...Overflow.args,
     overflow: 'scroll',
   },
   decorators: [useNarrowParentDecorator],
@@ -138,7 +138,7 @@ export const ChipSizing: Story = {
       <ChipGroup.Item key="7" {...ChipStories.FilterChip.args}>
         Chip 6
       </ChipGroup.Item>,
-      <ChipGroup.Item key="8" {...ChipStories.Wrapping.args}>
+      <ChipGroup.Item key="8" {...ChipStories.Overflow.args}>
         Or, you can avoid truncation and allow a long chip label to wrap to multiple lines
       </ChipGroup.Item>,
       <ChipGroup.Item key="9" {...ChipStories.LongWords.args} />,

--- a/src/components/chip-group/styles.ts
+++ b/src/components/chip-group/styles.ts
@@ -13,6 +13,9 @@ interface ElChipGroupListProps {
 }
 
 export const ElChipGroupList = styled.ul<ElChipGroupListProps>`
+  all: unset;
+  box-sizing: border-box;
+
   display: flex;
   gap: var(--spacing-2);
   list-style: none;

--- a/src/components/chip/__tests__/chip.test.tsx
+++ b/src/components/chip/__tests__/chip.test.tsx
@@ -47,19 +47,10 @@ test('chip label has `data-will-truncate="true"` attribute when `willTruncateLab
   expect(screen.getByText('Label')).toHaveAttribute('data-will-truncate', 'true')
 })
 
-test('disabled chip has `aria-disabled="true"` attribute', () => {
-  render(
-    <Chip isDisabled variant="filter">
-      Label
-    </Chip>,
-  )
-  expect(screen.getByRole('button', { name: 'Label' })).toHaveAttribute('aria-disabled', 'true')
-})
-
-test('disabled chip does not call `onClick`', () => {
+test('ARIA disabled chip does not call `onClick`', () => {
   const fakeClick = vi.fn()
   render(
-    <Chip isDisabled onClick={fakeClick} variant="filter">
+    <Chip aria-disabled="true" onClick={fakeClick} variant="filter">
       Label
     </Chip>,
   )
@@ -69,11 +60,11 @@ test('disabled chip does not call `onClick`', () => {
   expect(fakeClick).not.toHaveBeenCalled()
 })
 
-test('disabled chip prevents click events from propagating', () => {
+test('ARIA disabled chip prevents click events from propagating', () => {
   const parentClickHandler = vi.fn()
   render(
     <div onClick={parentClickHandler}>
-      <Chip isDisabled variant="filter">
+      <Chip aria-disabled="true" variant="filter">
         Label
       </Chip>
     </div>,

--- a/src/components/chip/chip.stories.tsx
+++ b/src/components/chip/chip.stories.tsx
@@ -8,10 +8,13 @@ const meta = {
   title: 'Components/Chip',
   component: Chip,
   argTypes: {
+    'aria-disabled': {
+      control: 'boolean',
+    },
     children: {
       control: 'text',
     },
-    isDisabled: {
+    disabled: {
       control: 'boolean',
     },
     variant: {
@@ -25,15 +28,23 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+export const Example: Story = {
+  args: {
+    'aria-disabled': false,
+    children: 'Label',
+    disabled: false,
+    willTruncateLabel: false,
+    variant: 'filter',
+  },
+}
+
 /**
  * The filter chip variant is primarily used in a filter bar to indicate what
  * filters have been applied to a table
  */
 export const FilterChip: Story = {
   args: {
-    children: 'Label',
-    isDisabled: false,
-    willTruncateLabel: false,
+    ...Example.args,
     variant: 'filter',
   },
 }
@@ -44,20 +55,20 @@ export const FilterChip: Story = {
  */
 export const SelectionChip: Story = {
   args: {
-    ...FilterChip.args,
+    ...Example.args,
     variant: 'selection',
   },
 }
 
 /**
- * Chips can be disabled in order to prevent their removal. Disabled chips should
- * remain focusable in order to keep them in the accessibility tree. If it is
- * important to communicate why the chip is disabled, a tooltip can be provided.
+ * Chips can be disabled using `aria-disabled` or `disabled`. In both cases, click events will be ignored, however,
+ * `aria-disabled` allows the chip to still be focusable, which, for example, allows tooltips to still be displayed.
+ * A `disabled` chip is also `aria-disabled`, regardless of the value of `aria-disabled`.
  */
 export const Disabled: Story = {
   args: {
     ...FilterChip.args,
-    isDisabled: true,
+    disabled: true,
   },
   render: function DisabledChipStory(args) {
     const tooltip = useTooltip()
@@ -71,7 +82,7 @@ export const Disabled: Story = {
 }
 
 /** By default, long labels will wrap if there is not enough space is available. */
-export const Wrapping: Story = {
+export const Overflow: Story = {
   args: {
     ...FilterChip.args,
     children: "This very long label will wrap because it's parent is not wide enough",

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -1,3 +1,4 @@
+import { CloseIcon } from '#src/icons/close'
 import { ElChip, ElChipClearIcon, ElChipLabel } from './styles'
 import { useCallback } from 'react'
 
@@ -11,39 +12,63 @@ type ElementAttributes = ButtonHTMLAttributes<HTMLButtonElement>
 type ElementAttributesToOmit = Extract<keyof ElementAttributes, 'disabled' | 'type'>
 
 interface ChipProps extends Omit<ElementAttributes, ElementAttributesToOmit> {
+  /**
+   * Whether the chip is disabled. This can be used to make the chip appear disabled to users, but still be
+   * focusable. ARIA disabled chips, whether they are button or anchor DOM elements, will ignore click events.
+   * Using `aria-disabled` is preferred when the chip should still be focusable while it's disabled; for example,
+   * to allow a tooltip to be displayed that explains why the chip is disabled.
+   */
+  'aria-disabled'?: boolean | 'true' | 'false'
+  /** The label of the chip */
   children: ReactNode
-  isDisabled?: boolean
+  /**
+   * Whether the button is disabled or not. Unlike `aria-disabled`, chips disabled with this prop will not be
+   * focusable or interactive.
+   */
+  disabled?: boolean
+  /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
   maxWidth?: `--size-${string}`
+  /** The variant of the chip */
   variant: 'filter' | 'selection'
+  /** Whether the label of the chip should be truncated if it is too long */
   willTruncateLabel?: boolean
 }
 
 /**
  * An interactive chip that should be cleared (or removed) when clicked. Typically used within a `ChipGroup`.
  */
-export function Chip({ children, isDisabled, onClick, maxWidth, variant, willTruncateLabel, ...rest }: ChipProps) {
+export function Chip({
+  'aria-disabled': ariaDisabled,
+  children,
+  onClick,
+  maxWidth,
+  variant,
+  willTruncateLabel,
+  ...rest
+}: ChipProps) {
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (event) => {
-      // We are not using <button>'s `disabled` attribute because disabled buttons are bad for a11y.
-      // Rather, we keep the <button> enabled and available in the a11y tree, but mark it as disabled using
-      // `aria-disabled`. This means click events will still be fired, so we need to prevent any default action
-      // for the button from occuring, stop it propagating to ancestors and avoid calling the consumer-supplied
-      // `onClick` callback.
-      if (isDisabled) {
+      const element = event.currentTarget
+      // NOTE: Button elements disabled using the native `disabled` attribute are not focusable or interactive.
+      // Sometimes, we want them to be in order to communicate _why_ they are disabled (e.g. via a tooltip). As such
+      // we allow the `aria-disabled` attribute to functionally disable them as well. Since click events will still
+      // be fired when `aria-disabled='true'`, we need to prevent any default action for the button from occuring, stop
+      // it propagating to ancestors and avoid calling the consumer-supplied `onClick` callback.
+      if (element.getAttribute('aria-disabled') === 'true') {
         event.preventDefault()
         event.stopPropagation()
         return
       }
       onClick?.(event)
     },
-    [isDisabled, onClick],
+    [ariaDisabled, onClick],
   )
 
   return (
     <ElChip
       {...rest}
       type="button"
-      aria-disabled={isDisabled}
+      aria-disabled={!!rest['disabled'] || ariaDisabled}
       data-variant={variant}
       onClick={handleClick}
       // NOTE: We'd prefer --chip-max-width to be a data attribute, but browsers do not support CSS' advanced
@@ -51,7 +76,9 @@ export function Chip({ children, isDisabled, onClick, maxWidth, variant, willTru
       style={maxWidth ? { '--chip-max-width': `var(${maxWidth})` } : undefined}
     >
       <ElChipLabel data-will-truncate={willTruncateLabel}>{children}</ElChipLabel>
-      <ElChipClearIcon icon="close" />
+      <ElChipClearIcon>
+        <CloseIcon />
+      </ElChipClearIcon>
     </ElChip>
   )
 }

--- a/src/components/chip/styles.ts
+++ b/src/components/chip/styles.ts
@@ -1,5 +1,6 @@
+import { font } from '#src/components/text'
 import { styled } from '@linaria/react'
-import { DeprecatedIcon } from '../deprecated-icon'
+
 import type { CSSProperties } from 'react'
 
 interface ElChipCSSProperties extends CSSProperties {
@@ -22,12 +23,18 @@ export const ElChip = styled.button<ElChipProps>`
   display: grid;
   gap: var(--spacing-2);
   grid-template-columns: auto min-content;
-  height: min-content;
+  min-height: var(--size-8);
   max-width: var(--chip-max-width, auto);
   padding-block: var(--spacing-1);
   padding-inline: var(--spacing-4) var(--spacing-2);
   width: fit-content;
 
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+
+  &:disabled,
   &[aria-disabled='true'] {
     cursor: not-allowed;
     color: var(--comp-chip-colour-text-disabled);
@@ -40,6 +47,8 @@ export const ElChip = styled.button<ElChipProps>`
       background: var(--comp-chip-colour-fill-filter-hover);
     }
 
+    &:disabled,
+    &:disabled:hover,
     &[aria-disabled='true'],
     &[aria-disabled='true']:hover {
       background: var(--comp-chip-colour-fill-filter-disabled);
@@ -53,17 +62,12 @@ export const ElChip = styled.button<ElChipProps>`
       background: var(--comp-chip-colour-fill-selection-hover);
     }
 
+    &:disabled,
+    &:disabled:hover,
     &[aria-disabled='true'],
     &[aria-disabled='true']:hover {
       background: var(--comp-chip-colour-fill-selection-disabled);
     }
-  }
-
-  &:focus-visible {
-    box-shadow:
-      0 0 0 var(--size-px) var(--white),
-      0 0 0 var(--size-1) var(--purple-300);
-    outline: none;
   }
 `
 
@@ -77,13 +81,8 @@ export const ElChipLabel = styled.span<ElChipLabelProps>`
   /* Allows long words to be broken and wrapped onto the next line. */
   overflow-wrap: anywhere;
 
-  /* text-sm/Regular */
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  font-style: normal;
-  font-weight: 400;
-  letter-spacing: var(--letter-spacing-sm);
-  line-height: var(--line-height-sm);
+  ${font('sm', 'regular')}
+
   text-align: left;
 
   &[data-will-truncate='true'] {
@@ -92,19 +91,21 @@ export const ElChipLabel = styled.span<ElChipLabelProps>`
     white-space: nowrap;
   }
 
+  :disabled &,
   [aria-disabled='true'] & {
     color: var(--text-placeholder);
   }
 `
 
-export const ElChipClearIcon = styled(DeprecatedIcon)`
+export const ElChipClearIcon = styled.div`
   /* NOTE: We only use !important here because the current Icon component
    * does not allow consumer-supplied styles to have a higher specificity */
   color: var(--comp-chip-colour-icon-active) !important;
-  font-size: 1rem;
+
   height: var(--icon_size-s) !important;
   width: var(--icon_size-s) !important;
 
+  :disabled &,
   [aria-disabled='true'] & {
     color: var(--comp-chip-colour-icon-disabled) !important;
   }

--- a/src/components/tag-group/styles.ts
+++ b/src/components/tag-group/styles.ts
@@ -4,12 +4,16 @@ export const ElTagGroupList = styled.ul`
   all: unset;
   box-sizing: border-box;
 
-  display: flex;
+  display: inline-flex;
   flex-flow: row wrap;
   gap: var(--spacing-1);
+
+  /* NOTE: necessary when used in an inline or inline-block layout */
+  vertical-align: middle;
 `
 
 export const ElTagGroupListItem = styled.li`
-  display: block;
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
 `

--- a/src/icons/make-icon/styles.ts
+++ b/src/icons/make-icon/styles.ts
@@ -3,6 +3,9 @@ import { css } from '@linaria/core'
 export const elIcon = css`
   fill: currentColor;
 
+  /* NOTE: necessary when used in an inline or inline-block layout */
+  vertical-align: middle;
+
   &,
   &[color='primary'] {
     color: var(--colour-icon-primary);

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -21,6 +21,11 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add new `CompactSelectNative` component. See [CompactSelectNative](?path=/docs/components-compact-select-native--docs) for details.
 - **fix:** #502 introduced a visual regression in the `MobileControls` component. This has now been fixed.
 - **fix:** #502 introduced a visual regression in the `DeprecatedButton` component. This has now been fixed.
+- **chore!:** `Chip` component now aligned with `Button` component in terms of `aria-disabled` and `disabled` props. The original `isDisabled` prop has been removed.
+- **chore:** `Chip` now has the correct height (technically now a minimum height).
+- **chore:** `ChipGroup` now resets user-agent styles for its list and list item elements.
+- **chore:** `Badge`, `TagGroup` and icons will now default to `vertical-align: middle` in `inline` and `inline-block` layouts. This is important for the upcoming `PageHeader` replacement.
+- **chore:** `Button` labels will not wrap when used in a grid or flex layout that shrinks the button's container.
 
 ### **5.0.0-beta.36 - 04/07/25**
 


### PR DESCRIPTION
- Aligns `Chip` interface with new `Button` regarding `disabled` and `aria-disabled`.
- Updates `Chip` styles to ensure correct minimum height (fixes #580), update it to use the new `font` helper, the correct focus outline styles (outline instead of box-shadow) and use the new icons (instead of the deprecated icons).
- Updates `Badge`, `TagGroup` and new icons to use `vertical-align: middle` in inline and inline-block layouts. This has no effect in flex or grid layouts.