### PR TITLE
feat: support `PrimaryTabs` in `Drawer`

### DIFF
--- a/src/components/drawer/__story__/useDrawerBreakpointDecorator.tsx
+++ b/src/components/drawer/__story__/useDrawerBreakpointDecorator.tsx
@@ -51,7 +51,7 @@ export function Breakpoint({ breakpoint, children }: BreakpointProps) {
         containerType: 'size',
         display: 'grid',
         gridTemplateAreas: '"header" "body" "footer"',
-        gridTemplateColumns: '1fr',
+        gridTemplateColumns: '100%',
         gridTemplateRows: 'auto 1fr auto',
         height: '400px',
         width: breakpoint === 'XS-SM' ? DRAWER_WIDTH_XS_SM : DRAWER_WIDTH_MD_2XL,

--- a/src/components/drawer/drawer.stories.tsx
+++ b/src/components/drawer/drawer.stories.tsx
@@ -1,7 +1,8 @@
-import { DeprecatedButton } from '../../deprecated/button'
+import { Button } from '#src/components/button'
 import { Breakpoint, useDrawerBreakpointDecorator } from './__story__/useDrawerBreakpointDecorator'
 import { Drawer } from './drawer'
 import { Pattern } from './__story__/Pattern'
+import { PrimaryTabs } from '#src/components/primary-tabs'
 import { SupplementaryInfo } from '../supplementary-info'
 import { useArgs } from 'storybook/preview-api'
 import { useDrawerContextDecorator } from './__story__/useDrawerContextDecorator'
@@ -14,12 +15,13 @@ const meta = {
   argTypes: {
     children: {
       control: 'radio',
+      options: ['Simple', 'Tabbed', 'With Footer', 'Empty'],
       mapping: {
         Simple: <ExampleSimpleLayout />,
+        Tabbed: <ExampleSimpleLayout withTabs />,
         'With Footer': <ExampleFooterLayout />,
         Empty: null,
       },
-      options: ['Simple', 'With Footer', 'Empty'],
     },
   },
 } satisfies Meta<typeof Drawer>
@@ -93,10 +95,10 @@ export const Breakpoints: StoryObj = {
   render: () => (
     <>
       <Breakpoint breakpoint="XS-SM">
-        <ExampleSimpleLayout />
+        <ExampleSimpleLayout withTabs />
       </Breakpoint>
       <Breakpoint breakpoint="MD-2XL">
-        <ExampleSimpleLayout />
+        <ExampleSimpleLayout withTabs />
       </Breakpoint>
 
       <Breakpoint breakpoint="XS-SM">
@@ -114,7 +116,9 @@ export const Breakpoints: StoryObj = {
   },
 }
 
-function ExampleSimpleLayout() {
+function ExampleSimpleLayout({ withTabs }: { withTabs?: boolean }) {
+  const href = globalThis.top?.location.href!
+
   return (
     <>
       <Drawer.Header
@@ -125,6 +129,33 @@ function ExampleSimpleLayout() {
             <SupplementaryInfo.Item colour="secondary">Optional info 1</SupplementaryInfo.Item>
             <SupplementaryInfo.Item colour="secondary">Optional info 2</SupplementaryInfo.Item>
           </SupplementaryInfo>
+        }
+        tabs={
+          withTabs ? (
+            <PrimaryTabs overflow="scroll">
+              <PrimaryTabs.Item aria-current="page" href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+              <PrimaryTabs.Item aria-current={false} href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+              <PrimaryTabs.Item aria-current={false} href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+              <PrimaryTabs.Item aria-current={false} href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+              <PrimaryTabs.Item aria-current={false} href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+              <PrimaryTabs.Item aria-current={false} href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+              <PrimaryTabs.Item aria-current={false} href={href}>
+                Tab item
+              </PrimaryTabs.Item>
+            </PrimaryTabs>
+          ) : null
         }
       >
         Drawer title
@@ -156,11 +187,13 @@ function ExampleFooterLayout() {
       </Drawer.Body>
       <Drawer.Footer>
         <form style={{ display: 'contents' }}>
-          <DeprecatedButton formMethod="dialog" variant="secondary">
+          <Button formMethod="dialog" size="medium" variant="secondary">
             Cancel
-          </DeprecatedButton>
+          </Button>
         </form>
-        <DeprecatedButton variant="primary">Submit</DeprecatedButton>
+        <Button size="medium" variant="primary">
+          Submit
+        </Button>
       </Drawer.Footer>
     </>
   )

--- a/src/components/drawer/footer/footer.stories.tsx
+++ b/src/components/drawer/footer/footer.stories.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedButton } from '../../../deprecated/button'
+import { Button } from '#src/components/button'
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
 import { DrawerFooter } from './footer'
 import { Pattern } from '../__story__/Pattern'
@@ -40,11 +40,13 @@ export const Example: Story = {
          * There are other ways to achieve this, but this is one of the simplest. We may chose, in future, to
          * provide a Drawer-specific Cancel button similar to the header's Close button.*/}
         <form style={{ display: 'contents' }}>
-          <DeprecatedButton formMethod="dialog" type="submit">
+          <Button formMethod="dialog" size="medium" type="submit" variant="secondary">
             Cancel
-          </DeprecatedButton>
+          </Button>
         </form>
-        <DeprecatedButton variant="primary">Add</DeprecatedButton>
+        <Button size="medium" variant="primary">
+          Add
+        </Button>
       </>
     ),
   },

--- a/src/components/drawer/header/close-button.tsx
+++ b/src/components/drawer/header/close-button.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedButton } from '../../../deprecated/button'
+import { Button } from '#src/components/button'
 import { CloseIcon } from '#src/icons/close'
 
 /**
@@ -9,11 +9,11 @@ import { CloseIcon } from '#src/icons/close'
 export function DrawerHeaderCloseButton() {
   return (
     <form>
-      <DeprecatedButton
+      <Button
         autoFocus
         aria-label="Close"
         formMethod="dialog"
-        iconLeft={<CloseIcon size="lg" aria-hidden />}
+        iconLeft={<CloseIcon aria-hidden />}
         size="large"
         type="submit"
         variant="tertiary"

--- a/src/components/drawer/header/header.stories.tsx
+++ b/src/components/drawer/header/header.stories.tsx
@@ -1,8 +1,11 @@
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
 import { DrawerHeader } from './header'
+import { PrimaryTabs } from '#src/components/primary-tabs'
 import { useDrawerContextDecorator } from '../__story__/useDrawerContextDecorator'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
 
 const meta = {
   title: 'Components/Drawer/Header',
@@ -28,7 +31,31 @@ const meta = {
     tabs: {
       control: 'radio',
       mapping: {
-        Tabs: 'TODO',
+        Tabs: (
+          <PrimaryTabs overflow="scroll">
+            <PrimaryTabs.Item aria-current="page" href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+            <PrimaryTabs.Item aria-current={false} href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+            <PrimaryTabs.Item aria-current={false} href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+            <PrimaryTabs.Item aria-current={false} href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+            <PrimaryTabs.Item aria-current={false} href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+            <PrimaryTabs.Item aria-current={false} href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+            <PrimaryTabs.Item aria-current={false} href={href}>
+              Tab item
+            </PrimaryTabs.Item>
+          </PrimaryTabs>
+        ),
         None: null,
       },
       options: ['Tabs', 'None'],
@@ -55,19 +82,36 @@ export const Example: Story = {
 }
 
 /**
+ * Tabs can also be used within the Drawer's header. Typically, these will be
+ * [PrimaryTabs](?path=/docs/components-primarytabs--docs). While the number of tabs should generally be kept low,
+ * if there are too many to fit within the drawer's header, `overflow="scroll"` can be used with the `PrimaryTabs`
+ * component to allow them to scroll.
+ */
+export const Tabs: Story = {
+  args: {
+    ...Example.args,
+    tabs: 'Tabs',
+  },
+}
+
+/**
  * Like the body and footer, the drawer header will adjust it's layout based on the inline-size of its parent
  * container. This story demonstrates the layout changes within containers that mimic the drawer's width within
  * different breakpoints.
  */
-export const DynamicLayout: StoryObj = {
+export const DynamicLayout: Story = {
+  args: {
+    ...Example.args,
+    tabs: 'Tabs',
+  },
   decorators: [useDrawerBreakpointDecorator()],
-  render: () => (
+  render: (args) => (
     <>
       <Breakpoint breakpoint="XS-SM">
-        <DrawerHeader {...Example.args} action={<DrawerHeader.CloseButton />} />
+        <DrawerHeader {...args} action={<DrawerHeader.CloseButton />} />
       </Breakpoint>
       <Breakpoint breakpoint="MD-2XL">
-        <DrawerHeader {...Example.args} action={<DrawerHeader.CloseButton />} />
+        <DrawerHeader {...args} action={<DrawerHeader.CloseButton />} />
       </Breakpoint>
     </>
   ),

--- a/src/components/drawer/header/styles.ts
+++ b/src/components/drawer/header/styles.ts
@@ -1,22 +1,20 @@
-import { font } from '../../text'
 import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { font } from '../../text'
 import { styled } from '@linaria/react'
 
 export const ElDrawerHeader = styled.div`
   background: var(--fill-white);
-  border-bottom: var(--border-default) solid var(--outline-default);
+
+  /* NOTE: We use a "private" CSS variable to couple the negative margin of the tabs container to this border width */
+  --__drawer-header-border-width: var(--border-default);
+
+  border-bottom: var(--__drawer-header-border-width) solid var(--outline-default);
+
   display: grid;
   grid-area: header;
   grid-template:
     'main' minmax(0, auto)
-    'tabs' minmax(0, auto) / 1fr;
-
-  /* XS-SM container size */
-  padding-inline: var(--spacing-5) var(--spacing-3);
-
-  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
-    padding-inline: var(--spacing-8) var(--spacing-5);
-  }
+    'tabs' minmax(0, auto) / 100%;
 `
 
 export const ElDrawerHeaderContentContainer = styled.div`
@@ -30,14 +28,28 @@ export const ElDrawerHeaderContentContainer = styled.div`
 
   /* XS-SM container size */
   padding-block: var(--spacing-3);
+  padding-inline: var(--spacing-5) var(--spacing-3);
 
   @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
     padding-block: var(--spacing-5);
+    padding-inline: var(--spacing-8) var(--spacing-5);
   }
 `
 
 export const ElDrawerHeaderTabsContainer = styled.div`
   grid-area: tabs;
+
+  width: 100%;
+
+  /* NOTE: This negative margin is used to make the tabs border overlap the drawer header's border. */
+  margin-block-end: calc(0px - var(--__drawer-header-border-width));
+
+  /* XS-SM container size */
+  padding-inline-start: var(--spacing-5);
+
+  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding-inline-start: var(--spacing-8);
+  }
 `
 
 export const ElDrawerHeaderAction = styled.div`

--- a/src/components/drawer/styles.ts
+++ b/src/components/drawer/styles.ts
@@ -47,7 +47,7 @@ export const ElDrawer = styled.dialog`
     grid-template:
       'header' auto
       'body' 1fr
-      'footer' auto / 1fr;
+      'footer' auto / 100%;
 
     transform: translateX(0);
 

--- a/src/components/primary-tabs/index.ts
+++ b/src/components/primary-tabs/index.ts
@@ -1,3 +1,4 @@
 export * from './primary-tabs'
 export * from './primary-tabs-item'
+export * from './styles'
 export * from './tab'

--- a/src/components/primary-tabs/styles.ts
+++ b/src/components/primary-tabs/styles.ts
@@ -1,10 +1,13 @@
 import { styled } from '@linaria/react'
 
-interface ElPrimaryTabsProps {
-  'data-overflow'?: 'scroll' | 'visible'
+export interface ElPrimaryTabsProps {
+  'data-overflow': 'scroll' | 'visible'
 }
 
 export const ElPrimaryTabs = styled.nav<ElPrimaryTabsProps>`
+  border-bottom: var(--border-width-default) solid var(--comp-tab-colour-border-group);
+  width: 100%;
+
   &,
   &[data-overflow='visible'] {
     overflow-x: visible;
@@ -26,20 +29,6 @@ export const ElPrimaryTabsList = styled.menu`
 
   margin: 0;
   padding: 0;
-
-  /* NOTE: We use a pseudo-element to draw the bottom border of the menu element, as this
-   * provides the simplest and most reliable way to draw a border that can be overlapped by
-   * the list items' borders. */
-  &::after {
-    content: '';
-    position: absolute;
-    inset-inline: 0;
-    inset-block-end: 0;
-    width: 100%;
-    height: var(--border-width-default);
-    background-color: var(--comp-tab-colour-border-group);
-    z-index: -1;
-  }
 `
 
 export const ElPrimaryTabsListItem = styled.li`

--- a/src/components/secondary-tabs/index.ts
+++ b/src/components/secondary-tabs/index.ts
@@ -1,3 +1,4 @@
 export * from './secondary-tabs'
 export * from './secondary-tabs-item'
+export * from './styles'
 export * from './tab'

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -26,6 +26,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add new `SecondaryTabs` component. See [SecondaryTabs](?path=/docs/components-secondarytabs--docs) for details.
 - **chore!:** Deprecate `SplitButton` component. It is still available, but is now called `DeprecatedSplitButton`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from `@reapit/elements/deprecated/split-button`, as well as the root entry point, `@reapit/elements`.
 - **feat:** Add new `SplitButton` component. See [SplitButton](?path=/docs/components-splitbutton--docs) for details.
+- **feat:** Support `PrimaryTabs` in `Drawer` component. See [Drawer.Header](?path=/docs/components-drawer-header--docs) for details.
 
 ### **5.0.0-beta.37 - 09/07/25**
 


### PR DESCRIPTION
### Context

- The use of tabs in drawers was not implemented when the new Drawer component was implemented
- With the recent introduction of the new PrimaryTabs component, it is possible to finish Drawer's support for tabs.

### This PR

- Updates `Drawer.Header` to support `PrimaryTabs`.
- Updates `PrimaryTabs` so the border's stack (this was an update from Design post implementation)
- Scouts the removal of `DeprecatedButton` from drawer components and docs.

<img width="1024" height="400" alt="Screenshot 2025-07-17 at 11 58 34 pm" src="https://github.com/user-attachments/assets/a3c5c6e5-3f47-4c29-9fd3-bc545fc70b30" />
