### PR TITLE
feat: Add new `PageHeader.Title` component

### DIFF
--- a/src/components/page-header/title/__tests__/title.test.tsx
+++ b/src/components/page-header/title/__tests__/title.test.tsx
@@ -1,0 +1,24 @@
+import { PageHeaderTitle } from '../title'
+import { render, screen } from '@testing-library/react'
+
+test('renders a level 1 heading element with the expected title', () => {
+  render(<PageHeaderTitle>Page Title</PageHeaderTitle>)
+  expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Page Title')
+})
+
+test('displays actions when provided', () => {
+  render(<PageHeaderTitle actions={<button>Action</button>}>Test Title</PageHeaderTitle>)
+  expect(screen.getByRole('button', { name: 'Action' })).toBeVisible()
+})
+
+test('displays additional information when provided', () => {
+  render(<PageHeaderTitle additionalInfo="Fake info">Test Title</PageHeaderTitle>)
+  const additionalInfo = screen.getByRole('paragraph')
+  expect(additionalInfo).toBeVisible()
+  expect(additionalInfo).toHaveTextContent('Fake info')
+})
+
+test('forwards additional props to the title container', () => {
+  render(<PageHeaderTitle data-testid="test-id">Test Title</PageHeaderTitle>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/components/page-header/title/index.ts
+++ b/src/components/page-header/title/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './title'

--- a/src/components/page-header/title/styles.ts
+++ b/src/components/page-header/title/styles.ts
@@ -1,0 +1,51 @@
+import { font } from '../../text'
+import { styled } from '@linaria/react'
+
+export const ElPageHeaderTitle = styled.div`
+  display: grid;
+  align-items: start;
+  gap: var(--spacing-2);
+  grid-template: 'content actions' / 1fr auto;
+
+  padding-block: var(--spacing-half);
+
+  background-color: var(--page-header-title-background_colour);
+
+  container-name: page-header-title;
+  container-type: inline-size;
+`
+
+export const ElPageHeaderTitleContent = styled.div`
+  grid-area: content;
+
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--spacing-2);
+
+  padding-block: var(--spacing-1);
+`
+
+export const ElPageHeaderTitleText = styled.h1`
+  display: inline;
+  margin: 0;
+  color: var(--colour-text-primary);
+
+  ${font('xl', 'bold')}
+`
+
+export const ElPageHeaderTitleAdditionalInfo = styled.p`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: 0;
+`
+
+export const ElPageHeaderTitleActions = styled.div`
+  grid-area: actions;
+
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex-shrink: 0;
+`

--- a/src/components/page-header/title/title.stories.tsx
+++ b/src/components/page-header/title/title.stories.tsx
@@ -1,0 +1,138 @@
+import { AddIcon } from '#src/icons/add'
+import { Badge } from '#src/components/badge'
+import { Button } from '#src/components/button'
+import { ButtonGroup } from '#src/components/button-group'
+import { MoreIcon } from '#src/icons/more'
+import { PageHeaderTitle } from './title'
+import { StarIcon } from '#src/icons/star'
+import { TagGroup } from '#src/components/tag-group'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/PageHeader/Title',
+  component: PageHeaderTitle,
+  argTypes: {
+    actions: {
+      control: 'radio',
+      options: ['None', 'One', 'Some'],
+      mapping: {
+        None: null,
+        One: (
+          <Button iconLeft={<AddIcon />} size="medium" variant="primary">
+            Add new
+          </Button>
+        ),
+        Some: (
+          <ButtonGroup>
+            <Button variant="secondary" size="medium">
+              Button 1
+            </Button>
+            <Button variant="secondary" size="medium">
+              Button 2
+            </Button>
+            <Button variant="secondary" size="medium" iconLeft={<MoreIcon />} aria-label="More" />
+          </ButtonGroup>
+        ),
+      },
+    },
+    additionalInfo: {
+      control: 'radio',
+      options: ['None', 'Tag', 'Badge', 'Icon', 'All'],
+      mapping: {
+        None: null,
+        Tag: (
+          <TagGroup>
+            <TagGroup.Item>Tag</TagGroup.Item>
+          </TagGroup>
+        ),
+        Badge: <Badge colour="neutral">Badge</Badge>,
+        Icon: <StarIcon size="lg" color="primary" />,
+        All: (
+          <>
+            <TagGroup>
+              <TagGroup.Item>Tag</TagGroup.Item>
+            </TagGroup>
+            <Badge colour="neutral">Badge</Badge>
+            <StarIcon aria-label="Preferred" size="lg" color="primary" />
+          </>
+        ),
+      },
+    },
+    children: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof PageHeaderTitle>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * At its simplest, the page header's title contains just that: the page's title.
+ */
+export const Example: Story = {
+  args: {
+    actions: 'None',
+    additionalInfo: 'None',
+    children: 'Page Title',
+  },
+}
+
+/**
+ * Additional information can follow the title. This information is typically some combination of one or more tags,
+ * badges, and/or icons.
+ */
+export const AdditionalInfo: Story = {
+  args: {
+    ...Example.args,
+    additionalInfo: 'All',
+  },
+}
+
+/**
+ * The title can also contain a primary action for the page. If it does, this should be the only primary action
+ * on the page.
+ */
+export const SingleAction: Story = {
+  args: {
+    ...Example.args,
+    actions: 'One',
+  },
+}
+
+/**
+ * It's also common for pages to have multiple secondary actions. When more than one action is present, a `ButtonGroup`
+ * should be used.
+ */
+export const MultipleActions: Story = {
+  args: {
+    ...Example.args,
+    actions: 'Some',
+  },
+}
+
+/**
+ * When the title (and any additional information) do not have enough space to display on a single line, they will
+ * wrap to additional lines.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    actions: 'One',
+    additionalInfo: 'All',
+    children: 'This is a long title that flows into the next line.',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', flexFlow: 'column', gap: 'var(--spacing-10)' }}>
+        <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '650px' }}>
+          <Story />
+        </div>
+        <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '400px' }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+}

--- a/src/components/page-header/title/title.tsx
+++ b/src/components/page-header/title/title.tsx
@@ -1,0 +1,34 @@
+import {
+  ElPageHeaderTitle,
+  ElPageHeaderTitleContent,
+  ElPageHeaderTitleText,
+  ElPageHeaderTitleActions,
+  ElPageHeaderTitleAdditionalInfo,
+} from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface PageHeaderTitleProps extends HTMLAttributes<HTMLDivElement> {
+  /** The main title text to display */
+  children: ReactNode
+  /** Optional action buttons or elements (e.g., buttons, more menu) */
+  actions?: ReactNode
+  /** Optional information to display alongside the title. Typically a tag group, badge, or icon. */
+  additionalInfo?: ReactNode
+}
+
+/**
+ * A title component for page headers. Displays the main page title with optional, additional information and actions.
+ * Typically used via `PageHeader.Title`.
+ */
+export function PageHeaderTitle({ actions, additionalInfo, children, ...rest }: PageHeaderTitleProps) {
+  return (
+    <ElPageHeaderTitle {...rest}>
+      <ElPageHeaderTitleContent>
+        <ElPageHeaderTitleText>{children}</ElPageHeaderTitleText>
+        <ElPageHeaderTitleAdditionalInfo>{additionalInfo}</ElPageHeaderTitleAdditionalInfo>
+      </ElPageHeaderTitleContent>
+      <ElPageHeaderTitleActions>{actions}</ElPageHeaderTitleActions>
+    </ElPageHeaderTitle>
+  )
+}


### PR DESCRIPTION
### Context

- There's new [PageHeader](https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=2330-2964&m=dev&focus-id=10113-8278) designs for Elements;
- The existing `PageHeader` relies on "prop configuration" to display content rather than the composition of atomic components.
- We want to deliver the new PageHeader with a compositional API, so we want to deprecate the existing one and deliver a new one.
- Part 1: #594
- **Part 2: Add new `PageHeader.Title` (this PR)**

### This PR

- Adds a new `PageHeader.Title` component.

<img width="822" alt="Screenshot 2025-07-08 at 10 10 45 am" src="https://github.com/user-attachments/assets/008e551b-5a5e-473a-bb48-843be8daf7b3" />
<img width="822" alt="Screenshot 2025-07-08 at 10 10 53 am" src="https://github.com/user-attachments/assets/280ef176-27d3-497b-955e-088cf2422892" />
<img width="818" alt="Screenshot 2025-07-08 at 10 10 58 am" src="https://github.com/user-attachments/assets/eb6ee2af-789c-456a-b914-af806581b9c4" />
