### PR TITLE
feat: Add new `Menu`

### DIFF
--- a/src/core/menu/__tests__/menu.test.tsx
+++ b/src/core/menu/__tests__/menu.test.tsx
@@ -1,0 +1,42 @@
+import { Menu } from '../menu'
+import { render, screen } from '@testing-library/react'
+
+const requiredProps = {
+  'aria-labelledby': 'trigger-button',
+  id: 'test-menu',
+}
+
+test('renders a menu element', () => {
+  render(<Menu {...requiredProps}>Menu content</Menu>)
+  expect(screen.getByRole('menu')).toBeVisible()
+})
+
+test('uses popover="auto"', () => {
+  render(<Menu {...requiredProps}>Menu content</Menu>)
+  expect(screen.getByRole('menu')).toHaveAttribute('popover', 'auto')
+})
+
+test('forwards additional props to the menu', () => {
+  render(
+    <Menu {...requiredProps} data-testid="test-id">
+      Menu content
+    </Menu>,
+  )
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})
+
+test('exposes Menu.Item component', () => {
+  expect(Menu.Item).toBeDefined()
+})
+
+test('exposes Menu.AnchorItem component', () => {
+  expect(Menu.AnchorItem).toBeDefined()
+})
+
+test('exposes Menu.Divider component', () => {
+  expect(Menu.Divider).toBeDefined()
+})
+
+test('exposes Menu.Group component', () => {
+  expect(Menu.Group).toBeDefined()
+})

