### PR TITLE
fix: Avoid empty classes/styled elements

### DIFF
--- a/src/core/label-text/styles.ts
+++ b/src/core/label-text/styles.ts
@@ -21,4 +21,6 @@ export const ElLabelText = styled.span`
     color: var(--text-primary);
   }
 `
-export const ElLabelRequiredMark = styled.span``
+export const ElLabelRequiredMark = styled.span`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`

--- a/src/core/pagination/styles.ts
+++ b/src/core/pagination/styles.ts
@@ -1,6 +1,8 @@
 import { styled } from '@linaria/react'
 
-export const ElPagination = styled.nav``
+export const ElPagination = styled.nav`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 export const ElPaginationList = styled.ul`
   list-style: none;
@@ -12,7 +14,9 @@ export const ElPaginationList = styled.ul`
   gap: var(--spacing-6);
 `
 
-export const ElPaginationItem = styled.li``
+export const ElPaginationItem = styled.li`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 export const ElPaginationText = styled.span`
   text-align: center;

--- a/src/core/table/table-container/styles.ts
+++ b/src/core/table/table-container/styles.ts
@@ -1,3 +1,5 @@
 import { styled } from '@linaria/react'
 
-export const ElTableContainer = styled.div``
+export const ElTableContainer = styled.div`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`

--- a/src/core/table/table-toolbar/styles.ts
+++ b/src/core/table/table-toolbar/styles.ts
@@ -23,4 +23,6 @@ export const ElTableToolbarDescription = styled.div`
   letter-spacing: var(--font-sm-regular-letter_spacing);
 `
 
-export const ElTableToolbarActions = styled.div``
+export const ElTableToolbarActions = styled.div`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`

--- a/src/core/textarea/styles.ts
+++ b/src/core/textarea/styles.ts
@@ -2,7 +2,9 @@ import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 import type { CSSProperties, TextareaHTMLAttributes } from 'react'
 
-export const elTextAreaHasError = css``
+export const elTextAreaHasError = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 export type ContentFieldSizing = 'content'
 export type FixedFieldSizing = 'fixed'

--- a/src/core/top-bar/main-nav/styles.ts
+++ b/src/core/top-bar/main-nav/styles.ts
@@ -1,6 +1,8 @@
 import { styled } from '@linaria/react'
 
-export const ElTopBarMainNav = styled.nav``
+export const ElTopBarMainNav = styled.nav`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 export const ElTopBarMainNavList = styled.ul`
   display: flex;

--- a/src/core/top-bar/secondary-nav/styles.ts
+++ b/src/core/top-bar/secondary-nav/styles.ts
@@ -1,6 +1,8 @@
 import { styled } from '@linaria/react'
 
-export const ElTopBarSecondaryNav = styled.nav``
+export const ElTopBarSecondaryNav = styled.nav`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 export const ElTopBarSecondaryNavList = styled.ul`
   display: flex;

--- a/src/deprecated/avatar/__styles__/index.ts
+++ b/src/deprecated/avatar/__styles__/index.ts
@@ -2,7 +2,9 @@ import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
 /** @deprecated */
-export const elAvatarSmall = css``
+export const elAvatarSmall = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated will be replaced by new v5 ElAvatarRectangle */
 export const ElDeprecatedAvatar = styled.div`

--- a/src/deprecated/button/styles.ts
+++ b/src/deprecated/button/styles.ts
@@ -3,29 +3,51 @@ import { styled } from '@linaria/react'
 import { isMobile } from '#src/styles/deprecated-media'
 
 /** @deprecated */
-export const elDeprecatedButtonSizeSmall = css``
+export const elDeprecatedButtonSizeSmall = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonSizeMedium = css``
+export const elDeprecatedButtonSizeMedium = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonSizeLarge = css``
+export const elDeprecatedButtonSizeLarge = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elDeprecatedButtonLabel = css``
+export const elDeprecatedButtonLabel = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedIcon = css``
+export const elDeprecatedIcon = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonIconOnly = css``
+export const elDeprecatedButtonIconOnly = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonSpinner = css``
+export const elDeprecatedButtonSpinner = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated - Will be removed from future version */
-export const elDeprecatedFloatingButton = css``
+export const elDeprecatedFloatingButton = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonGroupAlignLeft = css``
+export const elDeprecatedButtonGroupAlignLeft = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonGroupAlignRight = css``
+export const elDeprecatedButtonGroupAlignRight = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elDeprecatedButtonGroupAlignCenter = css``
+export const elDeprecatedButtonGroupAlignCenter = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElDeprecatedButtonSpinner = styled.div`
@@ -68,7 +90,7 @@ const baseButtonStyles = `
   border-radius: var(--comp-button-border-radius-default);
   border: var(--comp-button-border-width-default) solid var(--comp-button-colour-border-secondary-default);
   text-decoration: none; /* For anchors */
-  
+
   .${elDeprecatedIcon} {
     padding: var(--spacing-half);
     color: var(--comp-button-colour-icon-secondary-defaul);
@@ -113,7 +135,7 @@ const baseButtonStyles = `
       font-weight: var(--font-base-medium-weight);
       line-height: var(--font-base-medium-line_height);
       letter-spacing: var(--font-base-medium-letter_spacing);
