### PR TITLE
feat: Add CSS anchor positioning polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
   },
   "dependencies": {
     "@linaria/core": "^6.3.0",
-    "@linaria/react": "^6.3.0"
+    "@linaria/react": "^6.3.0",
+    "@oddbird/css-anchor-positioning": "^0.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",

--- a/src/polyfills/css-anchor-positioning/__tests__/is-css-anchor-positioning-supported.test.ts
+++ b/src/polyfills/css-anchor-positioning/__tests__/is-css-anchor-positioning-supported.test.ts
@@ -1,0 +1,14 @@
+import { isCSSAnchorPositioningSupported } from '../is-css-anchor-positioning-supported'
+
+test('returns true when CSS anchor positioning is supported', () => {
+  Object.defineProperty(document.documentElement.style, 'anchorName', {
+    value: '',
+    configurable: true,
+  })
+  expect(isCSSAnchorPositioningSupported()).toBe(true)
+})
+
+test('returns false when CSS anchor positioning is NOT supported', () => {
+  delete (document.documentElement.style as any).anchorName
+  expect(isCSSAnchorPositioningSupported()).toBe(false)
+})

--- a/src/polyfills/css-anchor-positioning/__tests__/polyfill.test.ts
+++ b/src/polyfills/css-anchor-positioning/__tests__/polyfill.test.ts
@@ -1,0 +1,65 @@
+import { applyCSSAnchorPositioningPolyfill } from '../polyfill'
+import { isCSSAnchorPositioningSupported } from '../is-css-anchor-positioning-supported'
+import polyfill from '@oddbird/css-anchor-positioning/fn'
+
+vi.mock('@oddbird/css-anchor-positioning/fn')
+vi.mock('../is-css-anchor-positioning-supported')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('when CSS anchor positioning is not supported', () => {
+  beforeEach(() => {
+    vi.mocked(isCSSAnchorPositioningSupported).mockReturnValue(false)
+  })
+
+  test('applies the polyfill', async () => {
+    await applyCSSAnchorPositioningPolyfill()
+    expect(polyfill).toHaveBeenCalledOnce()
+  })
+
+  test('by default, does not polyfill eligible inline styles for all elements in the document', async () => {
+    await applyCSSAnchorPositioningPolyfill()
+    expect(polyfill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        excludeInlineStyles: true,
+      }),
+    )
+  })
+
+  test('by default, does not calculate position for each animation frame', async () => {
+    await applyCSSAnchorPositioningPolyfill()
+    expect(polyfill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useAnimationFrame: false,
+      }),
+    )
+  })
+
+  test('allows default options to be overridden', async () => {
+    const testElement = document.createElement('div')
+    await applyCSSAnchorPositioningPolyfill({
+      elements: [testElement],
+      excludeInlineStyles: false,
+      useAnimationFrame: true,
+    })
+    expect(polyfill).toHaveBeenCalledWith({
+      elements: [testElement],
+      excludeInlineStyles: false,
+      useAnimationFrame: true,
+    })
+    testElement.remove()
+  })
+})
+
+describe('when CSS anchor positioning is supported', () => {
+  beforeEach(() => {
+    vi.mocked(isCSSAnchorPositioningSupported).mockReturnValue(true)
+  })
+
+  test('does NOT apply the polyfill', async () => {
+    await applyCSSAnchorPositioningPolyfill()
+    expect(polyfill).not.toHaveBeenCalled()
+  })
+})

--- a/src/polyfills/css-anchor-positioning/index.ts
+++ b/src/polyfills/css-anchor-positioning/index.ts
@@ -1,0 +1,2 @@
+export * from './is-css-anchor-positioning-supported'
+export * from './polyfill'

--- a/src/polyfills/css-anchor-positioning/is-css-anchor-positioning-supported.ts
+++ b/src/polyfills/css-anchor-positioning/is-css-anchor-positioning-supported.ts
@@ -1,0 +1,7 @@
+/**
+ * Feature detects whether CSS anchor positioning is supported by the browser or not.
+ * @returns true if CSS anchor positioning is supported, false otherwise
+ */
+export function isCSSAnchorPositioningSupported() {
+  return 'anchorName' in document.documentElement.style
+}

