### PR TITLE
feat: Add new `MenuItem` and `AnchorMenuItem` components

### DIFF
--- a/src/core/menu/item/__tests__/anchor-item.test.tsx
+++ b/src/core/menu/item/__tests__/anchor-item.test.tsx
@@ -1,0 +1,7 @@
+import { AnchorMenuItem } from '../anchor-item'
+import { render, screen } from '@testing-library/react'
+
+test('renders a link element', () => {
+  render(<AnchorMenuItem href="https://www.google.com">Menu item</AnchorMenuItem>)
+  expect(screen.getByRole('link')).toBeVisible()
+})

--- a/src/core/menu/item/__tests__/item-base.test.tsx
+++ b/src/core/menu/item/__tests__/item-base.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { StarIcon } from '#src/icons/star'
+import { MenuItemBase } from '../item-base'
+import { Badge } from '#src/core/badge'
+
+test('renders as a button element when `as="button"`', () => {
+  render(<MenuItemBase as="button">Menu item</MenuItemBase>)
+  expect(screen.getByRole('button', { name: 'Menu item' })).toBeVisible()
+})
+
+test('renders as a link element when `as="a"`', () => {
+  render(
+    <MenuItemBase as="a" href="https://fake.url">
+      Menu item
+    </MenuItemBase>,
+  )
+  expect(screen.getByRole('link', { name: 'Menu item' })).toBeVisible()
+})
+
+test('has an `aria-details` attribute', () => {
+  render(<MenuItemBase as="button">Test Button</MenuItemBase>)
+  expect(screen.getByRole('button')).toHaveAttribute('aria-details')
+})
+
+test('is ARIA disabled when `disabled` is true', () => {
+  render(
+    <MenuItemBase as="button" disabled>
+      Menu item
+    </MenuItemBase>,
+  )
+  expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+})
+
+describe('when `aria-disabled="true"`', () => {
+  test('does not call the consumer-supplied `onClick` handler', () => {
+    const onClick = vi.fn()
+
+    render(
+      <MenuItemBase as="button" aria-disabled="true" onClick={onClick}>
+        Button
+      </MenuItemBase>,
+    )
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  test("prevents the event's default action", () => {
+    // NOTE: we have to spy on the `preventDefault` method on the `Event` prototype because our onClick handler
+    // will not be called when `aria-disabled` is true.
+    const preventDefaultSpy = vi.spyOn(Event.prototype, 'preventDefault')
+
+    render(
+      <MenuItemBase as="button" aria-disabled="true">
+        Button
+      </MenuItemBase>,
+    )
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  test("stops the event's propagation", () => {
+    const parentOnClick = vi.fn()
+
+    render(
+      // NOTE: we attach the onClick handler to the parent div AND the button itself, to allow us to assert the
+      <div onClick={parentOnClick}>
+        <MenuItemBase as="button" aria-disabled="true">
+          Button
+        </MenuItemBase>
+      </div>,
+    )
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(parentOnClick).not.toHaveBeenCalled()
+  })
+})
+
+test('forwards additional props to the underlying element', () => {
+  render(
+    <MenuItemBase as="button" data-testid="my-button">
+      Test Button
+    </MenuItemBase>,
+  )
+  expect(screen.getByTestId('my-button')).toBeVisible()
+})
+
+test('can display a badge', () => {
+  render(
+    <MenuItemBase
+      as="button"
+      badge={
+        <Badge colour="success" data-testid="badge">
+          New
+        </Badge>
+      }
+    >
+      Test Button
+    </MenuItemBase>,
+  )
+  expect(screen.getByTestId('badge')).toBeVisible()
+})
+
+test('can display supplementary information', () => {
+  render(
+    <MenuItemBase as="button" supplementaryInfo="Supplementary info">
+      Test Button
+    </MenuItemBase>,
+  )
+  expect(screen.getByText('Supplementary info')).toBeVisible()
+})
+
+test('can display an icon on the left', () => {
+  render(
+    <MenuItemBase as="button" iconLeft={<StarIcon data-testid="left-icon" />}>
+      Test Button
+    </MenuItemBase>,
+  )
+  expect(screen.getByTestId('left-icon')).toBeVisible()
+})
+
+test('can display an icon on the right', () => {
+  render(
+    <MenuItemBase as="button" iconRight={<StarIcon data-testid="right-icon" />}>
+      Test Button
+    </MenuItemBase>,
+  )
+  expect(screen.getByTestId('right-icon')).toBeVisible()
+})
+
+test('can display icons on both the left and right', () => {
+  render(
+    <MenuItemBase
+      as="button"
+      iconLeft={<StarIcon data-testid="left-icon" />}
+      iconRight={<StarIcon data-testid="right-icon" />}
+    >
+      Test Button
+    </MenuItemBase>,
+  )
+  expect(screen.getByTestId('left-icon')).toBeVisible()
+  expect(screen.getByTestId('right-icon')).toBeVisible()
+})

--- a/src/core/menu/item/__tests__/item.test.tsx
+++ b/src/core/menu/item/__tests__/item.test.tsx
@@ -1,0 +1,7 @@
+import { MenuItem } from '../item'
+import { render, screen } from '@testing-library/react'
+
+test('renders a button element', () => {
+  render(<MenuItem>Menu item</MenuItem>)
+  expect(screen.getByRole('button')).toBeVisible()
+})

--- a/src/core/menu/item/anchor-item.tsx
+++ b/src/core/menu/item/anchor-item.tsx
@@ -1,0 +1,21 @@
+import { MenuItemBase } from './item-base'
+
+import type { AnchorHTMLAttributes } from 'react'
+import type { CommonMenuItemBaseProps } from './item-base'
+
+export interface MenuAnchorItemProps extends CommonMenuItemBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Whether the menu item represents the current page */
+  'aria-current'?: 'page' | false
+  /** The URL to which this menu anchor item navigates */
+  href: string
+}
+
+/**
+ * A menu item component that renders as an anchor element for navigation.
+ *
+ * Use `Menu.AnchorItem` when you need menu item styling but want to navigate to a URL.
+ * Use `Menu.Item` when the action needs to occur on click.
+ */
+export function AnchorMenuItem(props: MenuAnchorItemProps) {
+  return <MenuItemBase as="a" {...props} />
+}

--- a/src/core/menu/item/index.ts
+++ b/src/core/menu/item/index.ts
@@ -1,0 +1,4 @@
+export * from './anchor-item'
+export * from './item'
+export * from './item-base'
+export * from './styles'

--- a/src/core/menu/item/item-base.tsx
+++ b/src/core/menu/item/item-base.tsx
@@ -1,0 +1,115 @@
+import { cx } from '@linaria/core'
+import {
+  elMenuItem,
+  ElMenuItemBadgeContainer,
+  ElMenuItemContentContainer,
+  ElMenuItemIconContainer,
+  ElMenuItemLabel,
+  ElMenuItemLabelText,
+  ElMenuItemSupplementaryInfo,
+} from './styles'
+import { useCallback, useId } from 'react'
+
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+
+export interface CommonMenuItemBaseProps {
+  /**
+   * Whether the menu item is disabled. This can be used to make the menu item appear disabled to users, but still be
+   * focusable. ARIA disabled menu items, whether they are button or anchor DOM elements, will ignore click events.
+   * Using `aria-disabled` is preferred when the menu item should still be focusable while it's disabled; for example,
+   * to allow a tooltip to be displayed that explains why the menu item is disabled.
+   */
+  'aria-disabled'?: boolean | 'true' | 'false'
+  /** Badge to display next to the primary text */
+  badge?: ReactNode
+  /** The menu item's primary label */
+  children?: ReactNode
+  /** Icon to display on the left side */
+  iconLeft?: ReactNode
+  /** Icon to display on the right side */
+  iconRight?: ReactNode
+  /** Secondary description text */
+  supplementaryInfo?: ReactNode
+}
+
+export interface MenuItemAsButtonProps extends CommonMenuItemBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
+  'aria-checked'?: boolean
+  as: 'button'
+}
+
+export interface MenuItemAsAnchorProps extends CommonMenuItemBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+  'aria-current'?: 'page' | false
+  as: 'a'
+  href: string
+}
+
+export type MenuItemBaseProps = MenuItemAsButtonProps | MenuItemAsAnchorProps
+
+/**
+ * A polymorphic menu item foundation that can render as either a button or anchor element.
+ * This component is used internally by the `Menu.Item` and `Menu.AnchorItem` components and
+ * should not be used directly by consumers.
+ */
+export function MenuItemBase({
+  'aria-disabled': ariaDisabled,
+  as: Element,
+  badge,
+  className,
+  children,
+  supplementaryInfo,
+  iconLeft,
+  iconRight,
+  onClick,
+  ...rest
+}: MenuItemBaseProps) {
+  const labelId = useId()
+  const badgeId = useId()
+  const supplementaryInfoId = useId()
+
+  const handleClick = useCallback<MouseEventHandler<HTMLElement>>(
+    (event) => {
+      const element = event.currentTarget
+      // NOTE: Anchor elements CANNOT be disabled using the native `disabled` attribute, so we allow the
+      // `aria-disabled` attribute to disable them instead. Since click events will still be fired when
+      // `aria-disabled='true'`, we need to prevent any default action for the menu item from occurring, stop it
+      // propagating to ancestors and avoid calling the consumer-supplied `onClick` callback.
+      if (element.getAttribute('aria-disabled') === 'true') {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+
+      // NOTE: We use a type assertion here to avoid having to narrow the type of `event` based on the specific
+      // `Element` type.
+      onClick?.(event as any)
+    },
+    [onClick],
+  )
+
+  return (
+    <Element
+      // NOTE: We use a type assertion here to avoid having to narrow the type of `rest` to the
+      // specific `Element` type.
+      {...(rest as HTMLAttributes<HTMLElement>)}
+      // NOTE: We use `aria-details` because our supplementary info may contain structured information
+      // and `aria-describedby` expects the referenced content to be plain text.
+      aria-details={`${badgeId} ${supplementaryInfoId}`}
+      aria-disabled={!!rest['disabled'] || !!ariaDisabled}
+      aria-labelledby={labelId}
+      className={cx(elMenuItem, className)}
+      onClick={handleClick}
+    >
+      {iconLeft && <ElMenuItemIconContainer aria-hidden>{iconLeft}</ElMenuItemIconContainer>}
+      <ElMenuItemContentContainer>
+        <ElMenuItemLabel>
+          {children && <ElMenuItemLabelText id={labelId}>{children}</ElMenuItemLabelText>}
+          {badge && <ElMenuItemBadgeContainer id={badgeId}>{badge}</ElMenuItemBadgeContainer>}
+        </ElMenuItemLabel>
+        {supplementaryInfo && (
+          <ElMenuItemSupplementaryInfo id={supplementaryInfoId}>{supplementaryInfo}</ElMenuItemSupplementaryInfo>
+        )}
+      </ElMenuItemContentContainer>
+      {iconRight && <ElMenuItemIconContainer aria-hidden>{iconRight}</ElMenuItemIconContainer>}
+    </Element>
+  )
+}

--- a/src/core/menu/item/item.stories.tsx
+++ b/src/core/menu/item/item.stories.tsx
@@ -1,0 +1,177 @@
+import { AnchorMenuItem } from './anchor-item'
+import { Badge } from '#src/core/badge'
+import { ExportIcon } from '#src/icons/export'
+import { MenuItem } from './item'
+import { PropertyIcon } from '#src/icons/property'
+import { StarIcon } from '#src/icons/star'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Menu/Item',
+  component: MenuItem,
+  subcomponents: { AnchorMenuItem },
+  argTypes: {
+    'aria-checked': {
+      control: 'boolean',
+    },
+    'aria-disabled': {
+      control: 'boolean',
+    },
+    children: {
+      control: 'text',
+    },
+    badge: {
+      control: 'radio',
+      options: ['None', 'New'],
+      mapping: {
+        None: null,
+        New: (
+          <Badge colour="success" variant="reversed">
+            New
+          </Badge>
+        ),
+      },
+    },
+    iconLeft: {
+      control: 'select',
+      options: ['None', 'Export', 'Property', 'Star'],
+      mapping: {
+        None: undefined,
+        Export: <ExportIcon />,
+        Property: <PropertyIcon />,
+        Star: <StarIcon />,
+      },
+    },
+    iconRight: {
+      control: 'select',
+      options: ['None', 'Export', 'Property', 'Star'],
+      mapping: {
+        None: undefined,
+        Export: <ExportIcon />,
+        Property: <PropertyIcon />,
+        Star: <StarIcon />,
+      },
+    },
+    supplementaryInfo: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof MenuItem>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    'aria-checked': false,
+    'aria-disabled': false,
+    children: 'Menu item',
+    disabled: false,
+  },
+}
+
+/**
+ * A badge can be placed next to the menu item's label. The badge's content will be used for the accessible
+ * description of the menu item.
+ */
+export const Badges: Story = {
+  args: {
+    ...Example.args,
+    badge: 'New',
+  },
+}
+
+/**
+ * Supplementary info can be included to provide further information about the menu item.
+ */
+export const SupplementaryInfo: Story = {
+  args: {
+    ...Example.args,
+    supplementaryInfo: 'Supplementary info',
+  },
+}
+
+/**
+ * Icons can be placed on the left or right side of the menu item, or both.
+ */
+export const Icons: Story = {
+  args: {
+    ...Example.args,
+    iconLeft: 'Property',
+    iconRight: 'Export',
+  },
+}
+
+/**
+ * Badges, supplementary info and icons can all be used together for detail-rich menu items.
+ */
+export const Everything: Story = {
+  args: {
+    ...Badges.args,
+    ...SupplementaryInfo.args,
+    ...Icons.args,
+  },
+}
+
+/**
+ * Menu items can be in a selected state to indicate the current active item.
+ */
+export const Selected: Story = {
+  args: {
+    ...Everything.args,
+    'aria-checked': true,
+  },
+}
+
+/**
+ * Menu items can be disabled using `aria-disabled` or `disabled`.
+ */
+export const Disabled: Story = {
+  args: {
+    ...Everything.args,
+    disabled: true,
+  },
+}
+
+/**
+ * Menu items should generally have short and concise content, but the text will flow to multiple lines
+ * if it cannot fit in the available space.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Everything.args,
+    children: 'Menu item long label that won’t fit in one line',
+    badge: <Badge colour="neutral">Badge with long label</Badge>,
+    supplementaryInfo: 'Secondary info long description that won’t fit in one line',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '277px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * `Menu.AnchorItem` is identical to `Menu.Item`, except it renders as an `<a>` element for navigation.
+ *
+ * Importantly, anchor elements do not support the `disabled` prop; to disable an anchor-based menu item,
+ * use `aria-disabled="true"` instead.
+ */
+export const Anchors: StoryObj<typeof AnchorMenuItem> = {
+  args: {
+    'aria-current': false,
+    'aria-selected': false,
+    'aria-disabled': false,
+    badge: 'New',
+    children: 'Agentbox',
+    href: '#',
+    iconLeft: 'Property',
+    iconRight: 'Export',
+    supplementaryInfo: 'Property sales and more',
+  },
+  render: (args) => <AnchorMenuItem {...args} />,
+}

--- a/src/core/menu/item/item.tsx
+++ b/src/core/menu/item/item.tsx
@@ -1,0 +1,24 @@
+import { MenuItemBase } from './item-base'
+
+import type { ButtonHTMLAttributes } from 'react'
+import type { CommonMenuItemBaseProps } from './item-base'
+
+export interface MenuItemProps extends CommonMenuItemBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Whether the menu item is selected/active */
+  'aria-checked'?: boolean
+  /**
+   * Whether the menu item is disabled or not. Unlike `aria-disabled`, menu items disabled with this prop will not be
+   * focusable or interactive.
+   */
+  disabled?: boolean
+}
+
+/**
+ * A menu item component that renders as a button element for interactive actions.
+ *
+ * Use `Menu.Item` when the action needs to occur on click.
+ * Use `Menu.AnchorItem` when you need menu item styling but want to navigate to a URL.
+ */
+export function MenuItem(props: MenuItemProps) {
+  return <MenuItemBase as="button" {...props} />
+}

