### PR TITLE
fix: #597 `DeprecatedNav` alignment regression

### DIFF
--- a/src/components/deprecated-nav/__styles__/index.ts
+++ b/src/components/deprecated-nav/__styles__/index.ts
@@ -87,6 +87,7 @@ export const ElDeprecatedNavItem = styled.a`
   flex: 1 0 100%;
   width: 100%;
   border-left: 3px solid var(--white);
+  text-decoration: none;
 
   &:first-child {
     opacity: 1;
@@ -126,10 +127,6 @@ export const ElDeprecatedNavItem = styled.a`
       height: auto;
     }
 
-    &:last-of-type {
-      margin-right: auto;
-    }
-
     &:not(:first-child) {
       overflow: visible;
       padding: 0.375rem 0.75rem;
@@ -137,6 +134,10 @@ export const ElDeprecatedNavItem = styled.a`
       height: 2rem;
       border-top: none;
       margin-right: 1rem;
+    }
+
+    &:last-of-type {
+      margin-right: auto;
     }
 
     &:hover:not(:first-child) {

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -28,6 +28,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore:** `Button` labels will not wrap when used in a grid or flex layout that shrinks the button's container.
 - **chore!:** Deprecated `PageHeader` component. It is still available, but is now called `DeprecatedPageHeader`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix.
 - **chore:** Stop using CSS `all` property in components as it impacts CSS custom properties as well. Also resolves icon alignment issue in `Features`.
+- **fix:** #551 introduced a visual regression in the `DeprecatedNav` component. This has now been fixed.
 
 ### **5.0.0-beta.36 - 04/07/25**
 


### PR DESCRIPTION
#551 introduced linting and, as a result, made a number of CSS changes to existing components to resolve lint issues now being surfaces. Once of these changes was the re-ordering of CSS blocks for the `DeprecatedNav` component. These blocks had the same specificity, so the change in order resulted in a different block's properties gaining precedence, thus causing the visual regression.

This PR fixes this issue while still adhering to the CSS lint rules now at play (specifically, the [no-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity) rule).

| Before | After |
| ------ | ----- |
| <img width="1010" alt="Screenshot 2025-07-08 at 11 17 29 pm" src="https://github.com/user-attachments/assets/eaf0b0b2-199b-42d5-b7c8-279b16ff72a5" /> | <img width="1015" alt="Screenshot 2025-07-08 at 11 17 06 pm" src="https://github.com/user-attachments/assets/0c074393-fab8-460f-84aa-fbcdf69c35df" /> |
