### PR TITLE
chore: Adjust Drawer styles to match design updates

### DIFF
--- a/src/core/drawer/__story__/useDrawerBreakpointDecorator.tsx
+++ b/src/core/drawer/__story__/useDrawerBreakpointDecorator.tsx
@@ -1,4 +1,4 @@
-import { DRAWER_WIDTH_XS_SM, DRAWER_WIDTH_MD_2XL } from '../constants'
+import { DRAWER_WIDTH_XS_SM, DRAWER_WIDTH_MD_2XL, DRAWER_CSS_CONTAINER_NAME } from '../constants'
 
 import type { Decorator } from '@storybook/react'
 import type { ReactNode } from 'react'
@@ -47,7 +47,7 @@ export function Breakpoint({ breakpoint, children }: BreakpointProps) {
   return (
     <div
       style={{
-        containerName: 'drawer',
+        containerName: DRAWER_CSS_CONTAINER_NAME,
         containerType: 'size',
         display: 'grid',
         gridTemplateAreas: '"header" "body" "footer"',

--- a/src/core/drawer/body/body.stories.tsx
+++ b/src/core/drawer/body/body.stories.tsx
@@ -1,5 +1,7 @@
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
+import { DRAWER_CSS_CONTAINER_NAME } from '../constants'
 import { DrawerBody } from './body'
+import { DrawerFooter } from '../footer'
 import { Pattern } from '../__story__/Pattern'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
@@ -27,6 +29,34 @@ export const Example: Story = {
   args: {
     children: 'Drawer content',
   },
+}
+
+/**
+ * When the drawer body is followed by a footer, the body will have no block start (top) padding because the
+ * header will not be sticky and, therefore, we do not need the additional space. This behaviour explicitly
+ * depends on the presence of the `ElDrawerFooter` class being used; it will not work for custom footers that
+ * use their own classes.
+ */
+export const Footer: Story = {
+  args: {
+    ...Example.args,
+    children: <Pattern height="100px" />,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'border-box',
+          border: '1px solid #FA00FF',
+          containerName: DRAWER_CSS_CONTAINER_NAME,
+          containerType: 'inline-size',
+        }}
+      >
+        <Story />
+        <DrawerFooter>Footer</DrawerFooter>
+      </div>
+    ),
+  ],
 }
 
 /**

--- a/src/core/drawer/body/styles.ts
+++ b/src/core/drawer/body/styles.ts
@@ -1,4 +1,5 @@
-import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { DRAWER_CSS_CONTAINER_NAME, DRAWER_WIDTH_MD_2XL } from '../constants'
+import { ElDrawerFooter } from '../footer'
 import { styled } from '@linaria/react'
 
 export const ElDrawerBody = styled.div`
@@ -6,10 +7,16 @@ export const ElDrawerBody = styled.div`
   background: var(--fill-white);
   height: 100%;
 
-  /* XS-SM container size */
-  padding: var(--spacing-5);
+  padding-block: var(--spacing-5);
+  padding-inline: var(--spacing-5);
 
-  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
-    padding: var(--spacing-6) var(--spacing-8);
+  @container ${DRAWER_CSS_CONTAINER_NAME} (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding-inline: var(--spacing-8);
+  }
+
+  /* When the drawer body is followed by a footer, we remove the top padding because the header will not be
+   * sticky (i.e. it'll scroll away with the body). */
+  &:has(~ ${ElDrawerFooter}) {
+    padding-block-start: 0;
   }
 `

--- a/src/core/drawer/constants.ts
+++ b/src/core/drawer/constants.ts
@@ -1,2 +1,4 @@
+export const DRAWER_CSS_CONTAINER_NAME = 'drawer'
+
 export const DRAWER_WIDTH_XS_SM = '375px'
 export const DRAWER_WIDTH_MD_2XL = '480px'

--- a/src/core/drawer/drawer.stories.tsx
+++ b/src/core/drawer/drawer.stories.tsx
@@ -95,7 +95,7 @@ export const Breakpoints: StoryObj = {
   render: () => (
     <>
       <Breakpoint breakpoint="XS-SM">
-        <ExampleSimpleLayout withTabs />
+        <ExampleSimpleLayout />
       </Breakpoint>
       <Breakpoint breakpoint="MD-2XL">
         <ExampleSimpleLayout withTabs />

--- a/src/core/drawer/footer/footer.stories.tsx
+++ b/src/core/drawer/footer/footer.stories.tsx
@@ -1,5 +1,6 @@
 import { Button } from '#src/core/button/index'
 import { Breakpoint, useDrawerBreakpointDecorator } from '../__story__/useDrawerBreakpointDecorator'
+import { DRAWER_CSS_CONTAINER_NAME } from '../constants'
 import { DrawerFooter } from './footer'
 import { Pattern } from '../__story__/Pattern'
 
@@ -17,7 +18,7 @@ const meta = {
     (Story) => (
       // NOTE: The footer requires a parent container with `containerType: 'inline-size'` to allow its container
       // queries to work. Typically, this would be the Drawer itself, but we're not rendering that here.
-      <div style={{ containerType: 'inline-size' }}>
+      <div style={{ containerName: DRAWER_CSS_CONTAINER_NAME, containerType: 'inline-size' }}>
         <Story />
       </div>
     ),
@@ -65,6 +66,7 @@ export const StickyPositioning: Story = {
         style={{
           boxSizing: 'border-box',
           border: '1px solid #FA00FF',
+          containerName: DRAWER_CSS_CONTAINER_NAME,
           containerType: 'inline-size',
           maxHeight: '200px',
           overflow: 'auto',

--- a/src/core/drawer/footer/styles.ts
+++ b/src/core/drawer/footer/styles.ts
@@ -1,4 +1,4 @@
-import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { DRAWER_CSS_CONTAINER_NAME, DRAWER_WIDTH_MD_2XL } from '../constants'
 import { styled } from '@linaria/react'
 
 export const ElDrawerFooter = styled.div`
@@ -7,22 +7,21 @@ export const ElDrawerFooter = styled.div`
   position: sticky;
   inset-block-end: 0;
 
-  background: var(--colour-fill-white);
-  border-block-start: var(--border-width-default, 1px) solid var(--colour-border-light_default);
-
-  width: 100%;
-
   display: inline-grid;
   grid-auto-flow: column;
   gap: var(--spacing-2);
   align-items: center;
   justify-content: end;
 
-  /* XS-SM container size */
+  width: 100%;
+
+  background: var(--colour-fill-white);
+  border-block-start: var(--border-width-default, 1px) solid var(--colour-border-light_default);
+
   grid-auto-columns: 1fr;
   padding: var(--spacing-3) var(--spacing-6);
 
-  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+  @container ${DRAWER_CSS_CONTAINER_NAME} (width >= ${DRAWER_WIDTH_MD_2XL}) {
     padding: var(--spacing-3) var(--spacing-8);
     grid-auto-columns: auto;
   }

--- a/src/core/drawer/header/header.stories.tsx
+++ b/src/core/drawer/header/header.stories.tsx
@@ -110,6 +110,7 @@ export const StickyPositioning: Story = {
         style={{
           boxSizing: 'border-box',
           border: '1px solid #FA00FF',
+          containerName: 'drawer',
           containerType: 'inline-size',
           maxHeight: '200px',
           overflow: 'auto',
@@ -138,6 +139,7 @@ export const StaticPositioning: Story = {
         style={{
           boxSizing: 'border-box',
           border: '1px solid #FA00FF',
+          containerName: 'drawer',
           containerType: 'inline-size',
           maxHeight: '200px',
           overflow: 'auto',
@@ -165,7 +167,7 @@ export const DynamicLayout: Story = {
   render: (args) => (
     <>
       <Breakpoint breakpoint="XS-SM">
-        <DrawerHeader {...args} action={<DrawerHeader.CloseButton />} />
+        <DrawerHeader {...args} action={<DrawerHeader.CloseButton />} tabs={null} />
       </Breakpoint>
       <Breakpoint breakpoint="MD-2XL">
         <DrawerHeader {...args} action={<DrawerHeader.CloseButton />} />

--- a/src/core/drawer/header/header.tsx
+++ b/src/core/drawer/header/header.tsx
@@ -3,11 +3,12 @@ import { DrawerHeaderCloseButton } from './close-button'
 import {
   ElDrawerHeader,
   ElDrawerHeaderAction,
-  ElDrawerHeaderContentContainer,
+  ElDrawerHeaderTitleContainer,
   ElDrawerHeaderOverline,
   ElDrawerHeaderSupplementaryInfo,
   ElDrawerHeaderTabsContainer,
   ElDrawerHeaderTitle,
+  ElDrawerHeaderContentContainer,
 } from './styles'
 import type { HTMLAttributes, ReactNode } from 'react'
 
@@ -33,12 +34,14 @@ export function DrawerHeader({ action, overline, children, supplementaryInfo, ta
   return (
     <ElDrawerHeader {...rest}>
       <ElDrawerHeaderContentContainer>
-        {action && <ElDrawerHeaderAction>{action}</ElDrawerHeaderAction>}
-        {overline && <ElDrawerHeaderOverline>{overline}</ElDrawerHeaderOverline>}
-        <ElDrawerHeaderTitle id={titleId}>{children}</ElDrawerHeaderTitle>
-        {supplementaryInfo && <ElDrawerHeaderSupplementaryInfo>{supplementaryInfo}</ElDrawerHeaderSupplementaryInfo>}
+        <ElDrawerHeaderTitleContainer>
+          {action && <ElDrawerHeaderAction>{action}</ElDrawerHeaderAction>}
+          {overline && <ElDrawerHeaderOverline>{overline}</ElDrawerHeaderOverline>}
+          <ElDrawerHeaderTitle id={titleId}>{children}</ElDrawerHeaderTitle>
+          {supplementaryInfo && <ElDrawerHeaderSupplementaryInfo>{supplementaryInfo}</ElDrawerHeaderSupplementaryInfo>}
+        </ElDrawerHeaderTitleContainer>
+        {tabs && <ElDrawerHeaderTabsContainer>{tabs}</ElDrawerHeaderTabsContainer>}
       </ElDrawerHeaderContentContainer>
-      {tabs && <ElDrawerHeaderTabsContainer>{tabs}</ElDrawerHeaderTabsContainer>}
     </ElDrawerHeader>
   )
 }

--- a/src/core/drawer/header/styles.ts
+++ b/src/core/drawer/header/styles.ts
@@ -1,7 +1,9 @@
-import { DRAWER_WIDTH_MD_2XL } from '../constants'
+import { DRAWER_CSS_CONTAINER_NAME, DRAWER_WIDTH_MD_2XL } from '../constants'
 import { ElDrawerFooter } from '../footer'
 import { font } from '../../text'
 import { styled } from '@linaria/react'
+
+export const DRAWER_HEADER_CSS_CONTAINER_NAME = 'drawer-header'
 
 export const ElDrawerHeader = styled.div`
   position: sticky;
@@ -9,42 +11,12 @@ export const ElDrawerHeader = styled.div`
 
   background: var(--fill-white);
 
-  /* NOTE: We use a "private" CSS variable to couple the negative margin of the tabs container to this border width */
-  --__drawer-header-border-width: var(--border-default);
+  container-type: scroll-state;
+  container-name: ${DRAWER_HEADER_CSS_CONTAINER_NAME};
 
-  border-block-end: var(--__drawer-header-border-width) solid var(--outline-default);
-
-  display: grid;
-  grid-area: header;
-  grid-template:
-    'main' minmax(0, auto)
-    'tabs' minmax(0, auto) / 100%;
-
-  /* NOTE: When the drawer has a footer, the header should not be sticky and it should therefore, have no border. */
+  /* When the drawer has a footer, the header should NOT be sticky. */
   &:has(~ ${ElDrawerFooter}) {
     position: static;
-    border-block-end: none;
-  }
-`
-
-export const ElDrawerHeaderContentContainer = styled.div`
-  display: grid;
-  grid-area: main;
-  grid-template:
-    'overline close' minmax(0, auto)
-    /* NOTE: We need to use minmax for the title row because min-content and auto will consider the close button's
-     * size, which will result in a larger track height when the close button is present than when it is not. */
-    'title close' minmax(0, auto)
-    'supplementary-info supplementary-info' minmax(0, auto) / auto min-content;
-  align-items: center;
-
-  /* XS-SM container size */
-  padding-block: var(--spacing-3);
-  padding-inline: var(--spacing-5) var(--spacing-3);
-
-  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
-    padding-block: var(--spacing-5);
-    padding-inline: var(--spacing-8) var(--spacing-5);
   }
 `
 
@@ -53,14 +25,62 @@ export const ElDrawerHeaderTabsContainer = styled.div`
 
   width: 100%;
 
-  /* NOTE: This negative margin is used to make the tabs border overlap the drawer header's border. */
-  margin-block-end: calc(0px - var(--__drawer-header-border-width));
+  /* This negative margin is used to make the tabs border overlap the drawer header's border. */
+  margin-block-end: calc(0px - var(--border-default));
 
-  /* XS-SM container size */
   padding-inline-start: var(--spacing-5);
 
-  @container (width >= ${DRAWER_WIDTH_MD_2XL}) {
+  @container ${DRAWER_CSS_CONTAINER_NAME} (width >= ${DRAWER_WIDTH_MD_2XL}) {
     padding-inline-start: var(--spacing-8);
+  }
+`
+
+export const ElDrawerHeaderContentContainer = styled.div`
+  display: grid;
+  grid-area: header;
+  grid-template:
+    'main' minmax(0, auto)
+    'tabs' minmax(0, auto) / 100%;
+
+  /* If the browser does not support scroll-state queries, we always show a border when there's no footer. */
+  @supports not (container-type: scroll-state) {
+    &:not(:has(~ ${ElDrawerFooter})) {
+      border-block-end: var(--border-default) solid var(--outline-default);
+    }
+  }
+
+  /* If the browser supports scroll-state queries, we only show a border when the header is stuck to the top of
+   * the drawer. This only happens when the header is sticky positioned, which only occurs when there's no footer. */
+  @supports (container-type: scroll-state) {
+    @container ${DRAWER_HEADER_CSS_CONTAINER_NAME} scroll-state(stuck: top) {
+      border-block-end: var(--border-default) solid var(--outline-default);
+    }
+  }
+
+  /* When the drawer has tabs, we need to add a border to this container (at all times) because the tabs own
+   * border will not stretch to the left edge of the drawer. */
+  &:has(> ${ElDrawerHeaderTabsContainer}) {
+    border-block-end: var(--border-default) solid var(--outline-default);
+  }
+`
+
+export const ElDrawerHeaderTitleContainer = styled.div`
+  display: grid;
+  grid-area: main;
+  grid-template:
+    'overline close' minmax(0, auto)
+    /* We need to use minmax for the title row because min-content and auto will consider the close button's size,
+     * which will result in a larger track height when the close button is present than when it is not. */
+    'title close' minmax(0, auto)
+    'supplementary-info supplementary-info' minmax(0, auto) / auto min-content;
+  align-items: center;
+
+  padding-block: var(--spacing-3);
+  padding-inline: var(--spacing-5) var(--spacing-3);
+
+  @container ${DRAWER_CSS_CONTAINER_NAME} (width >= ${DRAWER_WIDTH_MD_2XL}) {
+    padding-block: var(--spacing-5);
+    padding-inline: var(--spacing-8) var(--spacing-5);
   }
 `
 

--- a/src/core/drawer/index.ts
+++ b/src/core/drawer/index.ts
@@ -1,4 +1,5 @@
 export * from './body'
+export * from './constants'
 export * from './context'
 export * from './drawer'
 export * from './footer'

--- a/src/core/drawer/styles.ts
+++ b/src/core/drawer/styles.ts
@@ -1,22 +1,21 @@
-import { DRAWER_WIDTH_MD_2XL, DRAWER_WIDTH_XS_SM } from './constants'
-import { isDesktop } from '#src/styles/deprecated-media'
+import { DRAWER_CSS_CONTAINER_NAME, DRAWER_WIDTH_MD_2XL, DRAWER_WIDTH_XS_SM } from './constants'
+import { isWidthAtOrAbove } from '#src/utils/breakpoints/conditions'
 import { styled } from '@linaria/react'
 
 export const ElDrawer = styled.dialog`
   position: fixed;
 
-  container-name: drawer;
+  container-name: ${DRAWER_CSS_CONTAINER_NAME};
   container-type: size;
 
   background: var(--fill-white);
   border: none;
   padding: 0;
 
-  /* Size the drawer */
   max-width: ${DRAWER_WIDTH_XS_SM};
   min-width: ${DRAWER_WIDTH_XS_SM};
 
-  ${isDesktop} {
+  @media ${isWidthAtOrAbove('MD')} {
     max-width: ${DRAWER_WIDTH_MD_2XL};
     min-width: ${DRAWER_WIDTH_MD_2XL};
   }
@@ -25,8 +24,8 @@ export const ElDrawer = styled.dialog`
   inset-inline: auto 0;
   inset-block: 0;
   height: 100%;
-  max-height: 100vh;
-  min-height: 100vh;
+  max-height: 100svh;
+  min-height: 100svh;
   overflow: auto;
 
   /* Initially transform the drawer's position so it is off-screen */
@@ -37,12 +36,11 @@ export const ElDrawer = styled.dialog`
     background-color: rgb(0 0 0 / 0%);
   }
 
-  /* Open state of the dialog */
-  &:open,
-  &[open] {
-    /* NOTE: We deliberately only apply a display property when the drawer is open because if we apply it to
-     * the drawer when it is closed, it will override the browser's default "display: none" behaviour for closed
-     * dialog elements. */
+  /* Open state of the dialog. We use :is because it accepts a forgiving selector list, and not all browsers
+   * support the :open selector for dialog elements. */
+  &:is(:open, [open]) {
+    /* We only apply a display property when the drawer is open because if we apply it to the drawer when it is
+     * closed, it will override the browser's default "display: none" behaviour for closed dialog elements. */
     display: grid;
     grid-template:
       'header' auto
@@ -63,8 +61,7 @@ export const ElDrawer = styled.dialog`
     /* Starting styles for the drawer and backdrop. These are applied at the start of the drawer's
      * "open" transition. See https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style. */
     @starting-style {
-      &:open,
-      &[open] {
+      &:is(:open, [open]) {
         transform: translateX(100%);
         &::backdrop {
           background-color: transparent;

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -22,6 +22,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add new `isWidthAtOrAbove` and `isWidthBelow` utilities. See [breakpoints](?path=/docs/utils-breakpoints--docs) for details.
 - **chore:** Moved "Components" section to "Core" in Storybook to align with the subpath entry point recently introduced.
 - **feat:** `Drawer.Header` is now sticky by default. When a Drawer.Footer is present, the header will be statically positioned. See [Drawer.Header](?path=/docs/core-drawer-header--docs) for details.
+- **chore:** Design updates to the `Drawer` components.
 
 ### **5.0.0-beta.38 - 18/07/25**
 


### PR DESCRIPTION
### Context 

- After #626, Design made further adjustments to the Drawers, including changes to the paddings, and clarification around the sticky header vs sticky footer patterns.
- We've also recently introduced new breakpoints in Elements, yet the Drawer implementation currently relies on the old, deprecated helpers.

### This PR

- Updates drawer components to match latest design requirements
- Updates drawer component to use new breakpoint helpers