### PR TITLE
feat: Add new Popover utility component

### DIFF
--- a/src/polyfills/css-anchor-positioning/__tests__/is-css-anchor-positioning-supported.test.ts
+++ b/src/polyfills/css-anchor-positioning/__tests__/is-css-anchor-positioning-supported.test.ts
@@ -1,14 +1,15 @@
 import { isCSSAnchorPositioningSupported } from '../is-css-anchor-positioning-supported'
 
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
 test('returns true when CSS anchor positioning is supported', () => {
-  Object.defineProperty(document.documentElement.style, 'anchorName', {
-    value: '',
-    configurable: true,
-  })
+  vi.stubGlobal('CSS', { supports: () => true })
   expect(isCSSAnchorPositioningSupported()).toBe(true)
 })
 
 test('returns false when CSS anchor positioning is NOT supported', () => {
-  delete (document.documentElement.style as any).anchorName
+  vi.stubGlobal('CSS', { supports: () => false })
   expect(isCSSAnchorPositioningSupported()).toBe(false)
 })

--- a/src/polyfills/css-anchor-positioning/is-css-anchor-positioning-supported.ts
+++ b/src/polyfills/css-anchor-positioning/is-css-anchor-positioning-supported.ts
@@ -3,5 +3,5 @@
  * @returns true if CSS anchor positioning is supported, false otherwise
  */
 export function isCSSAnchorPositioningSupported() {
-  return 'anchorName' in document.documentElement.style
+  return CSS.supports('anchor-name', '--myanchor')
 }

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -21,6 +21,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore!:** Deprecate `Menu` component. It is still available, but is now called `DeprecatedMenu`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from
 - **chore:** Update design tokens to match latest changes in Figma
 - **chore!:** Renamed `ElipsisIcon` to `MoreVertIcon` to align with Design System changes.
+- **feat:** Add new `Popover` utility component. See [Popover](?path=/docs/utils-popover--docs) for details.
 
 ### **5.0.0-beta.39 - 23/07/25**
 

--- a/src/utils/popover/__tests__/__snapshots__/map-placement-to-css.test.ts.snap
+++ b/src/utils/popover/__tests__/__snapshots__/map-placement-to-css.test.ts.snap
@@ -1,0 +1,97 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`produces correct CSS for the "bottom" placement 1`] = `
+"
+        top: anchor(bottom);
+        justify-self: anchor-center;
+        margin-block: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "bottom-end" placement 1`] = `
+"
+        top: anchor(bottom);
+        right: anchor(right);
+        margin-block: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "bottom-start" placement 1`] = `
+"
+        top: anchor(bottom);
+        left: anchor(left);
+        margin-block: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "left" placement 1`] = `
+"
+        align-self: anchor-center;
+        right: anchor(left);
+        margin-inline: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "left-end" placement 1`] = `
+"
+        bottom: anchor(bottom);
+        right: anchor(left);
+        margin-inline: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "left-start" placement 1`] = `
+"
+        top: anchor(top);
+        right: anchor(left);
+        margin-inline: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "right" placement 1`] = `
+"
+        align-self: anchor-center;
+        left: anchor(right);
+        margin-inline: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "right-end" placement 1`] = `
+"
+        bottom: anchor(bottom);
+        left: anchor(right);
+        margin-inline: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "right-start" placement 1`] = `
+"
+        top: anchor(top);
+        left: anchor(right);
+        margin-inline: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "top" placement 1`] = `
+"
+        bottom: anchor(top);
+        justify-self: anchor-center;
+        margin-block: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "top-end" placement 1`] = `
+"
+        bottom: anchor(top);
+        right: anchor(right);
+        margin-block: var(--fake-gap);
+      "
+`;
+
+exports[`produces correct CSS for the "top-start" placement 1`] = `
+"
+        bottom: anchor(top);
+        left: anchor(left);
+        margin-block: var(--fake-gap);
+      "
+`;

