### PR TITLE
chore: stop using CSS `all` property as it unsets CSS variables too

### DIFF
--- a/src/components/breadcrumbs/item/styles.ts
+++ b/src/components/breadcrumbs/item/styles.ts
@@ -1,9 +1,6 @@
 import { styled } from '@linaria/react'
 
 export const ElBreadcrumbItem = styled.li`
-  all: unset;
-  box-sizing: border-box;
-
   display: inline-grid;
   grid-template-columns: auto min-content;
   align-items: center;

--- a/src/components/breadcrumbs/styles.ts
+++ b/src/components/breadcrumbs/styles.ts
@@ -21,14 +21,16 @@ export const ElBreadcrumbs = styled.nav<ElBreadcrumbsProps>`
 `
 
 export const ElBreadcrumbsList = styled.ul`
-  all: unset;
-  box-sizing: border-box;
-
   display: inline-grid;
   grid-auto-flow: column;
   /* NOTE: This helps ensure each item has an equal share of the available space, especially when truncation occurs */
   grid-template-columns: repeat(auto-fill, minmax(0, auto));
   align-items: center;
+
+  list-style: none;
+
+  margin: 0;
+  padding: 0;
 
   width: 100%;
 

--- a/src/components/chip-group/styles.ts
+++ b/src/components/chip-group/styles.ts
@@ -13,12 +13,13 @@ interface ElChipGroupListProps {
 }
 
 export const ElChipGroupList = styled.ul<ElChipGroupListProps>`
-  all: unset;
-  box-sizing: border-box;
-
   display: flex;
   gap: var(--spacing-2);
+
   list-style: none;
+
+  margin: 0;
+  padding: 0;
 
   &[data-overflow='scroll'] {
     flex-wrap: nowrap;

--- a/src/components/compact-select-native/compact-select-native.stories.tsx
+++ b/src/components/compact-select-native/compact-select-native.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
               <option value="portfolio1">Portfolio 1</option>
               <option value="portfolio2">Portfolio 2</option>
             </optgroup>
-            <optgroup aria-label="Other Portfolios">
+            <optgroup label="Other Portfolios">
               <option value="portfolio3">Portfolio 3</option>
               <option value="portfolio4">Portfolio 4</option>
               <option value="portfolio5">Portfolio 5</option>

--- a/src/components/compact-select-native/styles.ts
+++ b/src/components/compact-select-native/styles.ts
@@ -16,14 +16,10 @@ interface ElCompactSelectNativeProps {
 }
 
 export const ElCompactSelectNative = styled.select<ElCompactSelectNativeProps>`
-  all: unset;
-  box-sizing: border-box;
-
   max-width: var(--select-max-width);
 
-  @supports (field-sizing: content) {
-    field-sizing: content;
-  }
+  appearance: none;
+  border: none;
 
   text-overflow: ellipsis;
   overflow: hidden;
@@ -32,7 +28,9 @@ export const ElCompactSelectNative = styled.select<ElCompactSelectNativeProps>`
   cursor: pointer;
   color: var(--comp-input-colour-text-default-input);
 
-  appearance: none;
+  @supports (field-sizing: content) {
+    field-sizing: content;
+  }
 
   /* NOTE: We need to create space for the absolutely positioned icon. */
   padding-inline-end: calc(var(--spacing-1) + var(--icon_size-s));

--- a/src/components/features/item/styles.ts
+++ b/src/components/features/item/styles.ts
@@ -9,8 +9,8 @@ export const ElFeaturesItem = styled.div`
 `
 
 export const ElFeaturesItemIcon = styled.dt`
-  all: unset;
-  box-sizing: border-box;
+  display: inline-flex;
+  place-items: center;
 
   color: var(--comp-features-colour-icon);
 
@@ -19,8 +19,7 @@ export const ElFeaturesItemIcon = styled.dt`
 `
 
 export const ElFeaturesItemValue = styled.dd`
-  all: unset;
-  box-sizing: border-box;
+  margin: 0;
 
   color: var(--comp-features-colour-text);
 

--- a/src/components/features/styles.ts
+++ b/src/components/features/styles.ts
@@ -6,9 +6,6 @@ interface ElFeaturesProps {
 }
 
 export const ElFeatures = styled.dl<ElFeaturesProps>`
-  all: unset;
-  box-sizing: border-box;
-
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-3);

--- a/src/components/tag-group/styles.ts
+++ b/src/components/tag-group/styles.ts
@@ -1,12 +1,13 @@
 import { styled } from '@linaria/react'
 
 export const ElTagGroupList = styled.ul`
-  all: unset;
-  box-sizing: border-box;
-
   display: inline-flex;
   flex-flow: row wrap;
   gap: var(--spacing-1);
+
+  list-style: none;
+  margin: 0;
+  padding: 0;
 
   /* NOTE: necessary when used in an inline or inline-block layout */
   vertical-align: middle;

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -27,6 +27,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore:** `Badge`, `TagGroup` and icons will now default to `vertical-align: middle` in `inline` and `inline-block` layouts. This is important for the upcoming `PageHeader` replacement.
 - **chore:** `Button` labels will not wrap when used in a grid or flex layout that shrinks the button's container.
 - **chore!:** Deprecated `PageHeader` component. It is still available, but is now called `DeprecatedPageHeader`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix.
+- **chore:** Stop using CSS `all` property in components as it impacts CSS custom properties as well. Also resolves icon alignment issue in `Features`.
 
 ### **5.0.0-beta.36 - 04/07/25**
 


### PR DESCRIPTION
Recently, some of our components started leveraging the [all](https://developer.mozilla.org/en-US/docs/Web/CSS/all) CSS property with the view that it was an easy way of removing the user-agent styles applied for some elements (e.g. `<ul>` elements). Unfortunately, this property also impacts CSS custom properties elements may inherit from its ancestors.

As such, we want to stop using this property and just undo the user-agent styles manually.

This PR also scouts a small update to the Features.Item component to ensure icons are correctly aligned (this regressed in #595).