### PR TITLE
feat: Add new `Dialog.Header`

### DIFF
--- a/src/core/dialog/__story__/useDialogContextDecorator.tsx
+++ b/src/core/dialog/__story__/useDialogContextDecorator.tsx
@@ -1,0 +1,11 @@
+import { DialogContextProvider } from '../context'
+
+import type { Decorator } from '@storybook/react'
+
+export function useDialogContextDecorator(): Decorator {
+  return (Story) => (
+    <DialogContextProvider dialogRef={{ current: null }} titleId="test-title-id">
+      <Story />
+    </DialogContextProvider>
+  )
+}

--- a/src/core/dialog/context.tsx
+++ b/src/core/dialog/context.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useMemo } from 'react'
+
+import type { ReactNode, RefObject } from 'react'
+
+interface DialogContext {
+  dialogRef: RefObject<HTMLDialogElement>
+  titleId: string
+}
+
+interface DialogContextProviderProps extends DialogContext {
+  children: ReactNode
+}
+
+/**
+ * The context available to a Dialog's descendants. Provides access to a single `close` function
+ * that can be used to imperatively close the parent dialog.
+ */
+const DialogContext = createContext<DialogContext | null>(null)
+
+/**
+ * Provides the given values over the `DialogContext`. For internal Dialog use only.
+ */
+export function DialogContextProvider({ children, dialogRef, titleId }: DialogContextProviderProps) {
+  const value = useMemo<DialogContext>(
+    () => ({
+      dialogRef,
+      titleId,
+    }),
+    [dialogRef, titleId],
+  )
+  return <DialogContext.Provider value={value}>{children}</DialogContext.Provider>
+}
+
+/**
+ * Returns the current `DialogContext` value.
+ * @throws an error if the context is not defined.
+ */
+export function useDialogContext(): DialogContext | null {
+  const context = useContext(DialogContext)
+  if (!context) {
+    throw new Error('DialogContext not defined: useDialogContext can only be used in a child of DialogContext')
+  }
+  return context
+}
+
+export default DialogContext

--- a/src/core/dialog/header/__tests__/close-button.test.tsx
+++ b/src/core/dialog/header/__tests__/close-button.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { DialogHeaderCloseButton } from '../close-button'
+
+test('renders a button within a form', () => {
+  render(<DialogHeaderCloseButton />)
+  const button = screen.getByRole('button', { name: 'Close' })
+  expect(button).toBeVisible()
+  expect(button.parentElement?.tagName).toBe('FORM')
+})
+
+test('button is configured to be auto-focused', () => {
+  render(<DialogHeaderCloseButton />)
+  const button = screen.getByRole('button')
+  expect(button).toHaveFocus()
+})
+
+test('button is configured to close its parent dialog element', () => {
+  render(<DialogHeaderCloseButton />)
+  const button = screen.getByRole('button')
+  expect(button).toHaveAttribute('formMethod', 'dialog')
+  expect(button).toHaveAttribute('type', 'submit')
+})
+
+test('button has the expected icon', () => {
+  render(<DialogHeaderCloseButton />)
+  const button = screen.getByRole('button')
+  expect(button.querySelector('svg')).toBeInTheDocument()
+})

--- a/src/core/dialog/header/__tests__/header.test.tsx
+++ b/src/core/dialog/header/__tests__/header.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { DialogHeader } from '../header'
+import { DialogContextProvider } from '../../context'
+
+import type { ReactNode } from 'react'
+
+test('renders a header element with the expected content', () => {
+  render(<DialogHeader>Test Title</DialogHeader>, { wrapper })
+  expect(screen.getByText('Test Title')).toBeVisible()
+})
+
+test('renders action when provided', () => {
+  render(<DialogHeader action="Test Action">Test Title</DialogHeader>, { wrapper })
+  expect(screen.getByText('Test Action')).toBeVisible()
+})
+
+test('forwards additional props to the header element', () => {
+  render(<DialogHeader data-testid="test-id">Test Title</DialogHeader>, { wrapper })
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <DialogContextProvider dialogRef={{ current: null }} titleId="test-title-id">
+      {children}
+    </DialogContextProvider>
+  )
+}