--- a/src/polyfills/css-anchor-positioning/polyfill.ts
+++ b/src/polyfills/css-anchor-positioning/polyfill.ts
@@ -1,0 +1,53 @@
+import { isCSSAnchorPositioningSupported } from './is-css-anchor-positioning-supported'
+
+// This matches the `AnchorPositioningPolyfillOptions` type accepted by `@oddbird/css-anchor-positioning/fn`
+// JS Doc content copied from https://github.com/oddbird/css-anchor-positioning?tab=readme-ov-file#configuration
+interface ApplyCSSAnchorPositioningPolyfillOptions {
+  /**
+   * If set, the polyfill will only be applied to the specified elements instead of to all styles.
+   * This works by polyfilling each elements inline styles, if any. Any specified `<link>` and `<style>`
+   * elements will also be polyfilled.
+   */
+  elements?: HTMLElement[]
+  /**
+   * When not defined or set to false, the polyfill will be applied to all elements that have eligible
+   * inline styles, regardless of whether the elements option is defined. When set to true (the default),
+   * elements with eligible inline styles listed in the elements option will still be polyfilled, but no
+   * other elements in the document will be implicitly polyfilled.
+   *
+   * @default true
+   */
+  excludeInlineStyles?: boolean
+  /**
+   * Determines whether anchor calculations should update on every animation frame (e.g. when the anchor
+   * element is animated using transforms), in addition to always updating on scroll/resize. While this
+   * option is optimized for performance, it should be used sparingly.
+   *
+   * @default false
+   */
+  useAnimationFrame?: boolean
+}
+
+/**
+ * Applies the CSS anchor positioning polyfill, but only if the browser lacks native support.
+ */
+export async function applyCSSAnchorPositioningPolyfill({
+  elements,
+  // By default, we only want to polyfill inline styles on elements explicitly specified in the `elements`
+  // option. This is the opposite of the polyfill's default behaviour.
+  excludeInlineStyles = true,
+  // By default, we don't want to recalculate on every animation frame because we don't typically
+  // animate anchors.
+  useAnimationFrame = false,
+}: ApplyCSSAnchorPositioningPolyfillOptions = {}): Promise<void> {
+  if (!isCSSAnchorPositioningSupported()) {
+    // Dynamic import is cached by browser's module system - no repeated network requests
+    const { default: polyfillFn } = await import('@oddbird/css-anchor-positioning/fn')
+
+    await polyfillFn({
+      elements,
+      excludeInlineStyles,
+      useAnimationFrame,
+    })
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,6 +1528,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@floating-ui/core@npm:1.7.2"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: 10/2885a4c824f8d148222714cf2650c29bf3b30b70f465b990734766aafb1366ba23b4a285918c4f3ee67161096e7b9e4fbe0b3ca31e0f78800338cb4e6292912d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.1":
+  version: 1.7.2
+  resolution: "@floating-ui/dom@npm:1.7.2"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.2"
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: 10/2d581459973b66024c47f039cabdc059b39c72abca93a4a0a8110e0a90b79d3fb84e49099afb73e13b3e7f17096070422220d996b206a5f0120c92bd7c48b98b
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.10":
+  version: 0.2.10
+  resolution: "@floating-ui/utils@npm:0.2.10"
+  checksum: 10/b635ea865a8be2484b608b7157f5abf9ed439f351011a74b7e988439e2898199a9a8b790f52291e05bdcf119088160dc782d98cff45cc98c5a271bc6f51327ae
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.13.0":
   version: 0.13.0
   resolution: "@humanwhocodes/config-array@npm:0.13.0"
@@ -1851,6 +1877,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oddbird/css-anchor-positioning@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@oddbird/css-anchor-positioning@npm:0.6.1"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.1"
+    "@types/css-tree": "npm:^2.3.10"
+    css-tree: "npm:^3.1.0"
+    nanoid: "npm:^5.1.5"
+  checksum: 10/1e6f12f18f8953f0234dff3bb506b10826eaf1ae04a747f965eac48fba27cd7ed8784f6d1b1a7a1278d0d83aa69e07ef231d5a1ee691d5995dea1d13dcb5da8f
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -1887,6 +1925,7 @@ __metadata:
     "@linaria/postcss-linaria": "npm:^6.3.0"
     "@linaria/react": "npm:^6.3.0"
     "@mdx-js/react": "npm:^3.0.1"
+    "@oddbird/css-anchor-positioning": "npm:^0.6.1"
     "@playwright/test": "npm:^1.43.0"
     "@storybook/addon-a11y": "npm:^9.0.15"
     "@storybook/addon-designs": "npm:^10.0.1"
@@ -2762,6 +2801,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/b4172927cd1387cf037c3ade785ef46c87537b7bc2803d7f6663b4904d0c5d6f726415d1adb2fee4fecb21746738f11336076449265d46be4ce110cc3a8c8436
+  languageName: node
+  linkType: hard
+
+"@types/css-tree@npm:^2.3.10":
+  version: 2.3.10
+  resolution: "@types/css-tree@npm:2.3.10"
+  checksum: 10/d4c8d36eb6fc5ed97fadd64bb501e7cc0d87a40567ed915e2d9797402e8c278fe4f9cd62c97beb9a629682d8c8ed66862ef44dc02c3ad20566d1374c086bc9cd
   languageName: node
   linkType: hard
 
@@ -8191,6 +8237,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10/ac1eb60f615b272bccb0e2b9cd933720dad30bf9708424f691b8113826bb91aca7e9d14ef5d9415a6ba15c266b37817256f58d8ce980c82b0ba3185352565679
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^5.1.5":
+  version: 5.1.5
+  resolution: "nanoid@npm:5.1.5"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 10/6de2d006b51c983be385ef7ee285f7f2a57bd96f8c0ca881c4111461644bd81fafc2544f8e07cb834ca0f3e0f3f676c1fe78052183f008b0809efe6e273119f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context

- We're about to refactor our Menu and Tooltip components, with a focus on enhancing their positioning capability.
- [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning) is not yet supported by all the major browsers (at time of writing, Safari 26 has preview support and Firefox has no support).
- Without CSS anchor positioning, we would have to buy into a significant amount of complexity to implement an equally capable JavaScript positioning solution.
- OddBird provide a [CSS Anchor Positioning polyfill](https://anchor-positioning.oddbird.net/) that allows CSS anchor positioning to be used on browsers that don't yet natively support it.

### This PR

- Implements a new helper, `applyCSSAnchorPositioningPolyfill`, that allows anchor positioning CSS to be polyfilled on browsers that don't support it.

**note:** this is currently intended for internal use only, so it not exported in any way from the library for consumers to leverage directly.