### PR TITLE
feat: Add new `MatchMedia`, `useMatchMedia` and other breakpoint helpers

### DIFF
--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,8 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.39 - ??/??/25**
 
-- TBC
+- **feat:** Add new `MatchMedia` and `useMatchMedia`. See [MatchMedia](?path=/docs/utils-matchmedia--docs) and [useMatchMedia](?path=/docs/utils-matchmedia-usematchmedia--docs) for details.
+- **feat:** Add new `isWidthAtOrAbove` and `isWidthBelow` utilities. See [breakpoints](?path=/docs/utils-breakpoints--docs) for details.
 
 ### **5.0.0-beta.38 - 18/07/25**
 

--- a/src/utils/breakpoints/__tests__/breakpoints.test.ts
+++ b/src/utils/breakpoints/__tests__/breakpoints.test.ts
@@ -1,0 +1,14 @@
+import { BreakpointMinimumDimensions } from '../breakpoints'
+
+test('breakpoints have not been changed', () => {
+  expect(BreakpointMinimumDimensions).toMatchInlineSnapshot(`
+    {
+      "2XL": "2560px",
+      "LG": "1440px",
+      "MD": "1024px",
+      "SM": "768px",
+      "XL": "1920px",
+      "XS": "0px",
+    }
+  `)
+})

--- a/src/utils/breakpoints/__tests__/conditions.test.ts
+++ b/src/utils/breakpoints/__tests__/conditions.test.ts
@@ -1,0 +1,14 @@
+import { BreakpointMinimumDimensions } from '../breakpoints'
+import { isWidthAtOrAbove, isWidthBelow } from '../conditions'
+
+import type { Breakpoint } from '../breakpoints'
+
+const breakpoints = Object.keys(BreakpointMinimumDimensions).sort() as Breakpoint[]
+
+test.each(breakpoints)('isWidthAtOrAbove("%s")', (bp) => {
+  expect(isWidthAtOrAbove(bp)).toBe(`(min-width: ${BreakpointMinimumDimensions[bp]})`)
+})
+
+test.each(breakpoints)('isWidthBelow("%s")', (bp) => {
+  expect(isWidthBelow(bp)).toBe(`(max-width: ${BreakpointMinimumDimensions[bp]})`)
+})

--- a/src/utils/breakpoints/breakpoints.ts
+++ b/src/utils/breakpoints/breakpoints.ts
@@ -1,0 +1,10 @@
+export type Breakpoint = 'XS' | 'SM' | 'MD' | 'LG' | 'XL' | '2XL'
+
+export const BreakpointMinimumDimensions = {
+  XS: '0px',
+  SM: '768px',
+  MD: '1024px',
+  LG: '1440px',
+  XL: '1920px',
+  '2XL': '2560px',
+} as const satisfies Record<Breakpoint, `${number}px`>

--- a/src/utils/breakpoints/conditions.ts
+++ b/src/utils/breakpoints/conditions.ts
@@ -1,0 +1,25 @@
+import { BreakpointMinimumDimensions } from './breakpoints'
+
+import type { Breakpoint } from './breakpoints'
+
+/**
+ * Returns a width condition that matches when the width is greater than or equal to the minimum width of the given
+ * breakpoint.
+ *
+ * @param breakpoint - The breakpoint to match against.
+ * @returns A condition that can be used with media or container queries.
+ */
+export function isWidthAtOrAbove(breakpoint: Breakpoint) {
+  return `(min-width: ${BreakpointMinimumDimensions[breakpoint]})`
+}
+
+/**
+ * Returns a width condition that matches when the width is strictly less than the minimum width of the given
+ * breakpoint.
+ *
+ * @param breakpoint - The breakpoint to match against.
+ * @returns A condition that can be used with media or container queries.
+ */
+export function isWidthBelow(breakpoint: Breakpoint) {
+  return `(max-width: ${BreakpointMinimumDimensions[breakpoint]})`
+}

--- a/src/utils/breakpoints/index.mdx
+++ b/src/utils/breakpoints/index.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# Working with Breakpoints
+
+<Meta title="Utils/Breakpoints" />
+
+Elements defines a standard set of breakpoints that can be used to create responsive designs. The minimum width of
+each breakpoint is defined in the `BreakpointMinimumDimensions` object available via `@reapit/elements/utils/breakpoints`.
+
+Elements also provides utility functions to help create conditions based on these breakpoints. These functions can be
+combined with [MatchMedia](?path=/docs/utils-matchmedia--docs) or [useMatchMedia](?path=/docs/utils-matchmedia--docs) within
+your JavaScript code, or directly in styled components using Linaria's `styled` utility.
+
+For example, in JavaScript code:
+
+```tsx
+import { isWidthAtOrAbove, isWidthBelow } from '@reapit/elements/utils/breakpoints'
+
+// true when width >= BreakpointMinimumDimensions.SM
+const isWidthAtOrAboveSM = useMatchMedia(isWidthAtOrAbove('SM'))
+
+// true when width < BreakpointMinimumDimensions.MD
+const isWidthBelowMD = useMatchMedia(isWidthBelow('MD'))
+```
+
+Or in a styled component:
+
+```tsx
+import { isWidthAtOrAbove } from '@reapit/elements/utils/breakpoints'
+import { styled } from '@linaria/react'
+
+const MyResponsiveDiv = styled.div`
+  background-color: blue;
+
+  /* Equivalent to "@media (min-width: 1024px)" */
+  @media only screen and ${isWidthAtOrAbove('MD')} {
+    background-color: red;
+  }
+`
+```