--- a/src/utils/popover/__tests__/build-anchor-positioning-css.test.ts
+++ b/src/utils/popover/__tests__/build-anchor-positioning-css.test.ts
@@ -1,0 +1,45 @@
+import { buildAnchorPositioningCSS } from '../build-anchor-positioning-css'
+import { mapPlacementToCSS } from '../map-placement-to-css'
+
+vi.mock('../map-placement-to-css')
+vi.mocked(mapPlacementToCSS).mockReturnValue('/* mocked positioning css */')
+
+beforeEach(() => {
+  vi.mocked(mapPlacementToCSS).mockClear()
+})
+
+test('calls mapPlacementToCSS', () => {
+  buildAnchorPositioningCSS({
+    anchorElementId: 'anchor',
+    gap: 'var(--fake-gap)',
+    placement: 'top-start',
+    positionedElementId: 'positioned-element',
+    positionTryFallbacks: 'flip-block',
+  })
+
+  expect(mapPlacementToCSS).toHaveBeenCalledWith('top-start', 'var(--fake-gap)')
+})
+
+test('produces CSS for the anchor element and positioned element', () => {
+  expect(
+    buildAnchorPositioningCSS({
+      anchorElementId: ':r1:', // simulate a `useId` string
+      gap: 'var(--fake-gap)',
+      placement: 'top-start',
+      positionedElementId: 'positioned-element',
+      positionTryFallbacks: 'flip-block, flip-inline',
+    }),
+  ).toMatchInlineSnapshot(`
+    "
+        #\\:r1\\: {
+          anchor-name: --\\:r1\\:;
+        }
+
+        #positioned-element {
+          position-anchor: --\\:r1\\:;
+          position-try-fallbacks: flip-block, flip-inline;
+          /* mocked positioning css */
+        }
+      "
+  `)
+})

--- a/src/utils/popover/__tests__/get-popover-trigger-props.test.ts
+++ b/src/utils/popover/__tests__/get-popover-trigger-props.test.ts
@@ -1,0 +1,8 @@
+import { getPopoverTriggerProps } from '../get-popover-trigger-props'
+
+test('maps popover attributes to React 18 compatible attributes', () => {
+  expect(getPopoverTriggerProps({ popoverTarget: 'target', popoverTargetAction: 'toggle' })).toEqual({
+    popovertarget: 'target',
+    popovertargetaction: 'toggle',
+  })
+})

--- a/src/utils/popover/__tests__/map-placement-to-css.test.ts
+++ b/src/utils/popover/__tests__/map-placement-to-css.test.ts
@@ -1,0 +1,22 @@
+import { mapPlacementToCSS } from '../map-placement-to-css'
+import type { PopoverPlacement } from '../map-placement-to-css'
+
+export const supportedPopoverPlacements = [
+  'top-start',
+  'top',
+  'top-end',
+  'right-start',
+  'right',
+  'right-end',
+  'bottom-start',
+  'bottom',
+  'bottom-end',
+  'left-start',
+  'left',
+  'left-end',
+] as const satisfies PopoverPlacement[]
+
+test.each(supportedPopoverPlacements)('produces correct CSS for the "%s" placement', (placement) => {
+  const fakeGap = 'var(--fake-gap)'
+  expect(mapPlacementToCSS(placement, fakeGap)).toMatchSnapshot()
+})

