### PR TITLE
feat: Add new `PageHeader.Subtitle` component

### DIFF
--- a/src/components/page-header/subtitle/__tests__/subtitle.test.tsx
+++ b/src/components/page-header/subtitle/__tests__/subtitle.test.tsx
@@ -1,0 +1,21 @@
+import { PageHeaderSubtitle } from '../subtitle'
+import { render, screen } from '@testing-library/react'
+
+test('renders a paragraph element with the expected title', () => {
+  render(<PageHeaderSubtitle>Page Subtitle</PageHeaderSubtitle>)
+  // NOTE: The subtitle should be the first paragraph element
+  expect(screen.getAllByRole('paragraph')[0]).toHaveTextContent('Page Subtitle')
+})
+
+test('displays additional information when provided', () => {
+  render(<PageHeaderSubtitle additionalInfo="Fake info">Page Subtitle</PageHeaderSubtitle>)
+  // NOTE: The additional info should be the second paragraph element
+  const additionalInfo = screen.getAllByRole('paragraph')[1]
+  expect(additionalInfo).toBeVisible()
+  expect(additionalInfo).toHaveTextContent('Fake info')
+})
+
+test('forwards additional props to the title container', () => {
+  render(<PageHeaderSubtitle data-testid="test-id">Page Subtitle</PageHeaderSubtitle>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/components/page-header/subtitle/index.ts
+++ b/src/components/page-header/subtitle/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './subtitle'

--- a/src/components/page-header/subtitle/styles.ts
+++ b/src/components/page-header/subtitle/styles.ts
@@ -1,0 +1,27 @@
+import { font } from '../../text'
+import { styled } from '@linaria/react'
+
+export const ElPageHeaderSubtitle = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--spacing-2);
+
+  padding-block: var(--spacing-half);
+`
+
+export const ElPageHeaderSubtitleText = styled.p`
+  display: inline;
+  margin: 0;
+
+  color: var(--colour-text-primary);
+
+  ${font('base', 'bold')}
+`
+
+export const ElPageHeaderSubtitleAdditionalInfo = styled.p`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: 0;
+`

--- a/src/components/page-header/subtitle/subtitle.stories.tsx
+++ b/src/components/page-header/subtitle/subtitle.stories.tsx
@@ -1,0 +1,87 @@
+import { Badge } from '#src/components/badge'
+import { PageHeaderSubtitle } from './subtitle'
+import { StarIcon } from '#src/icons/star'
+import { TagGroup } from '#src/components/tag-group'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/PageHeader/Subtitle',
+  component: PageHeaderSubtitle,
+  argTypes: {
+    additionalInfo: {
+      control: 'radio',
+      options: ['None', 'Tag', 'Badge', 'Icon', 'All'],
+      mapping: {
+        None: null,
+        Tag: (
+          <TagGroup>
+            <TagGroup.Item>Tag</TagGroup.Item>
+          </TagGroup>
+        ),
+        Badge: <Badge colour="neutral">Badge</Badge>,
+        Icon: <StarIcon size="lg" color="primary" />,
+        All: (
+          <>
+            <TagGroup>
+              <TagGroup.Item>Tag</TagGroup.Item>
+            </TagGroup>
+            <Badge colour="neutral">Badge</Badge>
+            <StarIcon size="lg" color="primary" />
+          </>
+        ),
+      },
+    },
+    children: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof PageHeaderSubtitle>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * At its simplest, the page header's subtitle contains just that: the page's subtitle.
+ */
+export const Example: Story = {
+  args: {
+    additionalInfo: 'None',
+    children: 'Page Subtitle',
+  },
+}
+
+/**
+ * Additional information can follow the subtitle. This information is typically some combination of one or more tags,
+ * badges, and/or icons.
+ */
+export const AdditionalInfo: Story = {
+  args: {
+    ...Example.args,
+    additionalInfo: 'All',
+  },
+}
+
+/**
+ * When the subtitle (and any additional information) do not have enough space to display on a single line, they will
+ * wrap to additional lines.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    additionalInfo: 'All',
+    children: 'This is a long subtitle that flows into the next line.',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', flexFlow: 'column', gap: 'var(--spacing-10)' }}>
+        <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '400px' }}>
+          <Story />
+        </div>
+        <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '250px' }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+}

--- a/src/components/page-header/subtitle/subtitle.tsx
+++ b/src/components/page-header/subtitle/subtitle.tsx
@@ -1,0 +1,23 @@
+import { ElPageHeaderSubtitle, ElPageHeaderSubtitleText, ElPageHeaderSubtitleAdditionalInfo } from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface PageHeaderSubtitleProps extends HTMLAttributes<HTMLDivElement> {
+  /** The main title text to display */
+  children: ReactNode
+  /** Optional information to display alongside the title. Typically a tag group, badge, or icon. */
+  additionalInfo?: ReactNode
+}
+
+/**
+ * A title component for page headers. Displays the main page title with optional, additional information and actions.
+ * Typically used via `PageHeader.Subtitle`.
+ */
+export function PageHeaderSubtitle({ additionalInfo, children, ...rest }: PageHeaderSubtitleProps) {
+  return (
+    <ElPageHeaderSubtitle {...rest}>
+      <ElPageHeaderSubtitleText>{children}</ElPageHeaderSubtitleText>
+      <ElPageHeaderSubtitleAdditionalInfo>{additionalInfo}</ElPageHeaderSubtitleAdditionalInfo>
+    </ElPageHeaderSubtitle>
+  )
+}


### PR DESCRIPTION
### Context

- There's new [PageHeader](https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=2330-2964&m=dev&focus-id=10113-8278) designs for Elements;
- The existing `PageHeader` relies on "prop configuration" to display content rather than the composition of atomic components.
- We want to deliver the new PageHeader with a compositional API, so we want to deprecate the existing one and deliver a new one.
- Part 1: #594
- Part 2: #596 
- **Part 3: Add new `PageHeader.Subtitle` (this PR)**

### This PR

- Adds a new `PageHeader.Subtitle` component.

<img width="818" alt="Screenshot 2025-07-08 at 11 47 27 am" src="https://github.com/user-attachments/assets/ba70a4c7-a2de-4b35-a8b1-b57f06bda861" />
<img width="820" alt="Screenshot 2025-07-08 at 11 47 36 am" src="https://github.com/user-attachments/assets/0d09ecfa-ce22-433c-b632-3fb18895b53c" />