-      
+
     }
     .${elDeprecatedButtonSpinner} {
       height: 1.125rem;
@@ -211,7 +233,7 @@ const baseButtonStyles = `
       0px 0px 0px 4px var(--purple-300);
     outline: 0;
   }
-  
+
   /* TODO: no the token variable names not updated, since no design guide in figma */
   &.${elDeprecatedFloatingButton} {
     border-radius: 100%;

--- a/src/deprecated/card/__styles__/index.ts
+++ b/src/deprecated/card/__styles__/index.ts
@@ -27,7 +27,9 @@ export const ElCardWrap = styled.div`
 `
 
 /** @deprecated */
-export const elCardSubHeadingWrapAvatar = css``
+export const elCardSubHeadingWrapAvatar = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElCardHeadingWrap = styled.div`
@@ -77,7 +79,9 @@ export const ElCardSubHeading = styled.h6`
   font-size: var(--font-size-smallest);
 `
 
-export const elCardSubHeadingAdditionalExpanded = css``
+export const elCardSubHeadingAdditionalExpanded = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElCardSubHeadingAdditional = styled.h6`
@@ -91,7 +95,9 @@ export const ElCardSubHeadingAdditional = styled.h6`
   justify-content: space-between;
 `
 
-export const elCardBodyWrapExpanded = css``
+export const elCardBodyWrapExpanded = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElCardBodyWrap = styled.div`
@@ -155,7 +161,9 @@ export const ElCardList = styled.div`
 `
 
 /** @deprecated */
-export const elCardListMainWrapExpanded = css``
+export const elCardListMainWrapExpanded = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElCardListMainWrap = styled.div`

--- a/src/deprecated/form-layout/__styles__/index.ts
+++ b/src/deprecated/form-layout/__styles__/index.ts
@@ -3,7 +3,9 @@ import { styled } from '@linaria/react'
 import { isDesktop, isWideScreen, isTablet, isSuperWideScreen } from '../../../styles/deprecated-media'
 
 /** @deprecated */
-export const elFormLayoutHasMargin = css``
+export const elFormLayoutHasMargin = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElFormLayout = styled.div`

--- a/src/deprecated/input/__styles__/index.ts
+++ b/src/deprecated/input/__styles__/index.ts
@@ -2,7 +2,9 @@ import { styled } from '@linaria/react'
 import { css } from '@linaria/core'
 
 /** @deprecated */
-export const elHasInputError = css``
+export const elHasInputError = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElInput = styled.input`

--- a/src/deprecated/layout/styles.ts
+++ b/src/deprecated/layout/styles.ts
@@ -3,9 +3,13 @@ import { elHFull } from '../../styles/deprecated-sizing'
 import { css } from '@linaria/core'
 
 /** @deprecated */
-export const elHasGreyBackground = css``
+export const elHasGreyBackground = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasMaxWidth = css``
+export const elHasMaxWidth = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const elMainContainer = css`

--- a/src/deprecated/multi-select/__styles__/index.ts
+++ b/src/deprecated/multi-select/__styles__/index.ts
@@ -13,7 +13,9 @@ const dismiss = (fill: string) =>
   )}"/></svg>`
 
 /** @deprecated */
-export const elHasGreyChips = css``
+export const elHasGreyChips = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElMultiSelectCheckbox = styled.input`

--- a/src/deprecated/nav/__styles__/index.ts
+++ b/src/deprecated/nav/__styles__/index.ts
@@ -69,7 +69,9 @@ export const ElDeprecatedNavSubContainer = styled.div`
 `
 
 /** @deprecated */
-export const elDeprecatedNavItemSecondary = css``
+export const elDeprecatedNavItemSecondary = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElDeprecatedNavItem = styled.a`
@@ -329,7 +331,9 @@ export const ElDeprecatedNavResponsiveAvatarWrap = styled.div`
   }
 `
 
-export const elAppSwitcherOpen = css``
+export const elAppSwitcherOpen = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 export const ElNavResponsiveAppSwitcherWrap = styled.div`
   position: relative;

--- a/src/deprecated/page-header/__styles__/index.ts
+++ b/src/deprecated/page-header/__styles__/index.ts
@@ -11,7 +11,9 @@ const dot = `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
 `
 
 /** @deprecated */
-export const elDeprecatedPageHeaderMaxWidth = css``
+export const elDeprecatedPageHeaderMaxWidth = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElDeprecatedPageHeaderContainer = styled.div`

--- a/src/deprecated/persistent-notification/__styles__/index.ts
+++ b/src/deprecated/persistent-notification/__styles__/index.ts
@@ -13,13 +13,19 @@ import {
 } from '../../../styles/deprecated-intent'
 
 /** @deprecated */
