### PR TITLE
feat: Add `SplitButtonMenuButton` component

### DIFF
--- a/src/components/split-button/menu-button/__tests__/menu-button.test.tsx
+++ b/src/components/split-button/menu-button/__tests__/menu-button.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import { SplitButtonMenuButton } from '../menu-button'
+import { SplitButtonContext } from '../../context'
+
+import type { ReactNode } from 'react'
+
+vi.mock('#src/icons/chevron-down', () => ({
+  ChevronDownIcon: () => <span data-testid="chevron-down-icon" />,
+}))
+vi.mock('#src/icons/chevron-up', () => ({
+  ChevronUpIcon: () => <span data-testid="chevron-up-icon" />,
+}))
+
+test('renders a button element', () => {
+  render(<SplitButtonMenuButton aria-label="Open menu" />, { wrapper })
+  expect(screen.getByRole('button', { name: 'Open menu' })).toBeVisible()
+})
+
+test('forwards the `aria-expanded` prop', () => {
+  render(<SplitButtonMenuButton aria-label="Expand" aria-expanded={true} />, { wrapper })
+  expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+})
+
+test('forwards additional props to the underlying button', () => {
+  render(<SplitButtonMenuButton aria-label="Test" data-testid="menu-btn" />, { wrapper })
+  expect(screen.getByTestId('menu-btn')).toBeVisible()
+})
+
+test('shows `ChevronDownIcon` when aria-expanded is false or not set', () => {
+  render(<SplitButtonMenuButton aria-label="Menu" />, { wrapper })
+  expect(screen.getByTestId('chevron-down-icon')).toBeVisible()
+})
+
+test('shows `ChevronUpIcon` when aria-expanded is true', () => {
+  render(<SplitButtonMenuButton aria-label="Menu" aria-expanded={true} />, { wrapper })
+  expect(screen.getByTestId('chevron-up-icon')).toBeVisible()
+})
+
+test('applies size and variant from `SplitButtonContext`', () => {
+  render(<SplitButtonMenuButton aria-label="Menu" />, { wrapper })
+
+  const button = screen.getByRole('button')
+  expect(button).toHaveAttribute('data-size', 'medium')
+  expect(button).toHaveAttribute('data-variant', 'primary')
+})
+
+test('applies custom `className`', () => {
+  render(<SplitButtonMenuButton aria-label="Menu" className="custom-class" />, { wrapper })
+  expect(screen.getByRole('button')).toHaveClass('custom-class')
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SplitButtonContext.Provider value={{ size: 'medium', variant: 'primary' }}>{children}</SplitButtonContext.Provider>
+  )
+}

--- a/src/components/split-button/menu-button/index.ts
+++ b/src/components/split-button/menu-button/index.ts
@@ -1,0 +1,2 @@
+export * from './menu-button'
+export * from './styles'

--- a/src/components/split-button/menu-button/menu-button.stories.tsx
+++ b/src/components/split-button/menu-button/menu-button.stories.tsx
@@ -1,0 +1,101 @@
+import { SplitButtonMenuButton } from './menu-button'
+import { SplitButtonContext } from '../context'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/SplitButton/MenuButton',
+  component: SplitButtonMenuButton,
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+    },
+    'aria-disabled': {
+      control: 'boolean',
+    },
+    'aria-expanded': {
+      control: 'boolean',
+    },
+    className: {
+      control: 'text',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <SplitButtonContext.Provider value={{ size: 'medium', variant: 'primary' }}>
+        <Story />
+      </SplitButtonContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof SplitButtonMenuButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    'aria-disabled': false,
+    'aria-expanded': false,
+    'aria-label': 'More actions',
+    disabled: false,
+  },
+}
+
+/**
+ * The MenuButton respects the SplitButton's variant: `primary` or `secondary`.
+ */
+export const Variants: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)' }}>
+        <SplitButtonContext.Provider value={{ size: 'medium', variant: 'primary' }}>
+          <Story />
+        </SplitButtonContext.Provider>
+        <SplitButtonContext.Provider value={{ size: 'medium', variant: 'secondary' }}>
+          <Story />
+        </SplitButtonContext.Provider>
+      </div>
+    ),
+  ],
+}
+
+/**
+ * The MenuButton also respects the SplitButton's size: `small`, `medium`, and `large`.
+ */
+export const Sizes: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)' }}>
+        <SplitButtonContext.Provider value={{ size: 'small', variant: 'primary' }}>
+          <Story />
+        </SplitButtonContext.Provider>
+        <SplitButtonContext.Provider value={{ size: 'medium', variant: 'primary' }}>
+          <Story />
+        </SplitButtonContext.Provider>
+        <SplitButtonContext.Provider value={{ size: 'large', variant: 'primary' }}>
+          <Story />
+        </SplitButtonContext.Provider>
+      </div>
+    ),
+  ],
+}
+
+/**
+ * The MenuButton can be disabled using either the `disabled` or `aria-disabled` prop. When disabled, the button is
+ * not interactive. When `aria-disabled` is set, the button remains focusable but is styled as disabled.
+ *
+ * Generally, disabling the menu button should be avoided, as it decreases the discoverability of the secondary
+ * actions in the menu.
+ */
+export const Disabled: Story = {
+  args: {
+    ...Example.args,
+    disabled: true,
+  },
+}

