### PR TITLE
feat: Add new `MenuGroup` component

### DIFF
--- a/src/core/menu/group/__tests__/menu-group.test.tsx
+++ b/src/core/menu/group/__tests__/menu-group.test.tsx
@@ -1,0 +1,38 @@
+import { MenuGroup } from '../menu-group'
+import { render, screen } from '@testing-library/react'
+
+test('renders a group element', () => {
+  render(<MenuGroup>Group content</MenuGroup>)
+  expect(screen.getByRole('group')).toBeVisible()
+})
+
+test('renders label when provided', () => {
+  render(<MenuGroup label="Test Label">Group content</MenuGroup>)
+  expect(screen.getByRole('group', { name: 'Test Label' })).toBeVisible()
+})
+
+test('does not render label element when label is not provided', () => {
+  const { container } = render(<MenuGroup>Group content</MenuGroup>)
+
+  // Check that no label element exists.
+  //
+  // NOTE: we can't use ElMenuGroupLabelContainer directly as it won't be interpolated to
+  // class name correctly. That only happens when used with Linaria utilities
+  const labelElement = container.querySelector('.el-menu-group-label-container')
+  expect(labelElement).toBeNull()
+})
+
+test('does not wire-up `aria-labelledby` attribute when `aria-label` is provided', () => {
+  render(<MenuGroup aria-label="test">Group content</MenuGroup>)
+  expect(screen.getByRole('group')).not.toHaveAttribute('aria-labelledby')
+})
+
+test('forwards additional props to the group element', () => {
+  render(<MenuGroup data-testid="custom-group">Group content</MenuGroup>)
+  expect(screen.getByTestId('custom-group')).toBeVisible()
+})
+
+test('allows role override', () => {
+  render(<MenuGroup role="list">Group content</MenuGroup>)
+  expect(screen.getByRole('list')).toBeVisible()
+})

--- a/src/core/menu/group/index.ts
+++ b/src/core/menu/group/index.ts
@@ -1,0 +1,2 @@
+export * from './menu-group'
+export * from './styles'

--- a/src/core/menu/group/menu-group.stories.tsx
+++ b/src/core/menu/group/menu-group.stories.tsx
@@ -1,0 +1,94 @@
+import { Badge } from '#src/core/badge'
+import { MenuGroup } from './menu-group'
+import { AnchorMenuItem, MenuItem } from '../item'
+import { StarIcon } from '#src/icons/star'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Core/Menu/Group',
+  component: MenuGroup,
+  argTypes: {
+    children: {
+      control: 'select',
+      options: ['Simple', 'Fancy'],
+      mapping: {
+        Simple: (
+          <>
+            <AnchorMenuItem href={href}>Item 1</AnchorMenuItem>
+            <MenuItem>Item 2</MenuItem>
+            <MenuItem>Item 3</MenuItem>
+          </>
+        ),
+        Fancy: (
+          <>
+            <AnchorMenuItem
+              badge={
+                <Badge colour="success" variant="reversed">
+                  Badge
+                </Badge>
+              }
+              href={href}
+              iconLeft={<StarIcon />}
+              supplementaryInfo="Supplementary info"
+            >
+              Item 1
+            </AnchorMenuItem>
+            <MenuItem
+              iconLeft={<StarIcon />}
+              badge={
+                <Badge colour="success" variant="reversed">
+                  Badge
+                </Badge>
+              }
+              supplementaryInfo="Supplementary info"
+            >
+              Item 2
+            </MenuItem>
+            <MenuItem
+              iconLeft={<StarIcon />}
+              badge={
+                <Badge colour="success" variant="reversed">
+                  Badge
+                </Badge>
+              }
+              supplementaryInfo="Supplementary info"
+            >
+              Item 3
+            </MenuItem>
+          </>
+        ),
+      },
+    },
+    label: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof MenuGroup>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * A basic menu group with interactive menu items. Use `MenuItem` for menu items that perform
+ * actions when clicked.
+ */
+export const Example: Story = {
+  args: {
+    children: 'Simple',
+    label: 'Actions',
+  },
+}
+
+/**
+ * Menu groups can be created without a label.
+ */
+export const NoLabel: Story = {
+  args: {
+    'aria-label': 'Actions',
+    children: 'Simple',
+  },
+}

--- a/src/core/menu/group/menu-group.tsx
+++ b/src/core/menu/group/menu-group.tsx
@@ -1,0 +1,28 @@
+import { ElMenuGroup, ElMenuGroupLabelContainer } from './styles'
+import { useId, type HTMLAttributes, type ReactNode } from 'react'
+
+interface MenuGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Optional label for the menu group. Considered mandatory when there is no visual label defined
+   * by `label`.
+   */
+  'aria-label'?: string
+  /** A collection of menu items, typically `MenuGroup.Item` or `MenuGroup.AnchorItem` components */
+  children: ReactNode
+  /** Optional label for the menu group */
+  label?: ReactNode
+}
+
+/**
+ * A menu group component that provides semantic grouping of menu items with an optional title.
+ * Does not render items within a list structure, as not all menu items have to exist within a group.
+ */
+export function MenuGroup({ 'aria-label': ariaLabel, children, label, role = 'group', ...rest }: MenuGroupProps) {
+  const labelId = useId()
+  return (
+    <ElMenuGroup {...rest} aria-label={ariaLabel} aria-labelledby={ariaLabel ? undefined : labelId} role={role}>
+      {label && <ElMenuGroupLabelContainer id={labelId}>{label}</ElMenuGroupLabelContainer>}
+      {children}
+    </ElMenuGroup>
+  )
+}

