### PR TITLE
feat: Add `SplitButton` component

### DIFF
--- a/src/components/split-button/__tests__/split-button-menu.test.tsx
+++ b/src/components/split-button/__tests__/split-button-menu.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Menu } from '#src/components/menu'
+import { SplitButtonContext } from '../context'
+import { SplitButtonMenu } from '../split-button-menu'
+
+import type { ReactNode } from 'react'
+
+test('renders as a button', () => {
+  render(
+    <SplitButtonMenu aria-label="More">
+      <Menu.Item label="Item 1" />
+      <Menu.Item label="Item 2" />
+      <Menu.Item label="Item 3" />
+    </SplitButtonMenu>,
+    { wrapper },
+  )
+
+  const button = screen.getByRole('button', { name: 'More' })
+  expect(button).toBeVisible()
+})
+
+test('forwards props to the underlying button', () => {
+  render(
+    <SplitButtonMenu data-testid="nav-item" aria-label="More">
+      Fake child
+    </SplitButtonMenu>,
+    { wrapper },
+  )
+
+  expect(screen.getByTestId('nav-item')).toBeInstanceOf(HTMLButtonElement)
+})
+
+test('opens the menu when clicked', () => {
+  render(
+    <SplitButtonMenu aria-label="More">
+      <Menu.Item label="Item 1" />
+      <Menu.Item label="Item 2" />
+      <Menu.Item label="Item 3" />
+    </SplitButtonMenu>,
+    { wrapper },
+  )
+
+  const button = screen.getByRole('button')
+
+  fireEvent.click(button)
+
+  expect(button).toHaveAttribute('aria-expanded', 'true')
+  expect(screen.getByText('Item 1')).toBeVisible()
+  expect(screen.getByText('Item 2')).toBeVisible()
+  expect(screen.getByText('Item 3')).toBeVisible()
+})
+
+interface WrapperProps {
+  children: ReactNode
+}
+
+function wrapper({ children }: WrapperProps) {
+  return (
+    <SplitButtonContext.Provider value={{ size: 'medium', variant: 'primary' }}>{children}</SplitButtonContext.Provider>
+  )
+}

--- a/src/components/split-button/__tests__/split-button.test.tsx
+++ b/src/components/split-button/__tests__/split-button.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { SplitButton } from '../split-button'
+import { useSplitButtonContext } from '../context'
+
+test('renders a div element', () => {
+  const { container } = render(
+    <SplitButton action={<span>Action</span>} menu={<span>Menu</span>} size="medium" variant="primary" />,
+  )
+  expect(container.firstChild).toBeInstanceOf(HTMLDivElement)
+})
+
+test('renders the `action` and `menu` content', () => {
+  render(<SplitButton action={<span>Action</span>} menu={<span>Menu</span>} size="medium" variant="primary" />)
+  expect(screen.getByText('Action')).toBeVisible()
+  expect(screen.getByText('Menu')).toBeVisible()
+})
+
+test('forwards additional props to the container element', () => {
+  render(<SplitButton action="Action" data-testid="split-button" menu="Menu" size="small" variant="primary" />)
+  expect(screen.getByTestId('split-button')).toBeVisible()
+})
+
+test('provides `size` and `variant` to the action and menu content via `SplitButtonContext`', () => {
+  let size: string | undefined, variant: string | undefined
+
+  function TestConsumer() {
+    const ctx = useSplitButtonContext()
+    size = ctx.size
+    variant = ctx.variant
+    return null
+  }
+
+  render(<SplitButton action={<TestConsumer />} menu={<TestConsumer />} size="small" variant="primary" />)
+
+  expect(size).toBe('small')
+  expect(variant).toBe('primary')
+})

--- a/src/components/split-button/index.ts
+++ b/src/components/split-button/index.ts
@@ -1,0 +1,5 @@
+export * from './action'
+export * from './context'
+export * from './menu-button'
+export * from './split-button'
+export * from './styles'

