### PR TITLE
feat: Add new `URLSearchParams` helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/js/icons/*.js",
       "require": "./dist/js/icons/*.cjs"
     },
+    "./utils/*": {
+      "types": "./dist/types/utils/*/index.d.ts",
+      "import": "./dist/js/utils/*/index.js",
+      "require": "./dist/js/utils/*/index.cjs"
+    },
     "./reset.css": "./public/reset.css",
     "./styles.css": "./dist/js/style.css",
     "./dist/index.css": "./dist/js/style.css"

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,3 +117,5 @@ export * from './components/text'
 export * from './components/textarea'
 export * from './components/tooltip'
 export * from './components/top-bar'
+
+export * from './utils'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './url-search-params'

--- a/src/utils/url-search-params/__test__/to-map.test.ts
+++ b/src/utils/url-search-params/__test__/to-map.test.ts
@@ -1,0 +1,38 @@
+import { toMap } from '../to-map'
+
+test('returns a Map instance', () => {
+  const params = new URLSearchParams()
+  const map = toMap(params)
+  expect(map).toBeInstanceOf(Map)
+})
+
+test('Map is empty when URLSearchParams is empty', () => {
+  const params = new URLSearchParams()
+  const map = toMap(params)
+  expect(map.size).toBe(0)
+})
+
+test('Map has the same key-value pairs as the URLSearchParams', () => {
+  const params = new URLSearchParams('foo=bar&baz=qux')
+  const map = toMap(params)
+  expect(map.get('foo')).toBe('bar')
+  expect(map.get('baz')).toBe('qux')
+})
+
+test('Map has entries for empty search params', () => {
+  const params = new URLSearchParams('a=')
+  const map = toMap(params)
+  expect(map.get('a')).toBe('')
+})
+
+test('Map has an array of values for a key when that key is used by multiple search params', () => {
+  const params = new URLSearchParams('foo=&foo=1&foo=1&foo=2')
+  const map = toMap(params)
+  expect(map.get('foo')).toEqual(['', '1', '1', '2'])
+})
+
+test('Map keys are sorted alphabetically', () => {
+  const params = new URLSearchParams('b=2&a=1&c=3')
+  const map = toMap(params)
+  expect(Array.from(map.keys())).toEqual(['a', 'b', 'c'])
+})

--- a/src/utils/url-search-params/__test__/to-url-search-params.test.ts
+++ b/src/utils/url-search-params/__test__/to-url-search-params.test.ts
@@ -1,0 +1,97 @@
+import { toURLSearchParams } from '../to-url-search-params'
+
+test('returns a URLSearchParams instance', () => {
+  const data = { a: '1' }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params).toBeInstanceOf(URLSearchParams)
+})
+
+test('URLSearchParams is empty when input is empty', () => {
+  const data = {}
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.toString()).toBe('')
+})
+
+test('converts simple key-value pairs', () => {
+  const data = { foo: 'bar', baz: 'qux' }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.get('foo')).toBe('bar')
+  expect(params.get('baz')).toBe('qux')
+  expect(params.toString()).toBe('baz=qux&foo=bar')
+})
+
+test('removes pairs with null values', () => {
+  const data = { a: '1', b: null, c: '3' }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.has('b')).toBe(false)
+  expect(params.toString()).toBe('a=1&c=3')
+})
+
+test('expands array values into multiple key-value pairs', () => {
+  const data = { a: ['1', '2'], b: '3' }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.getAll('a')).toEqual(['1', '2'])
+  expect(params.get('b')).toBe('3')
+  expect(params.toString()).toBe('a=1&a=2&b=3')
+})
+
+test('handles empty string values', () => {
+  const data = { a: '', b: '2' }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.get('a')).toBe('')
+  expect(params.get('b')).toBe('2')
+  expect(params.toString()).toBe('a=&b=2')
+})
+
+test('sorts entries alphabetically', () => {
+  const data = { b: '2', a: '1', c: '3' }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(Array.from(params.keys())).toEqual(['a', 'b', 'c'])
+  expect(params.toString()).toBe('a=1&b=2&c=3')
+})
+
+test('replaces existing keys from init', () => {
+  const data = { a: '1', b: null }
+  const init = new URLSearchParams('a=5&b=6&c=7')
+
+  const params = toURLSearchParams(Object.entries(data), init)
+
+  expect(params.get('a')).toBe('1')
+  expect(params.has('b')).toBe(false)
+  expect(params.get('c')).toBe('7')
+  expect(params.toString()).toBe('a=1&c=7')
+})
+
+test('appends array values and replaces existing keys from init', () => {
+  const data = { a: ['1', '2'], b: null }
+  const init = new URLSearchParams('a=5&b=6&c=7')
+
+  const params = toURLSearchParams(Object.entries(data), init)
+
+  expect(params.getAll('a')).toEqual(['1', '2'])
+  expect(params.has('b')).toBe(false)
+  expect(params.get('c')).toBe('7')
+  expect(params.toString()).toBe('a=1&a=2&c=7')
+})
+
+test('handles input with only null values', () => {
+  const data = { a: null, b: null }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.toString()).toBe('')
+})
+
+test('handles input with array containing empty strings', () => {
+  const data = { a: ['', '1', ''] }
+  const params = toURLSearchParams(Object.entries(data))
+
+  expect(params.getAll('a')).toEqual(['', '1', ''])
+  expect(params.toString()).toBe('a=&a=1&a=')
+})

