### PR TITLE
fix: border radius on Menu

### DIFF
--- a/src/core/menu/menu.stories.tsx
+++ b/src/core/menu/menu.stories.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '#src/core/badge'
-import { getMenuTriggerProps, Menu } from './menu'
+import { Menu } from './menu'
 import { StarIcon } from '#src/icons/star'
 import { useId } from 'react'
 
@@ -110,7 +110,7 @@ const meta = {
           aria-controls={props.id}
           aria-haspopup="menu"
           id={props['aria-labelledby']}
-          {...getMenuTriggerProps({
+          {...Menu.getMenuTriggerProps({
             popoverTarget: props.id,
             popoverTargetAction: 'toggle',
           })}

--- a/src/core/menu/menu.tsx
+++ b/src/core/menu/menu.tsx
@@ -1,13 +1,11 @@
 import { AnchorMenuItem, MenuItem } from './item'
 import { ElMenuContent } from './styles'
+import { getPopoverTriggerProps as getMenuTriggerProps } from '#src/utils/popover'
 import { MenuDivider } from './divider'
 import { MenuGroup } from './group'
 import { Popover } from '#src/utils/popover'
 
 import type { HTMLAttributes } from 'react'
-
-// Make this helper available for convenience.
-export { getPopoverTriggerProps as getMenuTriggerProps } from '#src/utils/popover'
 
 // NOTE: We omit...
 // - role, because the Menu's role should always be "menu".
@@ -47,6 +45,7 @@ export function Menu({
       {...rest}
       aria-labelledby={ariaLabelledBy}
       anchorId={ariaLabelledBy}
+      borderRadius="var(--comp-menu-border-radius)"
       elevation="xl"
       gap={`var(${gap})`}
       maxHeight={`var(${maxHeight})`}
@@ -65,3 +64,6 @@ Menu.AnchorItem = AnchorMenuItem
 Menu.Divider = MenuDivider
 Menu.Group = MenuGroup
 Menu.Item = MenuItem
+
+// Make this helper available for convenience.
+Menu.getMenuTriggerProps = getMenuTriggerProps

--- a/src/core/menu/styles.ts
+++ b/src/core/menu/styles.ts
@@ -3,7 +3,6 @@ import { ElMenuGroup } from './group'
 import { ElMenuDivider } from './divider'
 
 export const ElMenuContent = styled.div`
-  border-radius: var(--comp-menu-border-radius);
   background: var(--colour-fill-white);
 
   padding: var(--spacing-2);

--- a/src/utils/popover/__tests__/popover.test.tsx
+++ b/src/utils/popover/__tests__/popover.test.tsx
@@ -54,6 +54,15 @@ test('can override the default elevation', () => {
   expect(screen.getByText('Popover content')).toHaveAttribute('data-elevation', 'xl')
 })
 
+test('provides custom CSS property for borderRadius when specified', () => {
+  render(
+    <Popover {...requiredProps} borderRadius="8px">
+      Popover content
+    </Popover>,
+  )
+  expect(screen.getByText('Popover content')).toHaveStyle('--popover-border-radius: 8px')
+})
+
 test('provides custom CSS property for maxWidth when specified', () => {
   render(
     <Popover {...requiredProps} maxWidth="300px">
@@ -72,13 +81,14 @@ test('provides custom CSS property for maxHeight when specified', () => {
   expect(screen.getByText('Popover content')).toHaveStyle('--popover-max-height: 200px')
 })
 
-test('provides custom CSS properties for both maxWidth and maxHeight when specified', () => {
+test('provides all custom CSS properties when specified', () => {
   render(
-    <Popover {...requiredProps} maxWidth="300px" maxHeight="200px">
+    <Popover {...requiredProps} borderRadius="8px" maxWidth="300px" maxHeight="200px">
       Popover content
     </Popover>,
   )
   const popover = screen.getByText('Popover content')
+  expect(popover).toHaveStyle('--popover-border-radius: 8px')
   expect(popover).toHaveStyle('--popover-max-width: 300px')
   expect(popover).toHaveStyle('--popover-max-height: 200px')
 })

--- a/src/utils/popover/popover.stories.tsx
+++ b/src/utils/popover/popover.stories.tsx
@@ -145,6 +145,18 @@ export const Placements: Story = {
 }
 
 /**
+ * The border radius of the popover element can be adjusted with the `borderRadius` prop. While
+ * this prop accepts any valid CSS length, it should typically be a border-radius-related CSS
+ * variable such as `--border-radius-xl` or `--comp-menu-border-radius`.
+ */
+export const BorderRadius: Story = {
+  args: {
+    ...Example.args,
+    borderRadius: 'var(--border-radius-xl)',
+  },
+}
+
+/**
  * By default, popovers will grow to the width of their content. To constrain this behaviour, a maximum
  * width can be specified. Content should generally adapt to the constrained width by wrapping rather
  * than overflowing.

--- a/src/utils/popover/popover.tsx
+++ b/src/utils/popover/popover.tsx
@@ -10,6 +10,11 @@ import type { PopoverPlacement } from './map-placement-to-css'
 export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
   /** The ID of the element this popover to which this popover should be anchored. */
   anchorId: string
+  /**
+   * The border radius of the popover. Can be any valid CSS length, though a border radius
+   * CSS variable is recommended. By default, the radius will be zero.
+   */
+  borderRadius?: string
   /** The content of the popover. */
   children: ReactNode
   /** The visual elevation of the popover. Determines how much shadow the popover casts. */
@@ -78,6 +83,7 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
  */
 export function Popover({
   anchorId,
+  borderRadius,
   children,
   className,
   elevation = 'none',
@@ -128,6 +134,7 @@ export function Popover({
       style={
         {
           ...style,
+          '--popover-border-radius': borderRadius,
           '--popover-max-height': maxHeight,
           '--popover-max-width': maxWidth,
         } as CSSProperties

--- a/src/utils/popover/styles.ts
+++ b/src/utils/popover/styles.ts
@@ -12,6 +12,7 @@ export const elPopover = css`
     padding: 0;
     margin: 0;
 
+    border-radius: var(--popover-border-radius, 0);
     max-height: var(--popover-max-height, max-content);
     max-width: var(--popover-max-width, max-content);
 


### PR DESCRIPTION
The new Menu's border radius is not working as expected. The popover's background is not transparent as intended, perhaps because of the box-shadow? 🤷 Either way, we need to shift the border-radius from the ElMenuContent styled element to the popover element itself.

<img width="110" height="203" alt="Screenshot 2025-07-31 at 8 22 28 am" src="https://github.com/user-attachments/assets/2c574a8e-fb51-4175-b666-31b4de09dadc" />