-export const elPnIsFullWidth = css``
+export const elPnIsFullWidth = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elPnIsFixed = css``
+export const elPnIsFixed = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elPnIsInline = css``
+export const elPnIsInline = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const elPnIcon = css`

--- a/src/deprecated/split-button/styles.ts
+++ b/src/deprecated/split-button/styles.ts
@@ -8,10 +8,14 @@ import {
 import { ElDeprecatedIcon } from '#src/deprecated/icon'
 
 /** @deprecated */
-export const ElDeprecatedSplitButtonActionButton = styled(DeprecatedButton)``
+export const ElDeprecatedSplitButtonActionButton = styled(DeprecatedButton)`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const ElDeprecatedSplitButtonMenuButton = styled(DeprecatedButton)``
+export const ElDeprecatedSplitButtonMenuButton = styled(DeprecatedButton)`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElDeprecatedSplitButton = styled.div`

--- a/src/deprecated/status-indicator/__styles__/index.ts
+++ b/src/deprecated/status-indicator/__styles__/index.ts
@@ -13,7 +13,9 @@ import {
 /**
  * @deprecated
  */
-export const elDeprecatedShapeTag = css``
+export const elDeprecatedShapeTag = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /**
  * @deprecated

--- a/src/deprecated/table/__styles__/index.ts
+++ b/src/deprecated/table/__styles__/index.ts
@@ -157,7 +157,9 @@ export const elTableNarrowCellIsFullWidth = css`
 `
 
 /** @deprecated */
-export const elTableCellHasDarkText = css``
+export const elTableCellHasDarkText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const elTableRowFocused = css`

--- a/src/deprecated/tabs/styles.ts
+++ b/src/deprecated/tabs/styles.ts
@@ -24,7 +24,9 @@ export const elTabsFullWidth = css`
 `
 
 /** @deprecated */
-export const elTabsHasNoBorder = css``
+export const elTabsHasNoBorder = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElTab = styled.input`

--- a/src/deprecated/tile/__styles__/index.ts
+++ b/src/deprecated/tile/__styles__/index.ts
@@ -2,10 +2,14 @@ import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
 /** @deprecated */
-export const elTilePaddingSmall = css``
+export const elTilePaddingSmall = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elTilePaddingNone = css``
+export const elTilePaddingNone = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElTile = styled.div`

--- a/src/deprecated/toggle/__styles__/index.ts
+++ b/src/deprecated/toggle/__styles__/index.ts
@@ -2,7 +2,9 @@ import { styled } from '@linaria/react'
 import { css } from '@linaria/core'
 
 /** @deprecated */
-export const elHasGreyBg = css``
+export const elHasGreyBg = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const ElToggleItem = styled.span`

--- a/src/deprecated/typography/__styles__/index.ts
+++ b/src/deprecated/typography/__styles__/index.ts
@@ -10,29 +10,53 @@ import {
 } from '../../../styles/deprecated-intent'
 
 /** @deprecated */
-export const elHasGreyText = css``
+export const elHasGreyText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasNoMargin = css``
+export const elHasNoMargin = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasRegularText = css``
+export const elHasRegularText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasBoldText = css``
+export const elHasBoldText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasMediumText = css``
+export const elHasMediumText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasMargin = css``
+export const elHasMargin = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasItalicText = css``
+export const elHasItalicText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasCenteredText = css``
+export const elHasCenteredText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasSectionMargin = css``
+export const elHasSectionMargin = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasDisabledText = css``
+export const elHasDisabledText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasCapitalisedText = css``
+export const elHasCapitalisedText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elHasUpperCasedText = css``
+export const elHasUpperCasedText = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
 export const elTextBase = css`

--- a/src/styles/deprecated-intent.ts
+++ b/src/styles/deprecated-intent.ts
@@ -1,22 +1,36 @@
 import { css } from '@linaria/core'
 
 /** @deprecated */
-export const elIntentPrimary = css``
+export const elIntentPrimary = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elIntentNeutral = css``
+export const elIntentNeutral = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elIntentSuccess = css``
+export const elIntentSuccess = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elIntentPending = css``
+export const elIntentPending = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elIntentWarning = css``
+export const elIntentWarning = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elIntentDanger = css``
+export const elIntentDanger = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 
 /** @deprecated */
-export const elIntentDefault = css``
+export const elIntentDefault = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`

--- a/src/styles/deprecated-states.ts
+++ b/src/styles/deprecated-states.ts
@@ -1,10 +1,18 @@
 import { css } from '@linaria/core'
 
 /** @deprecated */
-export const elIsLoading = css``
+export const elIsLoading = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elIsActive = css``
+export const elIsActive = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elIsUsed = css``
+export const elIsUsed = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`
 /** @deprecated */
-export const elIsFullPage = css``
+export const elIsFullPage = css`
+  /* https://github.com/Anber/wyw-in-js/issues/144 */
+`


### PR DESCRIPTION
Linaria 0.7.0 does not play nicely with empty classes/styled elements, sometimes throwing build errors like `[wyw-in-js] Cannot use 'in' operator to search for 'initialCode' in undefined`. There is an [issue raised](https://github.com/Anber/wyw-in-js/issues/144) and a [PR to fix it](https://github.com/Anber/wyw-in-js/pull/147), but it remains unmerged.

This PR adds a CSS comment to all currently empty classes/styled elements. This appears to avoid the build issues, though given the build issues are intermittent anyway, it's hard to know if this will stand up over time.