--- a/src/utils/breakpoints/index.ts
+++ b/src/utils/breakpoints/index.ts
@@ -1,0 +1,2 @@
+export * from './breakpoints'
+export * from './conditions'

--- a/src/utils/match-media/__tests__/match-media.test.tsx
+++ b/src/utils/match-media/__tests__/match-media.test.tsx
@@ -1,0 +1,49 @@
+import { MatchMedia } from '../match-media'
+import { useMatchMedia } from '../use-match-media'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('../use-match-media')
+
+test('renders children when condition matches', () => {
+  vi.mocked(useMatchMedia).mockReturnValue(true)
+
+  render(
+    <MatchMedia condition="fake condition">
+      <div data-testid="content">Desktop content</div>
+    </MatchMedia>,
+  )
+
+  expect(screen.getByTestId('content')).toBeVisible()
+})
+
+test('does not render children when condition does not match', () => {
+  vi.mocked(useMatchMedia).mockReturnValue(false)
+
+  render(
+    <MatchMedia condition="fake condition">
+      <div data-testid="content">Desktop content</div>
+    </MatchMedia>,
+  )
+
+  expect(screen.queryByTestId('content')).not.toBeInTheDocument()
+})
+
+test('calls useMatchMedia with the specified condition', () => {
+  vi.mocked(useMatchMedia).mockReturnValue(true)
+
+  const { rerender } = render(
+    <MatchMedia condition="condition 1">
+      <div data-testid="content">Desktop content</div>
+    </MatchMedia>,
+  )
+
+  expect(useMatchMedia).toHaveBeenCalledWith('condition 1')
+
+  rerender(
+    <MatchMedia condition="condition 2">
+      <div data-testid="content">Desktop content</div>
+    </MatchMedia>,
+  )
+
+  expect(useMatchMedia).toHaveBeenCalledWith('condition 2')
+})

--- a/src/utils/match-media/__tests__/use-match-media.test.tsx
+++ b/src/utils/match-media/__tests__/use-match-media.test.tsx
@@ -1,0 +1,29 @@
+import { useMatchMedia } from '../index'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// NOTE: HappyDOM does not appear to support MediaQueryList change events, so we can't test our
+// handling of those events here.
+
+test('returns true when condition matches', () => {
+  const { result } = renderHook(() => useMatchMedia('(min-width: 0px)'))
+  expect(result.current).toBe(true)
+})
+
+test('returns false when condition does not match', () => {
+  const { result } = renderHook(() => useMatchMedia('(min-width: 999999px)'))
+  expect(result.current).toBe(false)
+})
+
+test('updates when condition changes', async () => {
+  const { result, rerender } = renderHook(({ condition }) => useMatchMedia(condition), {
+    initialProps: { condition: '(min-width: 999999px)' },
+  })
+
+  expect(result.current).toBe(false)
+
+  rerender({ condition: '(min-width: 0px)' })
+
+  await waitFor(() => {
+    expect(result.current).toBe(true)
+  })
+})

--- a/src/utils/match-media/index.ts
+++ b/src/utils/match-media/index.ts
@@ -1,0 +1,2 @@
+export * from './match-media'
+export * from './use-match-media'