--- a/src/core/dialog/header/close-button.tsx
+++ b/src/core/dialog/header/close-button.tsx
@@ -1,0 +1,23 @@
+import { Button } from '#src/core/button/index'
+import { CloseIcon } from '#src/icons/close'
+
+/**
+ * A close button for dialog headers. Combines a form with a button in order to close the dialog via the
+ * `formMethod="dialog"` attribute. See
+ * [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#formmethod) for more information.
+ */
+export function DialogHeaderCloseButton() {
+  return (
+    <form>
+      <Button
+        autoFocus
+        aria-label="Close"
+        formMethod="dialog"
+        iconLeft={<CloseIcon aria-hidden />}
+        size="large"
+        type="submit"
+        variant="tertiary"
+      />
+    </form>
+  )
+}

--- a/src/core/dialog/header/header.stories.tsx
+++ b/src/core/dialog/header/header.stories.tsx
@@ -1,0 +1,123 @@
+import { DialogFooter } from '../footer'
+import { DialogHeader } from './header'
+import { Pattern } from '#src/core/drawer/__story__/Pattern'
+import { useDialogContextDecorator } from '../__story__/useDialogContextDecorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Dialog/Header',
+  component: DialogHeader,
+  argTypes: {
+    action: {
+      control: 'radio',
+      mapping: {
+        Close: <DialogHeader.CloseButton />,
+        None: null,
+      },
+      options: ['Close', 'None'],
+    },
+    children: {
+      control: 'text',
+    },
+  },
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+  decorators: [useDialogContextDecorator()],
+} satisfies Meta<typeof DialogHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * The dialog header can be used without an action. This will typically be the case when the dialog has a footer
+ * that contains the actions available to the user.
+ */
+export const Example: Story = {
+  args: {
+    action: 'None',
+    'aria-label': '',
+    children: 'Dialog Title',
+  },
+}
+
+/**
+ * Dialogs that do not provide one or more actions in a footer should have a close action in the header to allow
+ * user's to dismiss the dialog.
+ */
+export const Action: Story = {
+  args: {
+    ...Example.args,
+    action: 'Close',
+  },
+}
+
+/**
+ * The dialog header can also be used without a visible title. In this case, an `aria-label` should be provided
+ * to make the dialog accessible.
+ */
+export const NoTitle: Story = {
+  args: {
+    ...Action.args,
+    'aria-label': 'Dialog Title',
+    children: null,
+  },
+}
+
+/**
+ * By default, the dialog header will be sticky when the dialog content scrolls. This ensures the context displayed by
+ * the dialog's header is always visible when viewing the content.
+ */
+export const StickyPositioning: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'border-box',
+          border: '1px solid #FA00FF',
+          containerType: 'inline-size',
+          maxHeight: '200px',
+          overflow: 'auto',
+        }}
+      >
+        <Story />
+        <Pattern />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * However, when the drawer has a footer, the header will not be sticky and it will have no bottom border. This
+ * behaviour explicitly depends on the presence of the "official" drawer footer's class being a
+ * [subsequent sibling](https://developer.mozilla.org/en-US/docs/Web/CSS/Subsequent-sibling_combinator) to the header.
+ */
+export const StaticPositioning: Story = {
+  args: {
+    ...Example.args,
+    action: 'None',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'border-box',
+          border: '1px solid #FA00FF',
+          containerType: 'inline-size',
+          maxHeight: '200px',
+          overflow: 'auto',
+        }}
+      >
+        <Story />
+        <Pattern />
+        <DialogFooter>Footer</DialogFooter>
+      </div>
+    ),
+  ],
+}

