### PR TITLE
feat: Add new `MenuDivider`

### DIFF
--- a/src/core/menu/divider/__tests__/divider.test.tsx
+++ b/src/core/menu/divider/__tests__/divider.test.tsx
@@ -1,0 +1,12 @@
+import { MenuDivider } from '../divider'
+import { render, screen } from '@testing-library/react'
+
+test('renders a separator element', () => {
+  render(<MenuDivider />)
+  expect(screen.getByRole('separator')).toBeVisible()
+})
+
+test('forwards additional props to the separator element', () => {
+  render(<MenuDivider data-testid="my-divider" />)
+  expect(screen.getByTestId('my-divider')).toBeVisible()
+})

--- a/src/core/menu/divider/divider.stories.tsx
+++ b/src/core/menu/divider/divider.stories.tsx
@@ -1,0 +1,14 @@
+import { MenuDivider } from './divider'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Menu/Divider',
+  component: MenuDivider,
+} satisfies Meta<typeof MenuDivider>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {}

--- a/src/core/menu/divider/divider.tsx
+++ b/src/core/menu/divider/divider.tsx
@@ -1,0 +1,16 @@
+import { ElMenuDivider } from './styles'
+
+import type { HTMLAttributes } from 'react'
+
+// NOTE: We omit...
+// - role, because the divider's role should always be "separator".
+type AttributesToOmit = 'role'
+
+interface MenuDividerProps extends Omit<HTMLAttributes<HTMLHRElement>, AttributesToOmit> {}
+
+/**
+ * Used to separate groups of menu items in a menu. Will typically be used via `Menu.Divider`.
+ */
+export function MenuDivider(props: MenuDividerProps) {
+  return <ElMenuDivider {...props} role="separator" />
+}

--- a/src/core/menu/divider/index.ts
+++ b/src/core/menu/divider/index.ts
@@ -1,0 +1,2 @@
+export * from './divider'
+export * from './styles'

--- a/src/core/menu/divider/styles.ts
+++ b/src/core/menu/divider/styles.ts
@@ -1,0 +1,7 @@
+import { styled } from '@linaria/react'
+
+export const ElMenuDivider = styled.hr`
+  height: 0;
+  border: none;
+  border-bottom: var(--comp-divider-border-width) solid var(--comp-divider-colour-border-solid);
+`


### PR DESCRIPTION
### Context

- The existing Menu component is partially complete, but has a number of issues related to it (focus outline of items is clipped, menu item prop interface incomplete, inadequate positioning w.r.t anchor, reliant on div container which interferes with the layout of the trigger and more)
- We need to deliver a more solid foundation for Menu's while also supporting the updated Menu design requirements.
- To do this, we'll deprecate the existing Menu and implement a new one. This will allow consumers (including other Elements components) to gradually migrate to the new version.
- Previous work in this series:
  - #636 
  - #637 
  - #640 
  - #641 

### This PR

- Adds new `MenuDivider` component.

<img width="1014" height="257" alt="Screenshot 2025-07-30 at 4 04 50 pm" src="https://github.com/user-attachments/assets/048837b1-2af2-419f-8441-6e7ac2c13a4b" />