--- a/src/utils/match-media/match-media.stories.tsx
+++ b/src/utils/match-media/match-media.stories.tsx
@@ -1,0 +1,44 @@
+import { isWidthAtOrAbove } from '#src/utils/breakpoints'
+import { MatchMedia } from './match-media'
+import { Pattern } from '#src/core/drawer/__story__/Pattern'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Utils/MatchMedia',
+  component: MatchMedia,
+  argTypes: {
+    condition: {
+      control: 'text',
+    },
+    children: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof MatchMedia>
+
+export default meta
+type Story = StoryObj<typeof MatchMedia>
+
+/**
+ * A common use case is when content rendered by a component should only be visible at certain screen sizes. In this
+ * example, the pretty pattern will only be visible if your browser viewport is larger than the `MD` breakpoint.
+ */
+export const Example: Story = {
+  args: {
+    children: <Pattern height="100px" />,
+    condition: isWidthAtOrAbove('MD'),
+  },
+}
+
+/**
+ * But any valid media query condition can be specified, whether it's `(prefers-color-scheme: light)` or
+ * `(orientation: landscape)`. In this example, the content will only be visible if the user has `light` mode enabled
+ * in their system preferences.
+ */
+export const OtherUses: Story = {
+  args: {
+    condition: '(prefers-color-scheme: light)',
+    children: <Pattern height="100px" />,
+  },
+}

--- a/src/utils/match-media/match-media.tsx
+++ b/src/utils/match-media/match-media.tsx
@@ -1,0 +1,22 @@
+import { useMatchMedia } from './use-match-media'
+
+import type { ReactNode } from 'react'
+
+interface MatchMediaProps {
+  /** The media query condition to match against (e.g., "(min-width: 768px)", "(prefers-color-scheme: dark)") */
+  condition: string
+  /** The content to render when the media query matches */
+  children: ReactNode
+}
+
+/**
+ * A component that conditionally renders its children based on a media query condition. Uses the
+ * [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) Web API to determine if the
+ * condition matches the current viewport.
+ *
+ * `useMatchMedia` is also available if you want a hook API rather than a component.
+ */
+export function MatchMedia({ condition, children }: MatchMediaProps) {
+  const matches = useMatchMedia(condition)
+  return matches ? children : null
+}

--- a/src/utils/match-media/use-match-media.mdx
+++ b/src/utils/match-media/use-match-media.mdx
@@ -1,0 +1,29 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Utils/MatchMedia/useMatchMedia" />
+
+# useMatchMedia
+
+A hook-based API for working with media queries. Like [MatchMedia](?path=/docs/utils-matchmedia--docs), it works with
+any valid media query condition and returns a boolean value indicating whether the condition currently matches.
+
+## Syntax
+
+```tsx
+useMatchMedia(condition)
+```
+
+- `condition`: The media query condition to match against.
+
+## Example
+
+```tsx
+import { Button } from '@reapit/elements/core/button'
+import { isWidthAtOrAbove } from '@reapit/elements/utils/breakpoints'
+import { useMatchMedia } from '@reapit/elements/utils/match-media'
+
+function MyResponsiveButton(props: MyResponsiveButtonProps) {
+  const isWidthAtOrAboveMD = useMatchMedia(isWidthAtOrAbove('MD'))
+  return <Button {...props} size={isWidthAtOrAboveMD ? 'medium' : 'large'} />
+}
+```

--- a/src/utils/match-media/use-match-media.ts
+++ b/src/utils/match-media/use-match-media.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * A hook that tracks whether a media query condition matches.
+ *
+ * @param condition - The media query condition to match against (e.g., "(min-width: 1024px)")
+ * @returns boolean - Whether the media query condition matches
+ *
+ * @example
+ * ```tsx
+ * const isDesktop = useMatchMedia('(min-width: 1024px)')
+ * return isDesktop ? <DesktopContent /> : <MobileContent />
+ * ```
+ */
+export function useMatchMedia(condition: string): boolean {
+  const [matches, setMatches] = useState(() => globalThis.matchMedia(condition).matches)
+
+  useEffect(
+    function setupMediaQueryListener() {
+      const mediaQuery = globalThis.matchMedia(condition)
+
+      // If the condition changes, we update the state immediately
+      setMatches(mediaQuery.matches)
+
+      const handleChange = (event: MediaQueryListEvent) => {
+        setMatches(event.matches)
+      }
+
+      mediaQuery.addEventListener('change', handleChange)
+
+      return () => {
+        mediaQuery.removeEventListener('change', handleChange)
+      }
+    },
+    [condition],
+  )
+
+  return matches
+}

--- a/src/utils/url-search-params/to-map.mdx
+++ b/src/utils/url-search-params/to-map.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-# `toMap`
+# toMap
 
 <Meta title="Utils/URLSearchParams/toMap" />
 
@@ -14,7 +14,7 @@ toMap(searchParams)
 
 - `searchParams`: The `URLSearchParams` to convert.
 
-## Usage Example
+## Example
 
 ```ts
 import { toMap } from '@reapit/elements/utils/url-search-params'

--- a/src/utils/url-search-params/to-url-search-params.mdx
+++ b/src/utils/url-search-params/to-url-search-params.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-# `toURLSearchParams`
+# toURLSearchParams
 
 <Meta title="Utils/URLSearchParams/toURLSearchParams" />
 
@@ -18,7 +18,7 @@ toURLSearchParams(data, init)
 - `init`: An optional `URLSearchParams` object to initialize the new search params with. Entries in this object will
   always be replaced by new entries with the same key.
 
-## Usage Example
+## Example
 
 ```ts
 import { toURLSearchParams } from '@reapit/elements/utils/url-search-params'


### PR DESCRIPTION
### Context

- We have deprecated breakpoint names, and a deprecated `useMediaQuery` hook, that all need replacing.
- We want to introduce new breakpoint variables per the Design System's new names and allow them to be used for media and container queries.
- We want to introduce new helper functions for build width-based queries/conditions for use with media and container queries.
- We want to introduce a new component, `MatchMedia`, and a new hook, `useMatchMedia` that leverage the browser's `matchMedia` API (rather than the custom approach used in the deprecated hook).

### This PR

Does all of the above...

