### PR TITLE
feat: Add new `Dialog.Footer`

### DIFF
--- a/src/core/dialog/footer/__tests__/footer.test.tsx
+++ b/src/core/dialog/footer/__tests__/footer.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { DialogFooter } from '../footer'
+
+test('renders a footer element with the expected content', () => {
+  render(<DialogFooter>Test content</DialogFooter>)
+  expect(screen.getByText('Test content')).toBeVisible()
+})
+
+test('forwards additional props to the footer element', () => {
+  render(<DialogFooter data-testid="test-id">Test content</DialogFooter>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/core/dialog/footer/footer.stories.tsx
+++ b/src/core/dialog/footer/footer.stories.tsx
@@ -1,0 +1,93 @@
+import { Button } from '#src/core/button/index'
+import { DialogFooter } from './footer'
+import { Pattern } from '#src/core/drawer/__story__/Pattern'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Dialog/Footer',
+  component: DialogFooter,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      // NOTE: The footer requires a parent container with `containerType: 'inline-size'` to allow its container
+      // queries to work. Typically, this would be the Drawer itself, but we're not rendering that here.
+      <div style={{ containerType: 'inline-size' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+} satisfies Meta<typeof DialogFooter>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: (
+      <>
+        {/* Note: We use `display: contents` to allow the grid layout of the footer to affect the Cancel button.
+         * There are other ways to achieve this, but this is one of the simplest. We may chose, in future, to
+         * provide a Drawer-specific Cancel button similar to the header's Close button.*/}
+        <form style={{ display: 'contents' }}>
+          <Button formMethod="dialog" size="medium" type="submit" variant="secondary">
+            Cancel
+          </Button>
+        </form>
+        <Button size="medium" variant="primary">
+          Add
+        </Button>
+      </>
+    ),
+  },
+}
+
+/**
+ * The drawer footer actions will expand to equally share space when inside a full-screen dialog.
+ */
+export const FullScreen: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div data-size="full-screen">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * The drawer footer is sticky positioned to the bottom of its parent when it scrolls.
+ */
+export const Sticky: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'border-box',
+          border: '1px solid #FA00FF',
+          containerType: 'inline-size',
+          maxHeight: '200px',
+          overflow: 'auto',
+        }}
+      >
+        <Pattern />
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/core/dialog/footer/footer.tsx
+++ b/src/core/dialog/footer/footer.tsx
@@ -1,0 +1,16 @@
+import { ElDialogFooter } from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface DialogFooterProps extends HTMLAttributes<HTMLDivElement> {
+  /** The footer actions. Typically one or more buttons. */
+  children: ReactNode
+}
+
+/**
+ * A footer for dialogs. Typically used to display a set of actions related to the dialog's content (e.g.
+ * "Save" and "Cancel" buttons when the dialog contains a form).
+ */
+export function DialogFooter({ children, ...rest }: DialogFooterProps) {
+  return <ElDialogFooter {...rest}>{children}</ElDialogFooter>
+}

--- a/src/core/dialog/footer/index.ts
+++ b/src/core/dialog/footer/index.ts
@@ -1,0 +1,2 @@
+export * from './footer'
+export * from './styles'

--- a/src/core/dialog/footer/styles.ts
+++ b/src/core/dialog/footer/styles.ts
@@ -1,0 +1,27 @@
+import { styled } from '@linaria/react'
+
+export const ElDialogFooter = styled.footer`
+  grid-area: footer;
+
+  position: sticky;
+  inset-block-end: 0;
+
+  background: var(--colour-fill-white);
+  border-block-start: var(--border-width-default, 1px) solid var(--colour-border-light_default);
+
+  width: 100%;
+
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: var(--spacing-2);
+  align-items: center;
+  justify-content: end;
+
+  padding: var(--spacing-5) var(--spacing-6);
+  grid-auto-columns: auto;
+
+  [data-size='full-screen'] & {
+    padding: var(--spacing-3) var(--spacing-5);
+    grid-auto-columns: 1fr;
+  }
+`


### PR DESCRIPTION
### Context

- The `Dialog` component has received Design updates; we need to update our implementation to match.
- The work will be done over a series of PRs:
  - Part 1: Add new `Dialog.Footer`
  - Part 2: Add new `Dialog.Body`
  - Part 3: Add new `Dialog.Header`
  - Part 4: Update `Dialog` to use new subcomponents.

### This PR

- Adds a new `Dialog.Footer` subcomponent. It is not used or exposed yet, though docs are included for it.

<img width="820" height="607" alt="Screenshot 2025-07-22 at 1 49 08 pm" src="https://github.com/user-attachments/assets/2f14356b-b916-4feb-a686-ddcb623d0598" />
<img width="817" height="537" alt="Screenshot 2025-07-22 at 1 49 15 pm" src="https://github.com/user-attachments/assets/63ff40c1-bf56-419e-8030-8781cb8ba46e" />
