### PR TITLE
feat: Add new `PrimaryTabs` component

### DIFF
--- a/src/components/primary-tabs/__tests__/primary-tabs-item.test.tsx
+++ b/src/components/primary-tabs/__tests__/primary-tabs-item.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { PrimaryTabsItem } from '../primary-tabs-item'
+
+test('renders a list item containing a link', () => {
+  render(
+    <ul>
+      <PrimaryTabsItem aria-current={false} href="/test">
+        Primary tab
+      </PrimaryTabsItem>
+    </ul>,
+  )
+
+  expect(screen.getByRole('listitem')).toBeVisible()
+  expect(screen.getByRole('link', { name: 'Primary tab' })).toBeVisible()
+})
+
+test('passes through additional props to the PrimaryTab component', () => {
+  render(
+    <ul>
+      <PrimaryTabsItem aria-current="page" href="/current" data-testid="custom-tab">
+        Current Tab
+      </PrimaryTabsItem>
+    </ul>,
+  )
+
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('aria-current', 'page')
+  expect(link).toHaveAttribute('href', '/current')
+  expect(link).toHaveAttribute('data-testid', 'custom-tab')
+})

--- a/src/components/primary-tabs/__tests__/primary-tabs.test.tsx
+++ b/src/components/primary-tabs/__tests__/primary-tabs.test.tsx
@@ -1,0 +1,26 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+import * as stories from '../primary-tabs.stories'
+
+const PrimaryTabsStories = composeStories(stories)
+
+test('renders as a navigation element with a list', () => {
+  render(<PrimaryTabsStories.Example />)
+  expect(screen.getByRole('navigation')).toBeVisible()
+  expect(screen.getByRole('list')).toBeVisible()
+})
+
+test('has a default data-overflow of "visible"', () => {
+  render(<PrimaryTabsStories.Example />)
+  expect(screen.getByRole('navigation')).toHaveAttribute('data-overflow', 'visible')
+})
+
+test('allows overriding the data-overflow', () => {
+  render(<PrimaryTabsStories.Example overflow="scroll" />)
+  expect(screen.getByRole('navigation')).toHaveAttribute('data-overflow', 'scroll')
+})
+
+test('forwards additional props to the nav element', () => {
+  render(<PrimaryTabsStories.Example data-testid="test" />)
+  expect(screen.getByTestId('test')).toBeVisible()
+})

--- a/src/components/primary-tabs/index.ts
+++ b/src/components/primary-tabs/index.ts
@@ -1,0 +1,3 @@
+export * from './primary-tabs'
+export * from './primary-tabs-item'
+export * from './tab'

--- a/src/components/primary-tabs/primary-tabs-item.tsx
+++ b/src/components/primary-tabs/primary-tabs-item.tsx
@@ -1,0 +1,20 @@
+import { ElPrimaryTabsListItem } from './styles'
+import { PrimaryTab } from './tab'
+
+import type { ComponentProps } from 'react'
+
+interface PrimaryTabsItemProps extends ComponentProps<typeof PrimaryTab> {}
+
+/**
+ * A thin wrapper around `PrimaryTab` that ensures it is contained within a list item (`<li>`) for
+ * correct semantics and accessibility when used with `PrimaryTabs`.
+ *
+ * All props are passed through to `PrimaryTab`.
+ */
+export function PrimaryTabsItem(props: PrimaryTabsItemProps) {
+  return (
+    <ElPrimaryTabsListItem>
+      <PrimaryTab {...props} />
+    </ElPrimaryTabsListItem>
+  )
+}

