### PR TITLE
chore: remove margin on `Features`

### DIFF
--- a/src/components/features/styles.ts
+++ b/src/components/features/styles.ts
@@ -10,6 +10,9 @@ export const ElFeatures = styled.dl<ElFeaturesProps>`
   align-items: center;
   gap: var(--spacing-3);
 
+  margin: 0;
+  padding: 0;
+
   &,
   &[data-wrap='wrap'] {
     flex-wrap: wrap;


### PR DESCRIPTION
#598 missed the removal of the user-agent `margin` applied to `dl` elements. This PR fixes that omission.