--- a/src/utils/url-search-params/index.mdx
+++ b/src/utils/url-search-params/index.mdx
@@ -1,0 +1,25 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# Working with `URLSearchParams`
+
+<Meta title="Utils/URLSearchParams" />
+
+The `URLSearchParams` interface defines utility methods to work with the query string of a URL. It is common for
+web applications to use this interface to parse and manipulate the query string of a URL, particularly to store
+application state like the filters applied on a list page.
+
+It's valuable to store specific pieces of state in the URL because users should be able to:
+
+- Refresh the page or navigate through their browser history without losing their state;
+- Open links in a new tab using their OS' standard keyboard shortcut and reliably see the state they expect; and,
+- Share and bookmark links within a web application and have that link open to the same state as when the link was
+  copied.
+
+See [MDN's URLSearchParams documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) for
+more details and usage examples.
+
+Unfortunately, the `URLSearchParams` interface can be a bit awkward to work with. The following utility functions
+are provided to smooth over some of its rough edges:
+
+- [toMap](?path=/docs/utils-urlsearchparams-tomap--docs): Converts a `URLSearchParams` object to a `Map`, ensuring that multiple values for the same key are stored as arrays.
+- [toURLSearchParams](?path=/docs/utils-urlsearchparams-tourlsearchparams--docs): Converts iterable of key-value pairs to a `URLSearchParams` object.

--- a/src/utils/url-search-params/index.ts
+++ b/src/utils/url-search-params/index.ts
@@ -1,0 +1,2 @@
+export * from './to-map'
+export * from './to-url-search-params'

--- a/src/utils/url-search-params/to-map.mdx
+++ b/src/utils/url-search-params/to-map.mdx
@@ -1,0 +1,25 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# `toMap`
+
+<Meta title="Utils/URLSearchParams/toMap" />
+
+Converts a `URLSearchParams` object to a `Map`, ensuring that multiple values for the same key are stored as arrays.
+
+## Syntax
+
+```ts
+toMap(searchParams)
+```
+
+- `searchParams`: The `URLSearchParams` to convert.
+
+## Usage Example
+
+```ts
+import { toMap } from '@reapit/elements/utils/url-search-params'
+
+const searchParams = new URLSearchParams('a=1&a=2&b=3')
+const map = toMap(searchParams)
+console.log(map) // Map { 'a' => ['1', '2'], 'b' => ['3'] }
+```

--- a/src/utils/url-search-params/to-map.ts
+++ b/src/utils/url-search-params/to-map.ts
@@ -1,0 +1,43 @@
+/**
+ * Convert a URLSearchParams object to a Map, ensuring that multiple values for the same key are stored as arrays.
+ *
+ * @example
+ *
+ * ```ts
+ * const searchParams = new URLSearchParams('a=1&a=2&b=3')
+ * const map = toMap(searchParams)
+ * console.log(map) // Map { 'a' => ['1', '2'], 'b' => ['3'] }
+ * ```
+ *
+ * If you need a plain JavaScript object rather than a Map, simply use `Object.fromEntries`.
+ *
+ * @example
+ *
+ * ```ts
+ * const searchParams = new URLSearchParams('a=1&a=2&b=3')
+ * const obj = Object.fromEntries(toMap(searchParams))
+ * console.log(obj) // { a: ['1', '2'], b: ['3'] }
+ * ```
+ *
+ * @param searchParams - The URLSearchParams to convert.
+ *
+ * @returns A Map with the same key-value pairs as the URLSearchParams, but with multiple values for the same key
+ * stored as arrays.
+ */
+export function toMap(searchParams: URLSearchParams): Map<string, string | string[]> {
+  const result: Map<string, string | string[]> = new Map()
+
+  // Get unique keys and sort them to ensure consistent key order in the resulting Map.
+  const sortedKeys = [...new Set(Array.from(searchParams.keys()))].sort()
+
+  for (const key of sortedKeys) {
+    const values = searchParams.getAll(key)
+    if (values.length > 1) {
+      result.set(key, values)
+    } else {
+      result.set(key, values[0])
+    }
+  }
+
+  return result
+}

--- a/src/utils/url-search-params/to-url-search-params.mdx
+++ b/src/utils/url-search-params/to-url-search-params.mdx
@@ -1,0 +1,29 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# `toURLSearchParams`
+
+<Meta title="Utils/URLSearchParams/toURLSearchParams" />
+
+Converts an iterable of key-value pairs to a `URLSearchParams` object. The `URLSearchParams` object's entries will be
+sorted alphabetically. Pairs with a null value will be removed. Pairs with an array value will be expanded into
+multiple key-value pairs.
+
+## Syntax
+
+```ts
+toURLSearchParams(data, init)
+```
+
+- `entries`: An iterable of key-value pairs.
+- `init`: An optional `URLSearchParams` object to initialize the new search params with. Entries in this object will
+  always be replaced by new entries with the same key.
+
+## Usage Example
+
+```ts
+import { toURLSearchParams } from '@reapit/elements/utils/url-search-params'
+
+const data = { a: '1', b: null, c: ['3', '4'] }
+const params = toURLSearchParams(Object.entries(data))
+console.log(params.toString()) // 'a=1&c=3&c=4'
+```

--- a/src/utils/url-search-params/to-url-search-params.ts
+++ b/src/utils/url-search-params/to-url-search-params.ts
@@ -1,0 +1,53 @@
+/**
+ * Convert an Iterable of key-value pairs to a URLSearchParams object. The URLSearchParams object's entries will be
+ * sorted alphabetically. Pairs with a null value will be removed. Pairs with an array value will be expanded into
+ * multiple key-value pairs.
+ *
+ * @example
+ *
+ * ```ts
+ * const data = new Map([['a', '1'], ['b', null], ['c', ['3', '4']]])
+ * const searchParams = toURLSearchParams(data)
+ * console.log(searchParams.toString()) // 'a=1&c=3&c=4'
+ * ```
+ *
+ * The URLSearchParams object can be initialized with an existing URLSearchParams object. This is useful when the
+ * iterable's entries represent changes that should be applied to an existing URLSearchParams object.
+ *
+ * @example
+ *
+ * ```ts
+ * const data = new Map([['a', '1'], ['b', null], ['c', ['3', '4']]])
+ * const searchParams = toURLSearchParams(data, new URLSearchParams('a=5&b=6&d=7'))
+ * console.log(searchParams.toString()) // 'a=1&c=3&c=4&d=7'
+ * ```
+ *
+ * @param entries - The Iterable to convert. The Iterable must yield key-value pairs (i.e. [key, value]).
+ * @param init - Optional URLSearchParams object to initialize the new search params with. Entries in this object will
+ * always be replaced by new entries with the same key.
+ *
+ * @returns A URLSearchParams object with the same key-value pairs as the Iterable.
+ */
+export function toURLSearchParams(entries: Iterable<[string, string | string[] | null]>, init?: URLSearchParams) {
+  const searchParams = new URLSearchParams(init)
+
+  for (const [key, value] of entries) {
+    if (value === null) {
+      searchParams.delete(key)
+    } else if (Array.isArray(value)) {
+      // The new array of entries replaces any existing entries.
+      searchParams.delete(key)
+      for (const item of value) {
+        searchParams.append(key, item)
+      }
+    } else {
+      // The new entry replaces any existing entries.
+      searchParams.set(key, value)
+    }
+  }
+
+  // Sort the entries alphabetically.
+  searchParams.sort()
+
+  return searchParams
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       cssFileName: 'style',
       entry: {
         index: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+        'utils/url-search-params': fileURLToPath(new URL('./src/utils/url-search-params/index.ts', import.meta.url)),
         ...icons,
       },
       formats: ['es', 'cjs'],


### PR DESCRIPTION
### Context

- We have upcoming work related to Drawers and Dialogs that will require us to deliver URLSearchParam state management for them (i.e. a path-like search param that determines which drawer/dialog on the page is open or not).
- To do this, we need some small utilities to help us work with URLSearchParams instances.

### This PR

- Adds two new utilities: `toMap` and `toURLSearchParams`. These can be imported from a new `/utils` subpath: `@reapit/elements/utils/url-search-params`.
- Adds basic docs for these utilities.

<img width="1009" height="445" alt="Screenshot 2025-07-15 at 2 51 50 pm" src="https://github.com/user-attachments/assets/cb98d763-67e3-47c1-91bc-761cb92c98bc" />