--- a/src/utils/popover/__tests__/popover.test.tsx
+++ b/src/utils/popover/__tests__/popover.test.tsx
@@ -1,0 +1,138 @@
+import { applyCSSAnchorPositioningPolyfill } from '#src/polyfills/css-anchor-positioning'
+import { Popover } from '../popover'
+import { render, screen } from '@testing-library/react'
+
+import type { CSSProperties } from 'react'
+
+// Mock CSS anchor positioning polyfill since it's not necessary during test.
+vi.mock('#src/polyfills/css-anchor-positioning/polyfill')
+vi.mocked(applyCSSAnchorPositioningPolyfill).mockResolvedValue(undefined)
+
+const requiredProps = {
+  anchorId: 'anchor-element',
+  id: 'popover-element',
+  placement: 'bottom',
+} as const
+
+test('renders a div element with popover="auto" by default', () => {
+  render(<Popover {...requiredProps}>Popover content</Popover>)
+  expect(screen.getByText('Popover content')).toBeInTheDocument()
+})
+
+test('renders a style element as the first child of the popover', () => {
+  render(<Popover {...requiredProps}>Popover content</Popover>)
+
+  const popover = screen.getByText('Popover content')
+  expect(popover.firstChild).toBeInstanceOf(HTMLStyleElement)
+})
+
+test('has popover="auto" by default', () => {
+  render(<Popover {...requiredProps}>Popover content</Popover>)
+  expect(screen.getByText('Popover content')).toHaveAttribute('popover', 'auto')
+})
+
+test('can override the default popover value', () => {
+  render(
+    <Popover {...requiredProps} popover="manual">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveAttribute('popover', 'manual')
+})
+
+test('has data-elevation="none" attribute by default', () => {
+  render(<Popover {...requiredProps}>Popover content</Popover>)
+  expect(screen.getByText('Popover content')).toHaveAttribute('data-elevation', 'none')
+})
+
+test('can override the default elevation', () => {
+  render(
+    <Popover {...requiredProps} elevation="xl">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveAttribute('data-elevation', 'xl')
+})
+
+test('provides custom CSS property for maxWidth when specified', () => {
+  render(
+    <Popover {...requiredProps} maxWidth="300px">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveStyle('--popover-max-width: 300px')
+})
+
+test('provides custom CSS property for maxHeight when specified', () => {
+  render(
+    <Popover {...requiredProps} maxHeight="200px">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveStyle('--popover-max-height: 200px')
+})
+
+test('provides custom CSS properties for both maxWidth and maxHeight when specified', () => {
+  render(
+    <Popover {...requiredProps} maxWidth="300px" maxHeight="200px">
+      Popover content
+    </Popover>,
+  )
+  const popover = screen.getByText('Popover content')
+  expect(popover).toHaveStyle('--popover-max-width: 300px')
+  expect(popover).toHaveStyle('--popover-max-height: 200px')
+})
+
+test('allows other inline styles to be provided', () => {
+  render(
+    <Popover {...requiredProps} style={{ backgroundColor: 'red', fontSize: '14px' }}>
+      Popover content
+    </Popover>,
+  )
+  const popover = screen.getByText('Popover content')
+  expect(popover).toHaveStyle('background-color: red')
+  expect(popover).toHaveStyle('font-size: 14px')
+})
+
+test('combines existing styles with CSS custom properties', () => {
+  render(
+    <Popover
+      {...requiredProps}
+      maxWidth="300px"
+      style={{ backgroundColor: 'red', '--custom-prop': 'value' } as CSSProperties}
+    >
+      Popover content
+    </Popover>,
+  )
+  const popover = screen.getByText('Popover content')
+  expect(popover).toHaveStyle('background-color: red')
+  expect(popover).toHaveStyle('--popover-max-width: 300px')
+  expect(popover).toHaveStyle('--custom-prop: value')
+})
+
+test('forwards additional props to the div element', () => {
+  render(
+    <Popover {...requiredProps} data-testid="popover-element">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByTestId('popover-element')).toBeInTheDocument()
+})
+
+test('applies the el-popover className', () => {
+  render(
+    <Popover {...requiredProps} className="custom-class">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveClass('el-popover')
+})
+
+test('applies custom className along with default styling', () => {
+  render(
+    <Popover {...requiredProps} className="custom-class">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveClass('custom-class')
+})

--- a/src/utils/popover/build-anchor-positioning-css.ts
+++ b/src/utils/popover/build-anchor-positioning-css.ts
@@ -1,0 +1,42 @@
+import { mapPlacementToCSS } from './map-placement-to-css'
+
+import type { PopoverPlacement } from './map-placement-to-css'
+
+interface BuildAnchorPositioningCSSInput {
+  anchorElementId: string
+  gap: string
+  placement: PopoverPlacement
+  positionedElementId: string
+  positionTryFallbacks: string
+}
+
+/**
+ * Returns a CSS string that contains styles for an anchor and its positioned element via the
+ * specified element IDs. The IDs are escaped using
+ * [CSS.escape](https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static).
+ */
+export function buildAnchorPositioningCSS({
+  anchorElementId,
+  placement,
+  positionedElementId,
+  positionTryFallbacks,
+  gap,
+}: BuildAnchorPositioningCSSInput): string {
+  // NOTE: the anchor and positioned element IDs may include reserved CSS characters
+  // like `:` (especially IDs generated via `useId`). Thus, we need to escape them
+  // before using them in our CSS.
+  const anchorName = `--${CSS.escape(anchorElementId)}`
+  const positioningCSS = mapPlacementToCSS(placement, gap)
+
+  return `
+    #${CSS.escape(anchorElementId)} {
+      anchor-name: ${anchorName};
+    }
+
+    #${CSS.escape(positionedElementId)} {
+      position-anchor: ${anchorName};
+      position-try-fallbacks: ${positionTryFallbacks};
+      ${positioningCSS}
+    }
+  `
+}

--- a/src/utils/popover/get-popover-trigger-props.ts
+++ b/src/utils/popover/get-popover-trigger-props.ts
@@ -1,0 +1,33 @@
+interface GetPopoverTriggerPropsInput {
+  popoverTarget: string
+  popoverTargetAction: 'hide' | 'show' | 'toggle'
+}
+
+interface GetPopoverTriggerPropsOutput {
+  popovertarget: string
+  popovertargetaction: 'hide' | 'show' | 'toggle'
+}
+
+/**
+ * React 18 does not support the HTML attributes involved in the
+ * [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API). This helper
+ * provides a way for consumers to use them without incurring TS prop type errors or React
+ * development runtime errors.
+ *
+ * The input properties match React 19's type definitions for the popover attributes. See
+ * [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69670/files#diff-d0d8d4879e505e2bd1813a8e662eeedbdf85c1fae8b76c4dff609bb5bcfe3a98R128)
+ *
+ * The output properties are all lowercase so that React 18 will pass them through to the
+ * underlying DOM element without throwing a runtime error about unrecognised attributes.
+ *
+ * @returns popover trigger attributes for use in React 18 consumers.
+ */
+export function getPopoverTriggerProps({
+  popoverTarget,
+  popoverTargetAction,
+}: GetPopoverTriggerPropsInput): GetPopoverTriggerPropsOutput {
+  return {
+    popovertarget: popoverTarget,
+    popovertargetaction: popoverTargetAction,
+  }
+}

--- a/src/utils/popover/index.ts
+++ b/src/utils/popover/index.ts
@@ -1,0 +1,3 @@
+export * from './get-popover-trigger-props'
+export * from './popover'
+export * from './styles'

--- a/src/utils/popover/map-placement-to-css.ts
+++ b/src/utils/popover/map-placement-to-css.ts
@@ -1,0 +1,104 @@
+export type PopoverPlacement =
+  | 'top-start'
+  | 'top'
+  | 'top-end'
+  | 'right-start'
+  | 'right'
+  | 'right-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left'
+  | 'left-end'
+
+/**
+ * Returns a CSS string that defines the necessary CSS properties for a positioned element
+ * to be placed according to the specified `placement` value.
+ *
+ * @param placement the placement of the positioned element w.r.t. to its anchor
+ */
+export function mapPlacementToCSS(placement: PopoverPlacement, gap: string): string {
+  // NOTE: We do not use logical properties (like `inset-block-start`) because the polyfill
+  // we're currently relying on in some browsers doesn't work nicely with them. Likewise for
+  // our lack of use of the `position-area` property. In future, when all browsers natively
+  // support CSS anchor positioning, `position-area` will match quite easily to our `placement`
+  // options (such that we may want to simply expose `position-area` directly).
+  //
+  // For now, we map our `placement` value to inset properties (top, left etc) and the
+  // `align-self`/`justify-self` properties with the special `anchor-center` value.
+  switch (placement) {
+    case 'bottom':
+      return `
+        top: anchor(bottom);
+        justify-self: anchor-center;
+        margin-block: ${gap};
+      `
+    case 'bottom-end':
+      return `
+        top: anchor(bottom);
+        right: anchor(right);
+        margin-block: ${gap};
+      `
+    case 'bottom-start':
+      return `
+        top: anchor(bottom);
+        left: anchor(left);
+        margin-block: ${gap};
+      `
+    case 'left':
+      return `
+        align-self: anchor-center;
+        right: anchor(left);
+        margin-inline: ${gap};
+      `
+    case 'left-end':
+      return `
+        bottom: anchor(bottom);
+        right: anchor(left);
+        margin-inline: ${gap};
+      `
+    case 'left-start':
+      return `
+        top: anchor(top);
+        right: anchor(left);
+        margin-inline: ${gap};
+      `
+    case 'right':
+      return `
+        align-self: anchor-center;
+        left: anchor(right);
+        margin-inline: ${gap};
+      `
+    case 'right-end':
+      return `
+        bottom: anchor(bottom);
+        left: anchor(right);
+        margin-inline: ${gap};
+      `
+    case 'right-start':
+      return `
+        top: anchor(top);
+        left: anchor(right);
+        margin-inline: ${gap};
+      `
+    case 'top':
+      return `
+        bottom: anchor(top);
+        justify-self: anchor-center;
+        margin-block: ${gap};
+      `
+    case 'top-end':
+      return `
+        bottom: anchor(top);
+        right: anchor(right);
+        margin-block: ${gap};
+      `
+    case 'top-start':
+      return `
+        bottom: anchor(top);
+        left: anchor(left);
+        margin-block: ${gap};
+      `
+  }
+}

--- a/src/utils/popover/popover.stories.tsx
+++ b/src/utils/popover/popover.stories.tsx
@@ -1,0 +1,193 @@
+import { getPopoverTriggerProps } from './get-popover-trigger-props'
+import { Popover } from './popover'
+import { styled } from '@linaria/react'
+import { useId } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const MyPopoverContent = styled.div`
+  padding: var(--spacing-2);
+  background: var(--colour-fill-action-lightest);
+  border: 1px solid #fa00ff;
+`
+
+const meta = {
+  title: 'Utils/Popover',
+  component: Popover,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  render: (args) => {
+    // NOTE: because we have multiple stories on the one docs page, we append a "suffix" to
+    // the IDs so they are unique per story. Then ensures our positioning of the popover will
+    // be anchored to the correct element.
+    const suffix = useId()
+    const props = {
+      ...args,
+      anchorId: `${args.anchorId}-${suffix}`,
+      id: `${args.id}-${suffix}`,
+    }
+    return (
+      <>
+        <button
+          autoFocus
+          {...getPopoverTriggerProps({ popoverTarget: props.id, popoverTargetAction: 'toggle' })}
+          id={props.anchorId}
+        >
+          Anchor
+        </button>
+        <Popover {...props} />
+      </>
+    )
+  },
+} satisfies Meta<typeof Popover>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * Popovers come with no styling: no background, no padding, no border. They are intended to be a blank
+ * canvas on which to build a more visually attractive UI element, such as a tooltip or a menu.
+ *
+ * In the examples here, we're using a simple styled element as the content of the popover in order to
+ * help communicate the behaviour and capabilities of the popover.
+ */
+export const Example: Story = {
+  args: {
+    anchorId: 'anchor',
+    children: <MyPopoverContent>Popover content</MyPopoverContent>,
+    elevation: 'none',
+    gap: 'var(--spacing-1)',
+    id: 'popover',
+    placement: 'top-start',
+    positionTryFallbacks: 'flip-block, flip-inline',
+  },
+}
+
+/**
+ * The distance, or gap, between the popover and its anchor can be customised. By default, there will be
+ * no gap, but many use cases will call for a non-zero gap. While the `gap` prop accepts any valid CSS
+ * length, it should typically be a `--spacing-*` CSS variable.
+ */
+export const Gap: Story = {
+  args: {
+    ...Example.args,
+    gap: 'var(--spacing-6)',
+  },
+}
+
+/**
+ * There are a number of placements available for popovers relative to their anchor. They are shown below.
+ */
+export const Placements: Story = {
+  args: {
+    ...Example.args,
+  },
+  parameters: {
+    controls: {
+      disabled: true,
+    },
+  },
+  render: () => {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '300px' }}>
+        <div
+          id="anchor"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--colour-fill-neutral-light',
+            borderRadius: 'var(--border-radius-xl)',
+            width: '400px',
+            height: '200px',
+          }}
+        >
+          Anchor
+        </div>
+        {(
+          [
+            'top-start',
+            'top',
+            'top-end',
+            'right-start',
+            'right',
+            'right-end',
+            'bottom-start',
+            'bottom',
+            'bottom-end',
+            'left-start',
+            'left',
+            'left-end',
+          ] as const
+        ).map((placement) => (
+          <Popover
+            key={placement}
+            id={placement}
+            anchorId="anchor"
+            gap="var(--spacing-2)"
+            placement={placement}
+            popover={null}
+            positionTryFallbacks="none"
+          >
+            <MyPopoverContent>{placement}</MyPopoverContent>
+          </Popover>
+        ))}
+      </div>
+    )
+  },
+}
+
+/**
+ * By default, popovers will grow to the width of their content. To constrain this behaviour, a maximum
+ * width can be specified. Content should generally adapt to the constrained width by wrapping rather
+ * than overflowing.
+ *
+ * While the maximum width can be defined using any valid CSS length, the value should typically be a
+ * `--size-*` CSS variable.
+ */
+export const MaxWidth: Story = {
+  args: {
+    ...Example.args,
+    children: (
+      <MyPopoverContent>
+        This popover has a lot of words, which increases the element&apos;s width to the point that it overflows the
+        popover&apos;s maximum width constraint. In this case, the text flows to additional lines, increasing the
+        intrinic height of the popover.
+      </MyPopoverContent>
+    ),
+    maxWidth: 'var(--size-36)',
+  },
+}
+
+/**
+ * Similarly, popovers will grow, by default, to the height of their content. To constrain this behaviour,
+ * a maximum height can also be specified, at which point the popover will scroll the content.
+ *
+ * As with the maximum width, the maximum height can be defined using any valid CSS length, but the value
+ * should typically be a `--size-*` CSS variable.
+ */
+export const MaxHeight: Story = {
+  args: {
+    ...MaxWidth.args,
+    maxHeight: 'var(--size-36)',
+  },
+}
+
+/**
+ * Since popovers are an elevated, non-modal material, it's common for them to cast a shadow on the
+ * UI beneath them. This can be achieved using the `elevation` prop. There's currently two supported
+ * elevations: `none` and `xl`.
+ */
+export const Elevation: Story = {
+  args: {
+    ...Example.args,
+    elevation: 'xl',
+  },
+}

--- a/src/utils/popover/popover.tsx
+++ b/src/utils/popover/popover.tsx
@@ -1,0 +1,140 @@
+import { applyCSSAnchorPositioningPolyfill } from '#src/polyfills/css-anchor-positioning'
+import { buildAnchorPositioningCSS } from './build-anchor-positioning-css'
+import { cx } from '@linaria/core'
+import { elPopover } from './styles'
+import { useLayoutEffect, useRef } from 'react'
+
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
+import type { PopoverPlacement } from './map-placement-to-css'
+
+export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
+  /** The ID of the element this popover to which this popover should be anchored. */
+  anchorId: string
+  /** The content of the popover. */
+  children: ReactNode
+  /** The visual elevation of the popover. Determines how much shadow the popover casts. */
+  elevation?: 'none' | 'xl'
+  /**
+   * The gap between the popover and the anchor. Can be any valid CSS length, though `--spacing-*`
+   * CSS variables are recommended. By default, the gap will be zero.
+   */
+  gap?: string
+  /**
+   * The ID of this popover. This is mandatory because the popover's trigger will need to reference
+   * this in it's `popovertarget` attribute.
+   */
+  id: string
+  /**
+   * The maximum height of the popover. Can be any valid CSS length, though `--size-*`
+   * CSS variables are recommended. By default, the popover will be as tall as its content requires.
+   */
+  maxHeight?: string
+  /**
+   * The maximum width of the popover. Can be any valid CSS length, though `--size-*`
+   * CSS variables are recommended. By default, the popover will be as wide as its content requires.
+   */
+  maxWidth?: string
+  /**
+   * The "kind" of popover this should be. See
+   * [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover)
+   * for more details.
+   *
+   * A special value of `null` allows the popover to not be a popover. This can be useful when you need
+   * to display a popover element permanently in the UI (such as in documentation or example code). Just
+   * note that the absence of the `popover` attribute means the element will not be displayed within the
+   * top-layer, so may be susceptible to z-index issues.
+   */
+  popover?: 'auto' | 'manual' | null
+  /** Where the popover should be placed relative to its anchor. */
+  placement: PopoverPlacement
+  /**
+   * Fallback positions for the popover that should be tried when it would otherwise overflow the viewport.
+   * See [position-try-fallbacks](https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks)
+   * for more details. Note that the [polyfill](https://anchor-positioning.oddbird.net/) we rely on for
+   * anchor positioning in some browsers will not play nicely with all available options.
+   *
+   * Typically, "flip-block", "flip-inline" or both will be sufficient for most use cases.
+   * Defaults to "none".
+   */
+  positionTryFallbacks?: string
+}
+
+/**
+ * A simple popover that can be positioned relative to an anchor. It is designed to work with the
+ * global [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover)
+ * attribute. Positioning is facilitated using
+ * [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning),
+ * which currently requires a polyfill in some browsers.
+ *
+ * If custom styles need to be applied to the Popover element itself, it's important to ensure a
+ * custom `display` property is only set when the popover is open (via the `:popover-open`
+ * pseudo-class), otherwise the custom `display` property will override the browser's default handling
+ * of the popover's display.
+ *
+ * **note:** When working with Popover directly (uncommon) within a React 18 consumer, the
+ * `getPopoverTriggerProps` helper will be useful to avoid type errors or development runtime errors
+ * about the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) attributes used
+ * to show/hide/toggle popovers.
+ */
+export function Popover({
+  anchorId,
+  children,
+  className,
+  elevation = 'none',
+  gap = '0',
+  id,
+  maxHeight,
+  maxWidth,
+  placement,
+  positionTryFallbacks = 'none',
+  popover = 'auto',
+  style,
+  ...rest
+}: PopoverProps) {
+  const styleRef = useRef<HTMLStyleElement>(null)
+
+  // NOTE: The polyfill we're using supports inline styles on elements, however, because React
+  // renders content in the DOM dynamically, this would require us to pass the polyfill both DOM
+  // elements---the anchor and the positioned element---in order for it to polyfill the CSS anchor
+  // positioning styles on-demand. This would result in an API where we need refs for both the anchor
+  // and the popover, which is far more awkard than simply relying on element IDs and a simple <style>
+  // element that we polyfill on-demand. Given this technical approach, our anchor positioning CSS
+  // is a simple string, as produced by `buildAnchorPositioningCSS`.
+  //
+  // In future, when we no longer need the polyfill, we'll be able to simplify this implementation to
+  // rely solely on inline styles (or something equally low-tech).
+  const anchorPositioningCSS = buildAnchorPositioningCSS({
+    anchorElementId: anchorId,
+    positionedElementId: id,
+    placement,
+    positionTryFallbacks,
+    gap,
+  })
+
+  useLayoutEffect(function polyfillCSSAnchorPositioning() {
+    if (styleRef.current) {
+      applyCSSAnchorPositioningPolyfill({ elements: [styleRef.current] })
+    }
+  }, [])
+
+  return (
+    <div
+      {...rest}
+      className={cx(elPopover, className)}
+      data-elevation={elevation}
+      id={id}
+      // @ts-expect-error -- React 18 does not have types for the popover attribute
+      popover={popover}
+      style={
+        {
+          ...style,
+          '--popover-max-height': maxHeight,
+          '--popover-max-width': maxWidth,
+        } as CSSProperties
+      }
+    >
+      <style ref={styleRef}>{anchorPositioningCSS}</style>
+      {children}
+    </div>
+  )
+}