--- a/src/components/primary-tabs/primary-tabs.stories.tsx
+++ b/src/components/primary-tabs/primary-tabs.stories.tsx
@@ -1,0 +1,89 @@
+import { PrimaryTabs } from './primary-tabs'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Components/PrimaryTabs',
+  component: PrimaryTabs,
+  argTypes: {
+    children: {
+      control: 'radio',
+      options: ['No selected tab', 'Selected tab'],
+      mapping: {
+        'No selected tab': buildTabs('No selected tab'),
+        'Selected tab': buildTabs('Selected tab'),
+      },
+    },
+    overflow: {
+      control: 'radio',
+      options: ['scroll', 'undefined'],
+      mapping: {
+        scroll: 'scroll',
+        undefined: undefined,
+      },
+    },
+  },
+} satisfies Meta<typeof PrimaryTabs>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'No selected tab',
+  },
+}
+
+/**
+ * If a tab represents the current page/section, it should be marked as "selected" with aria-current="page".
+ * This will show the blue bottom border and selected styling.
+ */
+export const SelectedTab: Story = {
+  args: {
+    children: 'Selected tab',
+  },
+}
+
+/**
+ * Ideally, overflowing should be avoided as much as possible. When it can’t be avoided (e.g. small
+ * breakpoints) use horizontal scrolling by providing `overflow="scroll"`. By default, tabs will simply
+ * overflow the container.
+ */
+export const Overflow: Story = {
+  args: {
+    children: 'Selected tab',
+    overflow: 'scroll',
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ border: '1px solid #FA00FF', width: '397px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+}
+
+function buildTabs(type: 'No selected tab' | 'Selected tab') {
+  return [
+    <PrimaryTabs.Item key="apples" href={href} aria-current={type === 'Selected tab' ? 'page' : false}>
+      Apples
+    </PrimaryTabs.Item>,
+    <PrimaryTabs.Item key="bananas" aria-current={false} href={href}>
+      Bananas
+    </PrimaryTabs.Item>,
+    <PrimaryTabs.Item key="peaches" aria-current={false} href={href}>
+      Peaches
+    </PrimaryTabs.Item>,
+    <PrimaryTabs.Item key="strawberries" aria-current={false} href={href}>
+      Strawberries
+    </PrimaryTabs.Item>,
+    <PrimaryTabs.Item key="watermelon" aria-current={false} href={href}>
+      Watermelon
+    </PrimaryTabs.Item>,
+  ]
+}

--- a/src/components/primary-tabs/primary-tabs.tsx
+++ b/src/components/primary-tabs/primary-tabs.tsx
@@ -1,0 +1,30 @@
+import { ElPrimaryTabs, ElPrimaryTabsList } from './styles'
+import { PrimaryTabsItem } from './primary-tabs-item'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface PrimaryTabsProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * The tab items for primary navigation. Typically a collection of `PrimaryTabs.Item` components.
+   */
+  children: ReactNode
+  /**
+   * Ideally, overflow is avoided as much as possible. When it can't be avoided (e.g. small screens),
+   * use horizontal scrolling by providing `overflow="scroll"`. By default, overflow will be visible
+   * without scrolling.
+   */
+  overflow?: 'scroll' | 'visible'
+}
+
+/**
+ * A navigation container for primary tabs. Typically used with `PrimaryTabs.Item`.
+ */
+export function PrimaryTabs({ children, overflow = 'visible', ...rest }: PrimaryTabsProps) {
+  return (
+    <ElPrimaryTabs data-overflow={overflow} {...rest}>
+      <ElPrimaryTabsList>{children}</ElPrimaryTabsList>
+    </ElPrimaryTabs>
+  )
+}
+
+PrimaryTabs.Item = PrimaryTabsItem

--- a/src/components/primary-tabs/styles.ts
+++ b/src/components/primary-tabs/styles.ts
@@ -1,0 +1,48 @@
+import { styled } from '@linaria/react'
+
+interface ElPrimaryTabsProps {
+  'data-overflow'?: 'scroll' | 'visible'
+}
+
+export const ElPrimaryTabs = styled.nav<ElPrimaryTabsProps>`
+  &,
+  &[data-overflow='visible'] {
+    overflow-x: visible;
+  }
+
+  &[data-overflow='scroll'] {
+    overflow-x: auto;
+  }
+`
+
+export const ElPrimaryTabsList = styled.menu`
+  position: relative;
+
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  gap: var(--spacing-8);
+  list-style: none;
+
+  margin: 0;
+  padding: 0;
+
+  /* NOTE: We use a pseudo-element to draw the bottom border of the menu element, as this
+   * provides the simplest and most reliable way to draw a border that can be overlapped by
+   * the list items' borders. */
+  &::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    inset-block-end: 0;
+    width: 100%;
+    height: var(--border-width-default);
+    background-color: var(--comp-tab-colour-border-group);
+    z-index: -1;
+  }
+`
+
+export const ElPrimaryTabsListItem = styled.li`
+  display: flex;
+  align-items: center;
+`

--- a/src/components/primary-tabs/tab/__tests__/tab.test.tsx
+++ b/src/components/primary-tabs/tab/__tests__/tab.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { PrimaryTab } from '../tab'
+
+test('renders a link element', () => {
+  render(
+    <PrimaryTab aria-current={false} href="/">
+      Tab item
+    </PrimaryTab>,
+  )
+  expect(screen.getByRole('link', { name: 'Tab item' })).toBeVisible()
+})
+
+test('has the specified `aria-current` attribute', () => {
+  render(
+    <PrimaryTab aria-current="page" href="/">
+      Tab item
+    </PrimaryTab>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'page')
+})
+
+test('passes through additional props to the link element', () => {
+  render(
+    <PrimaryTab aria-current="page" data-testid="custom-tab" href="/">
+      Tab item
+    </PrimaryTab>,
+  )
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('data-testid', 'custom-tab')
+})

--- a/src/components/primary-tabs/tab/index.ts
+++ b/src/components/primary-tabs/tab/index.ts
@@ -1,0 +1,2 @@
+export * from './tab'
+export * from './styles'

--- a/src/components/primary-tabs/tab/styles.ts
+++ b/src/components/primary-tabs/tab/styles.ts
@@ -1,0 +1,42 @@
+import { font } from '#src/components/text'
+import { styled } from '@linaria/react'
+
+interface ElPrimaryTabProps {
+  'aria-current': 'page' | false
+}
+
+export const ElPrimaryTab = styled.a<ElPrimaryTabProps>`
+  display: inline-flex;
+  align-items: center;
+  height: var(--size-12);
+  width: min-content;
+  padding-block: var(--spacing-3);
+
+  border-bottom: var(--comp-tab-border-width-primary) solid transparent;
+  color: var(--comp-tab-colour-text-primary-default);
+
+  cursor: pointer;
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+
+  &:hover {
+    color: var(--comp-tab-colour-text-primary-hover);
+    border-bottom-color: var(--comp-tab-colour-border-primary-hover);
+  }
+
+  &[aria-current='page'] {
+    color: var(--comp-tab-colour-text-primary-selected);
+    border-bottom-color: var(--comp-tab-colour-border-primary-selected);
+  }
+`
+
+export const ElPrimaryTabLabel = styled.span`
+  white-space: nowrap;
+  ${font('base', 'medium')}
+
+  color: inherit;
+`

--- a/src/components/primary-tabs/tab/tab.stories.tsx
+++ b/src/components/primary-tabs/tab/tab.stories.tsx
@@ -1,0 +1,31 @@
+import { PrimaryTab } from './tab'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/PrimaryTabs/Tab',
+  component: PrimaryTab,
+} satisfies Meta<typeof PrimaryTab>
+
+export default meta
+
+type Story = StoryObj<typeof PrimaryTab>
+
+export const Example: Story = {
+  args: {
+    'aria-current': false,
+    children: 'Primary tab',
+    href: globalThis.top?.location.href!,
+  },
+}
+
+/**
+ * When the tab represents the current page, `aria-current="page"` should be supplied to communicate to
+ * visual and accessible users that the tab is currently "selected". This shows the blue bottom border.
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    'aria-current': 'page',
+  },
+}

--- a/src/components/primary-tabs/tab/tab.tsx
+++ b/src/components/primary-tabs/tab/tab.tsx
@@ -1,0 +1,29 @@
+import { ElPrimaryTab, ElPrimaryTabLabel } from './styles'
+
+import type { AnchorHTMLAttributes } from 'react'
+
+interface PrimaryTabProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /**
+   * Whether the tab item represents the current page/section.
+   */
+  'aria-current': 'page' | false
+  /**
+   * The URL to navigate to when this tab is activated.
+   */
+  href: string
+}
+
+/**
+ * A primary navigation tab. It always renders as a link because changing tabs is best modelled as navigation between
+ * pages in the product. Will typically be used via `PrimaryTabs.Item`.
+ *
+ * The selected state is determined by the `aria-current` prop, which should be set to 'page' when this
+ * tab represents the current page.
+ */
+export function PrimaryTab({ 'aria-current': ariaCurrent, children, ...rest }: PrimaryTabProps) {
+  return (
+    <ElPrimaryTab {...rest} aria-current={ariaCurrent}>
+      <ElPrimaryTabLabel>{children}</ElPrimaryTabLabel>
+    </ElPrimaryTab>
+  )
+}

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -22,6 +22,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore:** Deprecate v4 components and put them in `src/deprecated`.
 - **feat:** Add new `URLSearchParams` utilities. See [URLSearchParams](?path=/docs/utils-urlsearchparams--docs) for details.
 - **feat:** Add new package entry points for components and deprecated components: `@reapit/elements/core/*` and `@reapit/elements/deprecated/*` respectively.
+- **feat:** Add new `PrimaryTabs` component. See [PrimaryTabs](?path=/docs/components-primarytabs--docs) for details.
 
 ### **5.0.0-beta.37 - 09/07/25**
 


### PR DESCRIPTION
### Context

- The existing Tabs component is already deprecated. It is named `Tabs`.
- There are three new tab components in the Design System: PrimaryTabs, SecondaryTabs and FolderTabs. We will deliver new v5 components for each of these, rather than a single Tabs component with variants, because there is considerable visual difference between them.
- This means we do not need to rename the deprecated Tabs component to DeprecatedTabs, as we do not need its current name for the new components.

### This PR

- Adds a new `PrimaryTabs` component.

<img width="924" height="723" alt="Screenshot 2025-07-17 at 7 16 38 am" src="https://github.com/user-attachments/assets/a270f571-8ac9-4a10-9295-78640b8bf9c7" />
<img width="922" height="496" alt="Screenshot 2025-07-17 at 7 16 43 am" src="https://github.com/user-attachments/assets/63ab8a7c-b1ab-49fe-be26-9fb9c5df3c86" />