--- a/src/core/menu/group/styles.ts
+++ b/src/core/menu/group/styles.ts
@@ -1,0 +1,18 @@
+import { font } from '#src/core/text'
+import { styled } from '@linaria/react'
+
+export const ElMenuGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding-inline: var(--spacing-2);
+`
+
+export const ElMenuGroupLabelContainer = styled.div`
+  ${font('2xs', 'bold')}
+  text-transform: uppercase;
+
+  color: var(--comp-menu-colour-text-group_title, #9faebc);
+  padding-block: var(--spacing-2);
+  padding-inline: var(--spacing-3);
+`

--- a/src/core/menu/item/__tests__/anchor-item.test.tsx
+++ b/src/core/menu/item/__tests__/anchor-item.test.tsx
@@ -1,7 +1,7 @@
 import { AnchorMenuItem } from '../anchor-item'
 import { render, screen } from '@testing-library/react'
 
-test('renders a link element', () => {
+test('renders a menuitem element', () => {
   render(<AnchorMenuItem href="https://www.google.com">Menu item</AnchorMenuItem>)
-  expect(screen.getByRole('link')).toBeVisible()
+  expect(screen.getByRole('menuitem')).toBeVisible()
 })

--- a/src/core/menu/item/__tests__/item-base.test.tsx
+++ b/src/core/menu/item/__tests__/item-base.test.tsx
@@ -3,23 +3,23 @@ import { StarIcon } from '#src/icons/star'
 import { MenuItemBase } from '../item-base'
 import { Badge } from '#src/core/badge'
 
-test('renders as a button element when `as="button"`', () => {
+test('renders as a menuitem element when `as="button"`', () => {
   render(<MenuItemBase as="button">Menu item</MenuItemBase>)
-  expect(screen.getByRole('button', { name: 'Menu item' })).toBeVisible()
+  expect(screen.getByRole('menuitem', { name: 'Menu item' })).toBeVisible()
 })
 
-test('renders as a link element when `as="a"`', () => {
+test('renders as a menuitem element when `as="a"`', () => {
   render(
     <MenuItemBase as="a" href="https://fake.url">
       Menu item
     </MenuItemBase>,
   )
-  expect(screen.getByRole('link', { name: 'Menu item' })).toBeVisible()
+  expect(screen.getByRole('menuitem', { name: 'Menu item' })).toBeVisible()
 })
 
 test('has an `aria-details` attribute', () => {
   render(<MenuItemBase as="button">Test Button</MenuItemBase>)
-  expect(screen.getByRole('button')).toHaveAttribute('aria-details')
+  expect(screen.getByRole('menuitem')).toHaveAttribute('aria-details')
 })
 
 test('is ARIA disabled when `disabled` is true', () => {
@@ -28,7 +28,7 @@ test('is ARIA disabled when `disabled` is true', () => {
       Menu item
     </MenuItemBase>,
   )
-  expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+  expect(screen.getByRole('menuitem')).toHaveAttribute('aria-disabled', 'true')
 })
 
 describe('when `aria-disabled="true"`', () => {
@@ -40,7 +40,7 @@ describe('when `aria-disabled="true"`', () => {
         Button
       </MenuItemBase>,
     )
-    const button = screen.getByRole('button')
+    const button = screen.getByRole('menuitem')
     fireEvent.click(button)
 
     expect(onClick).not.toHaveBeenCalled()
@@ -56,7 +56,7 @@ describe('when `aria-disabled="true"`', () => {
         Button
       </MenuItemBase>,
     )
-    const button = screen.getByRole('button')
+    const button = screen.getByRole('menuitem')
     fireEvent.click(button)
 
     expect(preventDefaultSpy).toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('when `aria-disabled="true"`', () => {
         </MenuItemBase>
       </div>,
     )
-    const button = screen.getByRole('button')
+    const button = screen.getByRole('menuitem')
     fireEvent.click(button)
 
     expect(parentOnClick).not.toHaveBeenCalled()

--- a/src/core/menu/item/__tests__/item.test.tsx
+++ b/src/core/menu/item/__tests__/item.test.tsx
@@ -1,7 +1,7 @@
 import { MenuItem } from '../item'
 import { render, screen } from '@testing-library/react'
 
-test('renders a button element', () => {
+test('renders a menuitem element', () => {
   render(<MenuItem>Menu item</MenuItem>)
-  expect(screen.getByRole('button')).toBeVisible()
+  expect(screen.getByRole('menuitem')).toBeVisible()
 })

--- a/src/core/menu/item/item-base.tsx
+++ b/src/core/menu/item/item-base.tsx
@@ -56,10 +56,11 @@ export function MenuItemBase({
   badge,
   className,
   children,
-  supplementaryInfo,
   iconLeft,
   iconRight,
   onClick,
+  role = 'menuitem',
+  supplementaryInfo,
   ...rest
 }: MenuItemBaseProps) {
   const labelId = useId()
@@ -98,6 +99,7 @@ export function MenuItemBase({
       aria-labelledby={labelId}
       className={cx(elMenuItem, className)}
       onClick={handleClick}
+      role={role}
     >
       {iconLeft && <ElMenuItemIconContainer aria-hidden>{iconLeft}</ElMenuItemIconContainer>}
       <ElMenuItemContentContainer>

--- a/src/core/menu/item/item.stories.tsx
+++ b/src/core/menu/item/item.stories.tsx
@@ -164,7 +164,6 @@ export const Overflow: Story = {
 export const Anchors: StoryObj<typeof AnchorMenuItem> = {
   args: {
     'aria-current': false,
-    'aria-selected': false,
     'aria-disabled': false,
     badge: 'New',
     children: 'Agentbox',
@@ -172,6 +171,12 @@ export const Anchors: StoryObj<typeof AnchorMenuItem> = {
     iconLeft: 'Property',
     iconRight: 'Export',
     supplementaryInfo: 'Property sales and more',
+  },
+  argTypes: {
+    'aria-current': {
+      control: 'radio',
+      options: ['page', false],
+    },
   },
   render: (args) => <AnchorMenuItem {...args} />,
 }

--- a/src/core/menu/item/item.tsx
+++ b/src/core/menu/item/item.tsx
@@ -8,7 +8,7 @@ export interface MenuItemProps extends CommonMenuItemBaseProps, ButtonHTMLAttrib
   'aria-checked'?: boolean
   /**
    * Whether the menu item is disabled or not. Unlike `aria-disabled`, menu items disabled with this prop will not be
-   * focusable or interactive.
+   * focusable or interactive. Typically, disabled menu items should be focusable, so `aria-disabled` is preferred.
    */
   disabled?: boolean
 }

--- a/src/core/menu/item/styles.ts
+++ b/src/core/menu/item/styles.ts
@@ -23,6 +23,10 @@ export const elMenuItem = css`
   &:focus-visible {
     outline: var(--border-width-double) solid var(--colour-border-focus);
     outline-offset: var(--border-width-default);
+
+    /* NOTE: Menu items sit flush against each other, so we need to ensure the focus outline
+     * sits above subsequent items */
+    z-index: 1;
   }
 
   &:hover {


### PR DESCRIPTION
### Context

- The existing Menu component is partially complete, but has a number of issues related to it (focus outline of items is clipped, menu item prop interface incomplete, inadequate positioning w.r.t anchor, reliant on div container which interferes with the layout of the trigger and more)
- We need to deliver a more solid foundation for Menu's while also supporting the updated Menu design requirements.
- To do this, we'll deprecate the existing Menu and implement a new one. This will allow consumers (including other Elements components) to gradually migrate to the new version.
- Previous work in this series:
  - #636 
  - #637 

### This PR

- Adds new `MenuGroup` component

**note:** We have not taken the approach of rendering the menu group's items as list items in a list, as we have done for `SideBarSubmenu`. This is because the [MDN docs for the menu role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role) suggest the `<li>` elements receive `role="presentation"`; as such, it doesn't seem beneficial to increase the complexity of our components (e.g. having separate `Menu.Item` and `Menu.GroupItem` components that wrap the underlying MenuItem in an `<li>`).

<img width="818" height="716" alt="Screenshot 2025-07-28 at 11 19 06 am" src="https://github.com/user-attachments/assets/e3e3a83e-0fe5-461c-be05-48aba105c09a" />
<img width="816" height="593" alt="Screenshot 2025-07-28 at 11 19 12 am" src="https://github.com/user-attachments/assets/7d2b1418-3de5-42af-9b1d-7933243979e5" />