--- a/src/core/menu/item/styles.ts
+++ b/src/core/menu/item/styles.ts
@@ -1,0 +1,135 @@
+import { css } from '@linaria/core'
+import { styled } from '@linaria/react'
+import { font } from '../../text'
+
+export const elMenuItem = css`
+  box-sizing: border-box;
+
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  width: 100%;
+
+  border: none;
+  border-radius: var(--comp-menu-border-radius);
+  background: var(--comp-menu-colour-fill-default);
+
+  text-align: start;
+  text-decoration: none;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+
+  &:hover {
+    background: var(--comp-menu-colour-fill-hover);
+  }
+
+  &[aria-disabled='true'],
+  &:disabled {
+    cursor: not-allowed;
+    background: var(--comp-menu-colour-fill-default);
+  }
+
+  &[aria-checked='true'],
+  &[aria-current='page'] {
+    background: var(--comp-menu-colour-fill-highlighted);
+  }
+`
+
+export const ElMenuItemIconContainer = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: var(--icon_size-m);
+  height: var(--icon_size-m);
+
+  /* aka left icon */
+  &:first-of-type {
+    color: var(--comp-menu-colour-icon-default-left);
+
+    [aria-checked='true'] &,
+    [aria-current='page'] & {
+      color: var(--comp-menu-colour-icon-default-action);
+
+      &:hover {
+        color: var(--comp-menu-colour-icon-hover-action);
+      }
+    }
+  }
+
+  /* aka right icon */
+  &:last-of-type {
+    color: var(--comp-menu-colour-icon-default-right);
+  }
+
+  /* Disabled styles come last to ensure they override other state-based styles like hover */
+  [aria-disabled='true'] &,
+  :disabled & {
+    &:first-of-type {
+      color: var(--comp-menu-colour-icon-disabled-left);
+    }
+    &:last-of-type {
+      color: var(--comp-menu-colour-icon-disabled-right);
+    }
+  }
+`
+
+export const ElMenuItemContentContainer = styled.span`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--spacing-1);
+  align-items: start;
+  width: 100%;
+`
+
+export const ElMenuItemLabel = styled.span`
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--spacing-2);
+  align-items: center;
+  justify-content: start;
+  width: 100%;
+`
+
+export const ElMenuItemLabelText = styled.span`
+  ${font('sm', 'regular')}
+  color: var(--comp-menu-colour-text-default-primary);
+
+  [aria-checked='true'] &,
+  [aria-current='page'] & {
+    color: var(--comp-menu-colour-text-default-action);
+
+    &:hover {
+      color: var(--comp-menu-colour-text-hover-action);
+    }
+  }
+
+  [aria-disabled='true'] &,
+  :disabled & {
+    color: var(--comp-menu-colour-text-disabled-primary);
+  }
+`
+
+export const ElMenuItemBadgeContainer = styled.span`
+  /*
+   * NOTE: This element allows us to attached an ID that is used to describe the menu item.
+   * Further, Linaria currently has a bug where it falls over for empty styled elements/classes.
+   * Hence, why this comment is within the template string.
+   */
+`
+
+export const ElMenuItemSupplementaryInfo = styled.span`
+  ${font('xs', 'regular')}
+  color: var(--comp-menu-colour-text-default-secondary);
+
+  [aria-disabled='true'] &,
+  :disabled & {
+    color: var(--comp-menu-colour-text-disabled-secondary);
+  }
+`

--- a/src/deprecated/breadcrumb/breadcrumb.mdx
+++ b/src/deprecated/breadcrumb/breadcrumb.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks'
-import { BreadCrumb } from './index'
+import { DeprecatedBreadCrumb } from './index'
 import { RenderHtmlMarkup } from '../../storybook/render-html-markup'
 import * as BreadcrumbStories from './breadcrumb.stories'
 


### PR DESCRIPTION
### Context

- The existing Menu component is partially complete, but has a number of issues related to it (focus outline of items is clipped, menu item prop interface incomplete, inadequate positioning w.r.t anchor, reliant on div container which interferes with the layout of the trigger and more)
- We need to deliver a more solid foundation for Menu's while also supporting the updated Menu design requirements.
- To do this, we'll deprecate the existing Menu and implement a new one. This will allow consumers (including other Elements components) to gradually migrate to the new version.
- Previous work in this series:
  - #636 

### This PR

- Adds new `MenuItem` and `AnchorMenuItem` components.

<img width="822" height="721" alt="Screenshot 2025-07-24 at 3 06 08 pm" src="https://github.com/user-attachments/assets/76fe1a2d-954b-4099-a200-c415dabfbde6" />
<img width="824" height="630" alt="Screenshot 2025-07-24 at 3 06 18 pm" src="https://github.com/user-attachments/assets/a2c28957-8926-44e2-964b-abff4a1742e3" />
<img width="821" height="636" alt="Screenshot 2025-07-24 at 3 06 24 pm" src="https://github.com/user-attachments/assets/4d759daf-27e5-4e7f-8d6c-7303bb0d727c" />
<img width="819" height="698" alt="Screenshot 2025-07-24 at 3 06 30 pm" src="https://github.com/user-attachments/assets/f32d8c9b-f98a-4737-aa8c-abfcf6ffdc54" />
<img width="821" height="239" alt="Screenshot 2025-07-24 at 3 06 35 pm" src="https://github.com/user-attachments/assets/3b13e9ed-1225-4dbb-8595-ae6fd2500399" />