--- a/src/core/menu/group/__tests__/group.test.tsx
+++ b/src/core/menu/group/__tests__/group.test.tsx
@@ -1,4 +1,4 @@
-import { MenuGroup } from '../menu-group'
+import { MenuGroup } from '../group'
 import { render, screen } from '@testing-library/react'
 
 test('renders a group element', () => {

--- a/src/core/menu/group/group.stories.tsx
+++ b/src/core/menu/group/group.stories.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '#src/core/badge'
-import { MenuGroup } from './menu-group'
+import { MenuGroup } from './group'
 import { AnchorMenuItem, MenuItem } from '../item'
 import { StarIcon } from '#src/icons/star'
 
@@ -88,7 +88,42 @@ export const Example: Story = {
  */
 export const NoLabel: Story = {
   args: {
-    'aria-label': 'Actions',
-    children: 'Simple',
+    ...Example.args,
+    label: null,
   },
+}
+
+/**
+ * Menu groups should generally have short and concise labels, but the text will flow to multiple lines
+ * if it cannot fit in the available space.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    label: "This is a long group title that won't fit on one line",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '277px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * The menu group label will remain sticky positioned if the parent container scrolls.
+ */
+export const StickyPositioning: Story = {
+  args: {
+    ...Example.args,
+    children: 'Fancy',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', maxHeight: '100px', overflow: 'auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
 }

--- a/src/core/menu/group/group.tsx
+++ b/src/core/menu/group/group.tsx
@@ -1,5 +1,7 @@
 import { ElMenuGroup, ElMenuGroupLabelContainer } from './styles'
-import { useId, type HTMLAttributes, type ReactNode } from 'react'
+import { useId } from 'react'
+
+import type { HTMLAttributes, ReactNode } from 'react'
 
 interface MenuGroupProps extends HTMLAttributes<HTMLDivElement> {
   /**

--- a/src/core/menu/group/index.ts
+++ b/src/core/menu/group/index.ts
@@ -1,2 +1,2 @@
-export * from './menu-group'
+export * from './group'
 export * from './styles'

--- a/src/core/menu/group/styles.ts
+++ b/src/core/menu/group/styles.ts
@@ -9,6 +9,11 @@ export const ElMenuGroup = styled.div`
 `
 
 export const ElMenuGroupLabelContainer = styled.div`
+  position: sticky;
+  top: 0;
+
+  background: var(--colour-fill-white);
+
   ${font('2xs', 'bold')}
   text-transform: uppercase;
 

--- a/src/core/menu/index.ts
+++ b/src/core/menu/index.ts
@@ -1,0 +1,5 @@
+export * from './divider'
+export * from './group'
+export * from './item'
+export * from './menu'
+export * from './styles'

--- a/src/core/menu/item/styles.ts
+++ b/src/core/menu/item/styles.ts
@@ -39,8 +39,8 @@ export const elMenuItem = css`
     background: var(--comp-menu-colour-fill-default);
   }
 
-  &[aria-checked='true'],
-  &[aria-current='page'] {
+  &[aria-checked='true']:enabled,
+  &[aria-current='page']:enabled {
     background: var(--comp-menu-colour-fill-highlighted);
   }
 `
@@ -56,15 +56,6 @@ export const ElMenuItemIconContainer = styled.span`
   /* aka left icon */
   &:first-of-type {
     color: var(--comp-menu-colour-icon-default-left);
-
-    [aria-checked='true'] &,
-    [aria-current='page'] & {
-      color: var(--comp-menu-colour-icon-default-action);
-
-      &:hover {
-        color: var(--comp-menu-colour-icon-hover-action);
-      }
-    }
   }
 
   /* aka right icon */
@@ -72,7 +63,6 @@ export const ElMenuItemIconContainer = styled.span`
     color: var(--comp-menu-colour-icon-default-right);
   }
 
-  /* Disabled styles come last to ensure they override other state-based styles like hover */
   [aria-disabled='true'] &,
   :disabled & {
     &:first-of-type {
@@ -80,6 +70,20 @@ export const ElMenuItemIconContainer = styled.span`
     }
     &:last-of-type {
       color: var(--comp-menu-colour-icon-disabled-right);
+    }
+  }
+
+  [aria-checked='true']:enabled &,
+  [aria-current='page']:enabled & {
+    &:first-of-type {
+      color: var(--comp-menu-colour-icon-default-action);
+    }
+  }
+
+  [aria-checked='true']:enabled:hover &,
+  [aria-current='page']:enabled:hover & {
+    &:first-of-type {
+      color: var(--comp-menu-colour-icon-hover-action);
     }
   }
 `
@@ -105,18 +109,19 @@ export const ElMenuItemLabelText = styled.span`
   ${font('sm', 'regular')}
   color: var(--comp-menu-colour-text-default-primary);
 
-  [aria-checked='true'] &,
-  [aria-current='page'] & {
-    color: var(--comp-menu-colour-text-default-action);
-
-    &:hover {
-      color: var(--comp-menu-colour-text-hover-action);
-    }
-  }
-
   [aria-disabled='true'] &,
   :disabled & {
     color: var(--comp-menu-colour-text-disabled-primary);
+  }
+
+  [aria-checked='true']:enabled &,
+  [aria-current='page']:enabled & {
+    color: var(--comp-menu-colour-text-default-action);
+  }
+
+  [aria-checked='true']:enabled:hover &,
+  [aria-current='page']:enabled:hover & {
+    color: var(--comp-menu-colour-text-hover-action);
   }
 `
 

--- a/src/core/menu/menu.stories.tsx
+++ b/src/core/menu/menu.stories.tsx
@@ -1,0 +1,185 @@
+import { Badge } from '#src/core/badge'
+import { getMenuTriggerProps, Menu } from './menu'
+import { StarIcon } from '#src/icons/star'
+import { useId } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Core/Menu',
+  component: Menu,
+  argTypes: {
+    children: {
+      control: 'select',
+      options: ['Simple', 'Fancy'],
+      mapping: {
+        Simple: (
+          <>
+            <Menu.AnchorItem href={href}>Item 1</Menu.AnchorItem>
+            <Menu.Item>Item 2</Menu.Item>
+            <Menu.Item>Item 3</Menu.Item>
+          </>
+        ),
+        Fancy: (
+          <>
+            <Menu.Group label="Menu group">
+              <Menu.AnchorItem
+                badge={
+                  <Badge colour="success" variant="reversed">
+                    Badge
+                  </Badge>
+                }
+                href={href}
+                iconLeft={<StarIcon />}
+                supplementaryInfo="Supplementary info"
+              >
+                Item 1
+              </Menu.AnchorItem>
+              <Menu.Item
+                iconLeft={<StarIcon />}
+                badge={
+                  <Badge colour="success" variant="reversed">
+                    Badge
+                  </Badge>
+                }
+                supplementaryInfo="Supplementary info"
+              >
+                Item 2
+              </Menu.Item>
+              <Menu.Item
+                iconLeft={<StarIcon />}
+                badge={
+                  <Badge colour="success" variant="reversed">
+                    Badge
+                  </Badge>
+                }
+                supplementaryInfo="Supplementary info"
+              >
+                Item 3
+              </Menu.Item>
+            </Menu.Group>
+            <Menu.Divider />
+            <Menu.Item>Item 4</Menu.Item>
+            <Menu.Item>Item 5</Menu.Item>
+            <Menu.Item>Item 6</Menu.Item>
+          </>
+        ),
+      },
+    },
+    gap: {
+      control: 'text',
+      table: {
+        type: {
+          summary: '--spacing-*',
+        },
+      },
+    },
+    maxHeight: {
+      control: 'text',
+      table: {
+        type: {
+          summary: '--size-*',
+        },
+      },
+    },
+    maxWidth: {
+      control: 'text',
+      table: {
+        type: {
+          summary: '--size-*',
+        },
+      },
+    },
+  },
+  render: (args) => {
+    // NOTE: because we have multiple stories on the one docs page, we append a "suffix" to
+    // the IDs so they are unique per story. Then ensures our positioning of the menu will
+    // be anchored to the correct element.
+    const suffix = useId()
+    const props = {
+      ...args,
+      'aria-labelledby': `${args['aria-labelledby']}-${suffix}`,
+      id: `${args.id}-${suffix}`,
+    }
+
+    return (
+      <>
+        <button
+          aria-controls={props.id}
+          aria-haspopup="menu"
+          id={props['aria-labelledby']}
+          {...getMenuTriggerProps({
+            popoverTarget: props.id,
+            popoverTargetAction: 'toggle',
+          })}
+        >
+          Click me!
+        </button>
+        <Menu {...props} />
+      </>
+    )
+  },
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Menu>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    'aria-labelledby': 'anchor',
+    children: 'Simple',
+    id: 'menu',
+  },
+}
+
+/**
+ * The distance, or gap, between the menu and its trigger can be customised. By default, there will be
+ * a `--spacing-1`, but any `--spacing-*` value can be specified.
+ */
+export const Gap: Story = {
+  args: {
+    ...Example.args,
+    gap: '--spacing-6',
+  },
+}
+
+/**
+ * By default, a menu will grow to the width of its widest item. A maximum width can be specified to
+ * constrain how wide it can grow. Menu item content that would otherwise to wider will subsequently wrap.
+ */
+export const MaxWidth: Story = {
+  args: {
+    ...Example.args,
+    children: (
+      <>
+        <Menu.Item>Item 1</Menu.Item>
+        <Menu.Item>Item 2</Menu.Item>
+        <Menu.Item>
+          An item with a really long label that will wrap to additional lines because the menu&apos;s width is
+          constrained
+        </Menu.Item>
+      </>
+    ),
+    maxWidth: '--size-40',
+  },
+}
+
+/**
+ * By default, a menu will grow to the height of its items. A maximum height can be specified to
+ * help ensure the menu does not grow beyond the viewport. If the menu exceeds this maximum height,
+ * the items will scroll.
+ */
+export const MaxHeight: Story = {
+  args: {
+    'aria-labelledby': 'anchor',
+    children: 'Fancy',
+    id: 'menu',
+    maxHeight: '--size-40',
+  },
+}

--- a/src/core/menu/menu.tsx
+++ b/src/core/menu/menu.tsx
@@ -1,0 +1,67 @@
+import { AnchorMenuItem, MenuItem } from './item'
+import { ElMenuContent } from './styles'
+import { MenuDivider } from './divider'
+import { MenuGroup } from './group'
+import { Popover } from '#src/utils/popover'
+
+import type { HTMLAttributes } from 'react'
+
+// Make this helper available for convenience.
+export { getPopoverTriggerProps as getMenuTriggerProps } from '#src/utils/popover'
+
+// NOTE: We omit...
+// - role, because the Menu's role should always be "menu".
+type AttributesToOmit = 'role'
+
+export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
+  /** The element that labels this menu. This should be the element that controls the menu. */
+  'aria-labelledby': string
+  /** The ID of the menu. */
+  id: string
+  /** The gap between the popover and the anchor. */
+  gap?: `--spacing-${string}`
+  /** The maximum height of the menu. By default, the menu will be as tall as its content requires. */
+  maxHeight?: `--size-${string}`
+  /** The maximum width of the menu. By default, the menu will be as wide as its widest item. */
+  maxWidth?: `--size-${string}`
+  /** Where the popover should be placed relative to its anchor. */
+  placement?: 'top-start' | 'top' | 'top-end' | 'bottom-start' | 'bottom' | 'bottom-end'
+}
+
+/**
+ * Menus provide a list of options to help users navigate, or perform actions. A menu is typically
+ * triggered by a button. Designed for use with the
+ * [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API).
+ */
+export function Menu({
+  'aria-labelledby': ariaLabelledBy,
+  children,
+  gap = '--spacing-1',
+  maxHeight,
+  maxWidth,
+  placement = 'top-start',
+  ...rest
+}: MenuProps) {
+  return (
+    <Popover
+      {...rest}
+      aria-labelledby={ariaLabelledBy}
+      anchorId={ariaLabelledBy}
+      elevation="xl"
+      gap={`var(${gap})`}
+      maxHeight={`var(${maxHeight})`}
+      maxWidth={`var(${maxWidth})`}
+      placement={placement}
+      positionTryFallbacks="flip-block, flip-inline"
+      popover="auto"
+      role="menu"
+    >
+      <ElMenuContent>{children}</ElMenuContent>
+    </Popover>
+  )
+}
+
+Menu.AnchorItem = AnchorMenuItem
+Menu.Divider = MenuDivider
+Menu.Group = MenuGroup
+Menu.Item = MenuItem

--- a/src/core/menu/styles.ts
+++ b/src/core/menu/styles.ts
@@ -1,0 +1,23 @@
+import { styled } from '@linaria/react'
+import { ElMenuGroup } from './group'
+import { ElMenuDivider } from './divider'
+
+export const ElMenuContent = styled.div`
+  border-radius: var(--comp-menu-border-radius);
+  background: var(--colour-fill-white);
+
+  padding: var(--spacing-2);
+
+  & > ${ElMenuDivider} {
+    margin-inline: calc(0px - var(--spacing-2));
+  }
+
+  & > ${ElMenuGroup} {
+    margin-inline: calc(0px - var(--spacing-2));
+
+    &:first-child {
+      padding-block-start: var(--spacing-2);
+      margin-block-start: calc(0px - var(--spacing-2));
+    }
+  }
+`

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -22,6 +22,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore:** Update design tokens to match latest changes in Figma
 - **chore!:** Renamed `ElipsisIcon` to `MoreVertIcon` to align with Design System changes.
 - **feat:** Add new `Popover` utility component. See [Popover](?path=/docs/utils-popover--docs) for details.
+- **feat:** Add new `Menu`. See [Menu](?path=/docs/core-menu--docs) for details.
 
 ### **5.0.0-beta.39 - 23/07/25**
 


### PR DESCRIPTION
### Context

- The existing Menu component is partially complete, but has a number of issues related to it (focus outline of items is clipped, menu item prop interface incomplete, inadequate positioning w.r.t anchor, reliant on div container which interferes with the layout of the trigger and more)
- We need to deliver a more solid foundation for Menu's while also supporting the updated Menu design requirements.
- To do this, we'll deprecate the existing Menu and implement a new one. This will allow consumers (including other Elements components) to gradually migrate to the new version.
- Previous work in this series:
  - #636 
  - #637 
  - #640 
  - #641 
  - #642 

### This PR

- Adds new `Menu` component.

**note:** Keyboard navigation within the menu has been deferred for a future item of work.

<img width="817" height="681" alt="Screenshot 2025-07-30 at 4 21 02 pm" src="https://github.com/user-attachments/assets/34b4789a-5ca5-4690-96e8-599728352312" />
<img width="815" height="773" alt="Screenshot 2025-07-30 at 4 21 20 pm" src="https://github.com/user-attachments/assets/d663c709-6766-41e4-9e09-698c990d2238" />