--- a/src/utils/popover/styles.ts
+++ b/src/utils/popover/styles.ts
@@ -1,0 +1,27 @@
+import { css } from '@linaria/core'
+
+export const elPopover = css`
+  /* NOTE: we place these styled inside an anonymous layer so they can border
+   * overriden by the Popover's consumers even if the consumer's styles have the
+   * same specificity. */
+  @layer {
+    position: absolute;
+    inset: auto;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+
+    max-height: var(--popover-max-height, max-content);
+    max-width: var(--popover-max-width, max-content);
+
+    &,
+    &[data-elevation='none'] {
+      box-shadow: none;
+    }
+
+    &[data-elevation='xl'] {
+      box-shadow: 0 var(--size-1) var(--size-4) 0 rgb(0 0 0 / 0.2);
+    }
+  }
+`


### PR DESCRIPTION
### Context

- The existing Menu component is partially complete, but has a number of issues related to it (focus outline of items is clipped, menu item prop interface incomplete, inadequate positioning w.r.t anchor, reliant on div container which interferes with the layout of the trigger and more)
- We need to deliver a more solid foundation for Menu's while also supporting the updated Menu design requirements.
- To do this, we'll deprecate the existing Menu and implement a new one. This will allow consumers (including other Elements components) to gradually migrate to the new version.
- Previous work in this series:
  - #636 
  - #637 
  - #640 

### This PR

- Adds new `Popover` component. This will for the foundation of the new Menu component (and later, the Tooltip).

<img width="812" height="670" alt="Screenshot 2025-07-30 at 3 55 25 pm" src="https://github.com/user-attachments/assets/2f694d33-6b69-4177-b640-b30c58e0ae7f" />
<img width="813" height="717" alt="Screenshot 2025-07-30 at 3 55 33 pm" src="https://github.com/user-attachments/assets/6cb26165-3c5f-4b10-aa89-995c80b5940f" />
<img width="814" height="473" alt="Screenshot 2025-07-30 at 3 55 40 pm" src="https://github.com/user-attachments/assets/83148c4e-5213-4e1a-bc36-8d7cb5e3c101" />
<img width="812" height="627" alt="Screenshot 2025-07-30 at 3 55 45 pm" src="https://github.com/user-attachments/assets/053950e3-3e15-4754-b482-de2f63b8db2f" />
<img width="811" height="421" alt="Screenshot 2025-07-30 at 3 55 54 pm" src="https://github.com/user-attachments/assets/d0a13556-2250-435d-9088-119cdaa1a655" />