--- a/src/components/split-button/menu-button/menu-button.tsx
+++ b/src/components/split-button/menu-button/menu-button.tsx
@@ -1,0 +1,51 @@
+import { Button } from '#src/components/button'
+import { ChevronDownIcon } from '#src/icons/chevron-down'
+import { ChevronUpIcon } from '#src/icons/chevron-up'
+import { cx } from '@linaria/core'
+import { elSplitButtonMenuButton } from './styles'
+import { useSplitButtonContext } from '../context'
+
+import type { ButtonHTMLAttributes } from 'react'
+
+interface SplitButtonMenuButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * Whether the action is disabled. This can be used to make the action appear disabled to users, but still be
+   * focusable. ARIA disabled actions, whether they are button or anchor DOM elements, will ignore click events.
+   * Using `aria-disabled` is preferred when the action should still be focusable while it's disabled; for example,
+   * to allow a tooltip to be displayed that explains why the action is disabled.
+   */
+  'aria-disabled'?: boolean | 'true' | 'false'
+  /** Whether the menu this button controls is expanded */
+  'aria-expanded'?: boolean | 'true' | 'false'
+  /** The button's label */
+  'aria-label': string
+  /**
+   * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will not be
+   * focusable or interactive.
+   */
+  disabled?: boolean
+  /** Whether the menu button is in a busy state */
+  isBusy?: boolean
+}
+
+/**
+ * The `SplitButton.MenuButton` component is used to represent the menu button in a `SplitButton`. It will typically
+ * be used as the trigger for a `Menu`.
+ */
+export function SplitButtonMenuButton({
+  'aria-expanded': ariaExpanded,
+  className,
+  ...rest
+}: SplitButtonMenuButtonProps) {
+  const { size, variant } = useSplitButtonContext()
+  return (
+    <Button
+      {...rest}
+      aria-expanded={ariaExpanded}
+      className={cx(elSplitButtonMenuButton, className)}
+      iconLeft={ariaExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+      size={size}
+      variant={variant}
+    />
+  )
+}

--- a/src/components/split-button/menu-button/styles.ts
+++ b/src/components/split-button/menu-button/styles.ts
@@ -1,0 +1,61 @@
+import { css } from '@linaria/core'
+
+// NOTE: This class is designed to be used in conjunction with the ElButton class.
+export const elSplitButtonMenuButton = css`
+  /* NOTE: This is used to help colour the special dividing border rendered in the ::before pseudo-element. */
+  --__divider-colour: transparent;
+
+  /* NOTE: This is used to help size the ::before pseudo-element. */
+  --__block-inset: calc(var(--size-half) + var(--size-1));
+
+  position: relative;
+  border-end-start-radius: 0;
+  border-start-start-radius: 0;
+
+  /* NOTE: This pseudo-element is used to render the dividing border between the action and menu buttons. */
+  &::before {
+    content: '';
+    position: absolute;
+    background-color: transparent;
+    top: var(--__block-inset);
+    bottom: var(--__block-inset);
+    left: 0;
+    border-inline-start: var(--comp-button-border-width-default) solid var(--__divider-colour);
+    pointer-events: none;
+  }
+
+  &[data-variant='primary'] {
+    --__divider-colour: var(--comp-button-colour-border-primary-default);
+  }
+
+  &[data-variant='secondary'] {
+    --__divider-colour: var(--comp-button-colour-border-secondary-default);
+
+    /* NOTE: We need to remove the border between the action and menu buttons, as we now facilitate it via the
+     * ::before pseudo-element. */
+    border-inline-start: none;
+
+    &:hover {
+      --__divider-colour: var(--comp-button-colour-border-secondary-hover);
+    }
+
+    &:hover::before {
+      --__block-inset: 0;
+    }
+  }
+
+  &:disabled,
+  &[aria-disabled='true'] {
+    --__divider-colour: var(--comp-button-colour-border-secondary-disabled);
+
+    &:hover::before {
+      --__block-inset: unset;
+    }
+  }
+
+  /* NOTE: We only want to elevate the action button when it is not disabled. If the action is aria-disabled, we will
+  * still elevate it, as it is focusable. */
+  &:focus-visible:not(:disabled) {
+    z-index: 1;
+  }
+`


### PR DESCRIPTION
### Context

- We recently refactored our `Button` component. This resulted in the existing Button being deprecated and renamed to `DeprecatedButton`.
- This impacted our existing `SplitButton` component, which is built on top of the old, now deprecated Button.
- We need to refactor `SplitButton` to work with the new `Button` component. We will do this over the following stages:
  - #616 
  - #617 
  - **Part 3: Implement new `SplitButtonMenuButton` (this PR)**
  - Part 4: Implement new `SplitButton`

### This PR

- Adds new `SplitButtonMenuButton` component

<img width="821" height="739" alt="Screenshot 2025-07-17 at 9 59 26 pm" src="https://github.com/user-attachments/assets/385ee7a1-8e1c-4e25-a065-66ae8554900a" />
<img width="823" height="577" alt="Screenshot 2025-07-17 at 9 59 32 pm" src="https://github.com/user-attachments/assets/9e4f64b9-a0d3-4ef8-876a-3bd34e45516f" />
<img width="817" height="235" alt="Screenshot 2025-07-17 at 9 59 36 pm" src="https://github.com/user-attachments/assets/dfcc5a59-e715-4e27-a9a9-ae8126b7ec4a" />