--- a/src/components/split-button/menu-button/menu-button.tsx
+++ b/src/components/split-button/menu-button/menu-button.tsx
@@ -30,7 +30,7 @@ interface SplitButtonMenuButtonProps extends Omit<ButtonHTMLAttributes<HTMLButto
 
 /**
  * The `SplitButton.MenuButton` component is used to represent the menu button in a `SplitButton`. It will typically
- * be used as the trigger for a `Menu`.
+ * be used via `SplitButton.Menu`, which includes the `Menu` component baked-in.
  */
 export function SplitButtonMenuButton({
   'aria-expanded': ariaExpanded,

--- a/src/components/split-button/split-button-menu.tsx
+++ b/src/components/split-button/split-button-menu.tsx
@@ -1,0 +1,23 @@
+import { Menu } from '#src/components/menu'
+import { SplitButtonMenuButton } from './menu-button'
+
+import type { ComponentProps, ReactNode } from 'react'
+
+interface SplitButtonMenuProps extends ComponentProps<typeof SplitButtonMenuButton> {
+  /** The menu items to display in the menu */
+  children: ReactNode
+}
+
+/**
+ * The menu for a `SplitButton`.
+ */
+export function SplitButtonMenu({ children, ...rest }: SplitButtonMenuProps) {
+  return (
+    <Menu data-alignment="right">
+      <Menu.Trigger>{({ getTriggerProps }) => <SplitButtonMenuButton {...getTriggerProps(rest)} />}</Menu.Trigger>
+      <Menu.Popover>
+        <Menu.List>{children}</Menu.List>
+      </Menu.Popover>
+    </Menu>
+  )
+}

--- a/src/components/split-button/split-button.stories.tsx
+++ b/src/components/split-button/split-button.stories.tsx
@@ -1,0 +1,166 @@
+import { Menu } from '../menu'
+import { SplitButton } from './split-button'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/SplitButton',
+  component: SplitButton,
+  argTypes: {
+    action: {
+      control: 'radio',
+      options: ['Default', 'Disabled', 'Disabled (aria-disabled)'],
+      mapping: {
+        Default: <SplitButton.Action>Button</SplitButton.Action>,
+        Disabled: <SplitButton.Action disabled>Button</SplitButton.Action>,
+        'Disabled (aria-disabled)': <SplitButton.Action aria-disabled="true">Button</SplitButton.Action>,
+      },
+    },
+    menu: {
+      control: 'radio',
+      options: ['Default', 'Disabled', 'Disabled (aria-disabled)'],
+      mapping: {
+        Default: (
+          <SplitButton.Menu aria-label="More actions">
+            <Menu.Group>
+              <Menu.Item label="Action 1" />
+              <Menu.Item label="Action 2" />
+            </Menu.Group>
+          </SplitButton.Menu>
+        ),
+        Disabled: (
+          <SplitButton.Menu aria-label="More actions" disabled>
+            {/* NOTE: We don't bother defining any items because the menu is disabled. */}
+            {null}
+          </SplitButton.Menu>
+        ),
+        'Disabled (aria-disabled)': (
+          <SplitButton.Menu aria-label="More actions" aria-disabled="true">
+            {/* NOTE: We don't bother defining any items because the menu is disabled. */}
+            {null}
+          </SplitButton.Menu>
+        ),
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SplitButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    action: 'Default',
+    menu: 'Default',
+    size: 'medium',
+    variant: 'primary',
+  },
+}
+
+/**
+ * The `SplitButton` component supports the following button variants: `primary` and `secondary`.
+ */
+export const Variants: Story = {
+  args: {
+    ...Example.args,
+    size: 'medium',
+    variant: 'primary',
+  },
+  argTypes: {
+    variant: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <>
+      <SplitButton {...args} />
+      <SplitButton {...args} variant="secondary" />
+    </>
+  ),
+}
+
+/**
+ * The `SplitButton` component supports the following button sizes: `small`, `medium`, and `large`.
+ */
+export const Sizes: Story = {
+  args: {
+    ...Example.args,
+    size: 'medium',
+    variant: 'primary',
+  },
+  argTypes: {
+    size: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <>
+      <SplitButton {...args} size="small" />
+      <SplitButton {...args} size="medium" />
+      <SplitButton {...args} size="large" />
+    </>
+  ),
+}
+
+/**
+ * While the individual buttons that comprise the `SplitButton` can be disabled, try to avoid disabling the menu
+ * button, as doing so will decrease the discoverability of the secondary actions in the menu.
+ */
+export const Disabled: Story = {
+  args: {
+    ...Example.args,
+    action: 'Disabled',
+    menu: 'Disabled',
+    variant: 'secondary',
+  },
+  argTypes: {
+    action: {
+      control: false,
+    },
+    menu: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'grid',
+          gridAutoFlow: 'row',
+          gridTemplateColumns: 'repeat(3, min-content)',
+          gap: 'var(--spacing-6)',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <>
+      <SplitButton {...args} />
+      <SplitButton {...args} action={meta.argTypes.action.mapping.Default} />
+      <SplitButton {...args} menu={meta.argTypes.menu.mapping.Default} />
+    </>
+  ),
+}

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -1,0 +1,37 @@
+import { ElSplitButton } from './styles'
+import { SplitButtonAction, SplitButtonAnchorAction } from './action'
+import { SplitButtonContext } from './context'
+import { SplitButtonMenu } from './split-button-menu'
+import { SplitButtonMenuButton } from './menu-button'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface SplitButtonProps extends HTMLAttributes<HTMLDivElement> {
+  /** The main action for the `SplitButton` */
+  action: ReactNode
+  /** The menu to display in the split button */
+  menu: ReactNode
+  /** The size of the button */
+  size: 'small' | 'medium' | 'large'
+  /** The visual variant of the button */
+  variant: 'primary' | 'secondary'
+}
+
+/**
+ * A split button lets users perform an action or choose from a small group of other related actions.
+ */
+export function SplitButton({ action, menu, size, variant, ...rest }: SplitButtonProps) {
+  return (
+    <ElSplitButton {...rest}>
+      <SplitButtonContext.Provider value={{ size, variant }}>
+        {action}
+        {menu}
+      </SplitButtonContext.Provider>
+    </ElSplitButton>
+  )
+}
+
+SplitButton.Action = SplitButtonAction
+SplitButton.AnchorAction = SplitButtonAnchorAction
+SplitButton.Menu = SplitButtonMenu
+SplitButton.MenuButton = SplitButtonMenuButton

--- a/src/components/split-button/styles.ts
+++ b/src/components/split-button/styles.ts
@@ -1,0 +1,8 @@
+import { styled } from '@linaria/react'
+
+export const ElSplitButton = styled.div`
+  display: inline-flex;
+  align-items: start;
+  height: min-content;
+  width: min-content;
+`

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -25,6 +25,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add new `PrimaryTabs` component. See [PrimaryTabs](?path=/docs/components-primarytabs--docs) for details.
 - **feat:** Add new `SecondaryTabs` component. See [SecondaryTabs](?path=/docs/components-secondarytabs--docs) for details.
 - **chore!:** Deprecate `SplitButton` component. It is still available, but is now called `DeprecatedSplitButton`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from `@reapit/elements/deprecated/split-button`, as well as the root entry point, `@reapit/elements`.
+- **feat:** Add new `SplitButton` component. See [SplitButton](?path=/docs/components-splitbutton--docs) for details.
 
 ### **5.0.0-beta.37 - 09/07/25**
 


### PR DESCRIPTION
### Context

- We recently refactored our `Button` component. This resulted in the existing Button being deprecated and renamed to `DeprecatedButton`.
- This impacted our existing `SplitButton` component, which is built on top of the old, now deprecated Button.
- We need to refactor `SplitButton` to work with the new `Button` component. We will do this over the following stages:
  - #616 
  - #617 
  - #618 
  - **Part 4: Implement new `SplitButton` (this PR)**

### This PR

- Adds new `SplitButton` component

<img width="816" height="676" alt="Screenshot 2025-07-17 at 10 26 23 pm" src="https://github.com/user-attachments/assets/a7cd8f4c-aab3-48f0-be9d-50f91358eae1" />
<img width="816" height="571" alt="Screenshot 2025-07-17 at 10 26 32 pm" src="https://github.com/user-attachments/assets/13004f17-5b2c-4f63-80ac-559b44021421" />
<img width="815" height="589" alt="Screenshot 2025-07-17 at 10 26 37 pm" src="https://github.com/user-attachments/assets/3551fa67-7668-45ad-ba58-cbdf9284f183" />