--- a/src/core/dialog/header/header.tsx
+++ b/src/core/dialog/header/header.tsx
@@ -1,0 +1,34 @@
+import { useDialogContext } from '../context'
+import { DialogHeaderCloseButton } from './close-button'
+import { ElDialogHeader, ElDialogHeaderAction, ElDialogHeaderContentContainer, ElDialogHeaderTitle } from './styles'
+import type { ComponentProps, ReactNode } from 'react'
+
+interface DialogHeaderProps extends Omit<ComponentProps<typeof ElDialogHeader>, 'title'> {
+  /** Optional close action for the dialog. Should not be used when the dialog contains a form. */
+  action?: ReactNode
+  /**
+   * The accessible label for the dialog. This should always be provided when the dialog has no visible
+   * title (i.e. `children`).
+   */
+  'aria-label'?: string
+  /** The title of the dialog. */
+  children?: ReactNode
+}
+
+/**
+ * A header for dialogs. Contains the dialog's title, as well as an optional action (close button).
+ */
+export function DialogHeader({ action, children, 'aria-label': ariaLabel, ...rest }: DialogHeaderProps) {
+  const { titleId } = useDialogContext() ?? {}
+  return (
+    // NOTE: If we don't have a visible title, we should have an aria-label on this root element.
+    <ElDialogHeader {...rest} aria-label={ariaLabel} id={!children ? titleId : undefined}>
+      <ElDialogHeaderContentContainer>
+        {action && <ElDialogHeaderAction>{action}</ElDialogHeaderAction>}
+        {children && <ElDialogHeaderTitle id={titleId}>{children}</ElDialogHeaderTitle>}
+      </ElDialogHeaderContentContainer>
+    </ElDialogHeader>
+  )
+}
+
+DialogHeader.CloseButton = DialogHeaderCloseButton

--- a/src/core/dialog/header/index.ts
+++ b/src/core/dialog/header/index.ts
@@ -1,0 +1,3 @@
+export * from './close-button'
+export * from './header'
+export * from './styles'

--- a/src/core/dialog/header/styles.ts
+++ b/src/core/dialog/header/styles.ts
@@ -1,0 +1,56 @@
+import { ElDialogFooter } from '../footer'
+import { font } from '../../text'
+import { styled } from '@linaria/react'
+
+export const ElDialogHeader = styled.header`
+  position: sticky;
+  inset-block-start: 0;
+
+  container-type: scroll-state;
+  container-name: dialog-header;
+
+  &:has(~ ${ElDialogFooter}) {
+    position: relative;
+  }
+`
+
+export const ElDialogHeaderContentContainer = styled.div`
+  box-sizing: content-box;
+
+  height: var(--size-16);
+
+  display: grid;
+  grid-template: 'title close' auto / 1fr auto;
+  align-items: center;
+
+  background: var(--fill-white);
+  padding-block: 0;
+
+  @container dialog-header scroll-state(stuck: top) {
+    border-block-end: var(--border-width-default, 1px) solid var(--colour-border-light_default);
+  }
+
+  &,
+  :not([data-size='full-screen']) & {
+    padding-inline: var(--spacing-6) var(--spacing-3);
+  }
+
+  [data-size='full-screen'] & {
+    padding-inline: var(--spacing-5) var(--spacing-3);
+  }
+`
+
+export const ElDialogHeaderAction = styled.div`
+  grid-area: close;
+  color: var(--text-secondary);
+`
+
+export const ElDialogHeaderTitle = styled.h2`
+  color: var(--text-primary);
+  grid-area: title;
+
+  ${font('xl', 'bold')}
+
+  margin: 0;
+  padding: 0;
+`


### PR DESCRIPTION
### Context

- The `Dialog` component has received Design updates; we need to update our implementation to match.
- The work will be done over a series of PRs:
  - #628 
  - #630 
  - **Part 3: Add new `Dialog.Header` (this PR)**
  - Part 4: Update `Dialog` to use new subcomponents.

### This PR

- Adds a new `Dialog.Header` subcomponent. It is not used or exposed yet, though docs are included for it.

<img width="818" height="518" alt="Screenshot 2025-07-22 at 2 43 17 pm" src="https://github.com/user-attachments/assets/586ca045-e933-42f9-8d6e-9623c8bc73e4" />
<img width="813" height="671" alt="Screenshot 2025-07-22 at 2 43 23 pm" src="https://github.com/user-attachments/assets/82c8b9d3-7bff-4dda-9065-a39bf6357418" />
<img width="818" height="678" alt="Screenshot 2025-07-22 at 2 43 32 pm" src="https://github.com/user-attachments/assets/12330400-171a-4e8f-86d1-1a692c54eaaf" />
