### PR TITLE
feat: Add new `Tooltip`

### DIFF
--- a/src/core/menu/menu.tsx
+++ b/src/core/menu/menu.tsx
@@ -1,5 +1,5 @@
 import { AnchorMenuItem, MenuItem } from './item'
-import { ElMenuContent } from './styles'
+import { elMenu } from './styles'
 import { getPopoverTriggerProps as getMenuTriggerProps } from '#src/utils/popover'
 import { MenuDivider } from './divider'
 import { MenuGroup } from './group'
@@ -45,7 +45,7 @@ export function Menu({
       {...rest}
       aria-labelledby={ariaLabelledBy}
       anchorId={ariaLabelledBy}
-      borderRadius="var(--comp-menu-border-radius)"
+      className={elMenu}
       elevation="xl"
       gap={`var(${gap})`}
       maxHeight={`var(${maxHeight})`}
@@ -55,7 +55,7 @@ export function Menu({
       popover="auto"
       role="menu"
     >
-      <ElMenuContent>{children}</ElMenuContent>
+      {children}
     </Popover>
   )
 }

--- a/src/core/menu/styles.ts
+++ b/src/core/menu/styles.ts
@@ -1,9 +1,10 @@
-import { styled } from '@linaria/react'
+import { css } from '@linaria/core'
 import { ElMenuGroup } from './group'
 import { ElMenuDivider } from './divider'
 
-export const ElMenuContent = styled.div`
+export const elMenu = css`
   background: var(--colour-fill-white);
+  border-radius: var(--comp-menu-border-radius);
 
   padding: var(--spacing-2);
 

--- a/src/core/tooltip/__tests__/get-tooltip-trigger-props.test.ts
+++ b/src/core/tooltip/__tests__/get-tooltip-trigger-props.test.ts
@@ -1,0 +1,27 @@
+import { getTooltipTriggerProps } from '../get-tooltip-trigger-props'
+
+test('returns aria-describedby when `tooltipPurpose` is "describe"', () => {
+  const result = getTooltipTriggerProps({
+    id: 'trigger',
+    tooltipId: 'test-tooltip',
+    tooltipPurpose: 'describe',
+  })
+
+  expect(result).toEqual({
+    'aria-describedby': 'test-tooltip',
+    id: 'trigger',
+  })
+})
+
+test('returns aria-labelledby when `tooltipPurpose` is "label"', () => {
+  const result = getTooltipTriggerProps({
+    id: 'trigger',
+    tooltipId: 'test-tooltip',
+    tooltipPurpose: 'label',
+  })
+
+  expect(result).toEqual({
+    'aria-labelledby': 'test-tooltip',
+    id: 'trigger',
+  })
+})

--- a/src/core/tooltip/__tests__/is-tooltip-needed.test.ts
+++ b/src/core/tooltip/__tests__/is-tooltip-needed.test.ts
@@ -1,0 +1,65 @@
+import { isTooltipNeeded } from '../is-tooltip-needed'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+test('returns true when no truncationTargetId is provided', () => {
+  const result = isTooltipNeeded()
+  expect(result).toBe(true)
+})
+
+test('returns true when truncationTargetId is empty string', () => {
+  const result = isTooltipNeeded('')
+  expect(result).toBe(true)
+})
+
+test('returns true when element with given ID does not exist', () => {
+  const result = isTooltipNeeded('non-existent-element')
+  expect(result).toBe(true)
+})
+
+test('returns false when scrollWidth is less than clientWidth', () => {
+  const scrollWidth = 80
+  const clientWidth = 100
+  createElementWithDimensions('test-element', scrollWidth, clientWidth)
+
+  const result = isTooltipNeeded('test-element')
+  expect(result).toBe(false)
+})
+
+test('returns false when scrollWidth equals clientWidth', () => {
+  const scrollWidth = 100
+  const clientWidth = 100
+  createElementWithDimensions('test-element', scrollWidth, clientWidth)
+
+  const result = isTooltipNeeded('test-element')
+  expect(result).toBe(false)
+})
+
+test('returns true when scrollWidth is greater than clientWidth', () => {
+  const scrollWidth = 150
+  const clientWidth = 100
+  createElementWithDimensions('test-element', scrollWidth, clientWidth)
+
+  const result = isTooltipNeeded('test-element')
+  expect(result).toBe(true)
+})
+
+// Helper function to create an element with specific dimensions
+function createElementWithDimensions(id: string, scrollWidth: number, clientWidth: number): HTMLElement {
+  const element = document.createElement('div')
+  element.id = id
+
+  Object.defineProperty(element, 'scrollWidth', {
+    configurable: true,
+    value: scrollWidth,
+  })
+  Object.defineProperty(element, 'clientWidth', {
+    configurable: true,
+    value: clientWidth,
+  })
+
+  document.body.appendChild(element)
+  return element
+}

--- a/src/core/tooltip/__tests__/tooltip.test.tsx
+++ b/src/core/tooltip/__tests__/tooltip.test.tsx
@@ -1,0 +1,29 @@
+import { Tooltip } from '../tooltip'
+import { render, screen } from '@testing-library/react'
+
+// NOTE: the unit tests here do NOT test the show/hide behaviour of the tooltip
+// as that would constitute testing the DOM.
+
+const requiredProps = {
+  id: 'test-tooltip',
+  triggerId: 'trigger',
+}
+
+test('renders a tooltip element', () => {
+  render(<Tooltip {...requiredProps}>Tooltip content</Tooltip>)
+  expect(screen.getByRole('tooltip')).toBeVisible()
+})
+
+test('uses popover="hint"', () => {
+  render(<Tooltip {...requiredProps}>Tooltip content</Tooltip>)
+  expect(screen.getByRole('tooltip')).toHaveAttribute('popover', 'hint')
+})
+
+test('forwards additional props to the tooltip', () => {
+  render(
+    <Tooltip {...requiredProps} data-testid="test-id">
+      Tooltip content
+    </Tooltip>,
+  )
+  expect(screen.getByTestId('test-id')).toBeVisible()
+})

--- a/src/core/tooltip/__tests__/use-tooltip-controller.test.tsx
+++ b/src/core/tooltip/__tests__/use-tooltip-controller.test.tsx
@@ -1,0 +1,169 @@
+import { renderHook } from '@testing-library/react'
+import { useTooltipController } from '../use-tooltip-controller'
+import { isTooltipNeeded } from '../is-tooltip-needed'
+
+// Mock Popover API methods
+const mockShowPopover = vi.fn()
+const mockHidePopover = vi.fn()
+
+// Mock isTooltipNeeded function
+vi.mock('../is-tooltip-needed')
+const mockIsTooltipNeeded = vi.mocked(isTooltipNeeded)
+
+let triggerElement: HTMLElement
+let tooltipElement: HTMLElement
+
+beforeEach(() => {
+  // Create mock DOM elements
+  tooltipElement = document.createElement('div')
+  tooltipElement.id = 'test-tooltip'
+
+  triggerElement = document.createElement('button')
+  triggerElement.id = 'test-trigger'
+
+  // Mock Popover API methods
+  tooltipElement.showPopover = mockShowPopover
+  tooltipElement.hidePopover = mockHidePopover
+
+  // Add elements to DOM
+  document.body.appendChild(triggerElement)
+  document.body.appendChild(tooltipElement)
+
+  // Default mock for isTooltipNeeded to return true
+  mockIsTooltipNeeded.mockReturnValue(true)
+})
+
+afterEach(() => {
+  // Clean up DOM
+  document.body.removeChild(triggerElement)
+  document.body.removeChild(tooltipElement)
+
+  // Reset mocks
+  mockShowPopover.mockClear()
+  mockHidePopover.mockClear()
+  mockIsTooltipNeeded.mockClear()
+})
+
+test('calls showPopover on anchor focus', () => {
+  renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+    }),
+  )
+
+  triggerElement.dispatchEvent(new Event('focus'))
+  expect(mockShowPopover).toHaveBeenCalledTimes(1)
+})
+
+test('calls hidePopover on anchor blur', () => {
+  renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+    }),
+  )
+
+  triggerElement.dispatchEvent(new Event('blur'))
+  expect(mockHidePopover).toHaveBeenCalledTimes(1)
+})
+
+test('calls showPopover on anchor mouseenter', () => {
+  renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+    }),
+  )
+
+  triggerElement.dispatchEvent(new Event('mouseenter'))
+  expect(mockShowPopover).toHaveBeenCalledTimes(1)
+})
+
+test('calls hidePopover on anchor mouseleave when not focus-visible', () => {
+  // Mock matches to return false for :focus-visible
+  triggerElement.matches = vi.fn().mockReturnValue(false)
+
+  renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+    }),
+  )
+
+  triggerElement.dispatchEvent(new Event('mouseleave'))
+  expect(mockHidePopover).toHaveBeenCalledTimes(1)
+  expect(triggerElement.matches).toHaveBeenCalledWith(':focus-visible')
+})
+
+test('does not call hidePopover on anchor mouseleave when focus-visible', () => {
+  // Mock matches to return true for :focus-visible
+  triggerElement.matches = vi.fn().mockReturnValue(true)
+
+  renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+    }),
+  )
+
+  triggerElement.dispatchEvent(new Event('mouseleave'))
+  expect(mockHidePopover).not.toHaveBeenCalled()
+  expect(triggerElement.matches).toHaveBeenCalledWith(':focus-visible')
+})
+
+test('does not throw when elements do not exist', () => {
+  expect(() => {
+    renderHook(() =>
+      useTooltipController({
+        tooltipId: 'non-existent-tooltip',
+        triggerId: 'non-existent-anchor',
+      }),
+    )
+  }).not.toThrow()
+})
+
+test('removes event listeners on cleanup', () => {
+  const { unmount } = renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+    }),
+  )
+
+  // Verify events work before unmount
+  triggerElement.dispatchEvent(new Event('focus'))
+  expect(mockShowPopover).toHaveBeenCalledTimes(1)
+
+  // Unmount the hook
+  unmount()
+
+  // Events should no longer trigger after cleanup
+  triggerElement.dispatchEvent(new Event('focus'))
+  expect(mockShowPopover).toHaveBeenCalledTimes(1) // Still 1, not 2
+})
+
+test('does not show tooltip when isTooltipNeeded returns false', () => {
+  // Mock isTooltipNeeded to return false
+  mockIsTooltipNeeded.mockReturnValue(false)
+
+  renderHook(() =>
+    useTooltipController({
+      tooltipId: 'test-tooltip',
+      triggerId: 'test-trigger',
+      truncationTargetId: 'test-truncation-target',
+    }),
+  )
+
+  // Try all the trigger events
+  triggerElement.dispatchEvent(new Event('focus'))
+  triggerElement.dispatchEvent(new Event('mouseenter'))
+  triggerElement.dispatchEvent(new Event('blur'))
+  triggerElement.dispatchEvent(new Event('mouseleave'))
+
+  expect(mockIsTooltipNeeded).toHaveBeenCalledWith('test-truncation-target')
+
+  // None of the popover methods should be called
+  expect(mockShowPopover).not.toHaveBeenCalled()
+  expect(mockHidePopover).not.toHaveBeenCalled()
+})

--- a/src/core/tooltip/get-tooltip-trigger-props.ts
+++ b/src/core/tooltip/get-tooltip-trigger-props.ts
@@ -1,0 +1,44 @@
+interface GetTooltipTriggerPropsInput {
+  /** The ID of the trigger element. This must match what is provided to the Tooltip component. */
+  id: string
+  /** The ID of the tooltip element. This must match what is provided to the Tooltip component. */
+  tooltipId: string
+  /**
+   * The purpose of the tooltip. Does it label the trigger, or does it describe it?
+   * Typically, tooltips will describe their trigger via `aria-describedby`. However, there are cases
+   * (like icon-only buttons) where they should label their trigger.
+   */
+  tooltipPurpose: 'label' | 'describe'
+}
+
+interface GetTooltipTriggerPropsOutput {
+  'aria-describedby'?: string
+  'aria-labelledby'?: string
+  id: string
+}
+
+/**
+ * Generates appropriate ARIA attributes for tooltip trigger elements.
+ *
+ * This function returns the correct ARIA attributes to associate a trigger element
+ * (like a button) with its corresponding tooltip. It supports two modes:
+ * - 'describe': Uses `aria-describedby` for tooltips that provide additional description
+ * - 'label': Uses `aria-labelledby` for tooltips that serve as the primary label (e.g., icon-only buttons)
+ */
+export function getTooltipTriggerProps({
+  id,
+  tooltipId,
+  tooltipPurpose,
+}: GetTooltipTriggerPropsInput): GetTooltipTriggerPropsOutput {
+  if (tooltipPurpose === 'describe') {
+    return {
+      'aria-describedby': tooltipId,
+      id,
+    }
+  } else {
+    return {
+      'aria-labelledby': tooltipId,
+      id,
+    }
+  }
+}

--- a/src/core/tooltip/index.ts
+++ b/src/core/tooltip/index.ts
@@ -1,0 +1,5 @@
+export * from './get-tooltip-trigger-props'
+export * from './is-tooltip-needed'
+export * from './styles'
+export * from './tooltip'
+export * from './use-tooltip-controller'

--- a/src/core/tooltip/is-tooltip-needed.ts
+++ b/src/core/tooltip/is-tooltip-needed.ts
@@ -1,0 +1,22 @@
+/**
+ * Determines whether a tooltip should be displayed based on content truncation.
+ *
+ * @param truncationTargetId - The ID of the DOM element to check for text truncation
+ * @returns `true` if tooltip should be shown (content is truncated or fallback conditions apply), `false` otherwise
+ */
+export function isTooltipNeeded(truncationTargetId?: string): boolean {
+  // If no truncation ID is provided, assume a truncation check is not required.
+  // In this case, return `true` to ensure the Tooltip is displayed as normal.
+  if (!truncationTargetId) return true
+
+  const truncationTargetElement = document.getElementById(truncationTargetId)
+
+  // Fallback mechanism: If the target element is not found in the DOM, return `true` to ensure
+  // the Tooltip is displayed as normal.
+  if (!truncationTargetElement) return true
+
+  // We can detect truncated content in an element by comparing its scroll width with its client
+  // width. If the scroll width is greater than the client width, the content of the element is
+  // truncated and we therefore want the tooltip to display as normal.
+  return truncationTargetElement.scrollWidth > truncationTargetElement.clientWidth
+}

--- a/src/core/tooltip/styles.ts
+++ b/src/core/tooltip/styles.ts
@@ -1,0 +1,14 @@
+import { css } from '@linaria/core'
+import { font } from '#src/core/text'
+
+export const elTooltip = css`
+  border-radius: var(--comp-tooltip-border-radius);
+  background: var(--comp-tooltip-colour-fill);
+  color: var(--comp-tooltip-colour-text);
+
+  padding: var(--spacing-2) var(--spacing-3);
+  width: max-content;
+
+  ${font('xs', 'regular')}
+  text-align: left;
+`

--- a/src/core/tooltip/tooltip.stories.tsx
+++ b/src/core/tooltip/tooltip.stories.tsx
@@ -1,0 +1,132 @@
+import { Tooltip } from './tooltip'
+import { useId } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Tooltip',
+  component: Tooltip,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    label: {
+      control: 'text',
+    },
+    maxWidth: {
+      control: 'text',
+      table: {
+        type: {
+          summary: '--size-*',
+        },
+      },
+    },
+    placement: {
+      control: 'select',
+      options: [
+        'top',
+        'top-start',
+        'top-end',
+        'right',
+        'right-start',
+        'right-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+        'left-start',
+        'left-end',
+      ],
+    },
+  },
+  render: (args) => {
+    // NOTE: because we have multiple stories on the one docs page, we append a "suffix" to
+    // the IDs so they are unique per story. This ensures our positioning of the tooltip will
+    // be anchored to the correct element.
+    const suffix = useId()
+    const props = {
+      ...args,
+      id: `${args.id}-${suffix}`,
+      triggerId: `${args.triggerId}-${suffix}`,
+      truncationTargetId: args.truncationTargetId ? `${args.truncationTargetId}-${suffix}` : undefined,
+    }
+
+    return (
+      <>
+        <button
+          {...Tooltip.getTooltipTriggerProps({ id: props.triggerId, tooltipId: props.id, tooltipPurpose: 'describe' })}
+          style={{
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            width: '100%',
+          }}
+        >
+          Hover or focus me!
+        </button>
+        <Tooltip {...props} />
+      </>
+    )
+  },
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Tooltip>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: "I'm a helpful tooltip, short and concise",
+    id: 'tooltip',
+    triggerId: 'trigger',
+  },
+}
+
+/**
+ * Tooltips can be positioned in different locations relative to their trigger element.
+ * The placement can be customized using the `placement` prop.
+ */
+export const Placement: Story = {
+  args: {
+    ...Example.args,
+    placement: 'bottom',
+  },
+}
+
+/**
+ * Tooltips will grow to the width of their content, up to a default maximum of `--size-100` (400px).
+ * This maximum width can be overridden when required.
+ */
+export const MaxWidth: Story = {
+  args: {
+    ...Example.args,
+    children: 'This is a very long tooltip message that will wrap to additional lines.',
+    maxWidth: '--size-40',
+  },
+}
+
+/**
+ * In some cases, we only want the tooltip to display if some or all of the trigger's content is truncated.
+ * By specifying a `truncationTargetId`, the tooltip will only display on focus/hover if that targeted
+ * element's content is not fully visible.
+ */
+export const ConditionalDisplay: Story = {
+  args: {
+    ...Example.args,
+    children: 'Hover or focus me!',
+    truncationTargetId: 'trigger',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)' }}>
+        <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '50px' }}>
+          <Story />
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/core/tooltip/tooltip.tsx
+++ b/src/core/tooltip/tooltip.tsx
@@ -1,0 +1,72 @@
+import { elTooltip } from './styles'
+import { getTooltipTriggerProps } from './get-tooltip-trigger-props'
+import { Popover } from '#src/utils/popover'
+import { useTooltipController } from './use-tooltip-controller'
+
+import type { HTMLAttributes } from 'react'
+import type { PopoverPlacement } from '#src/utils/popover'
+
+// NOTE: We omit...
+// - role, because the Tooltip's role should always be "menu".
+type AttributesToOmit = 'role'
+
+export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
+  /** The ID of the tooltip. */
+  id: string
+  /** The maximum width of the menu. By default, the menu will be as wide as its widest item. */
+  maxWidth?: `--size-${string}`
+  /** Where the popover should be placed relative to its anchor. */
+  placement?: PopoverPlacement
+  /**
+   * The ID of the element described by this tooltip. When this element receives focus or is
+   * hovered by the mouse, the tooltip will be displayed.
+   */
+  triggerId: string
+  /**
+   * The ID of element to measure for truncation. If supplied, the tooltip will only display
+   * if this element's content has been truncated.
+   */
+  truncationTargetId?: string
+}
+
+/**
+ * Tooltips are triggered on pointer hover or keyboard focus. They are used to provide additional information
+ * about an element. Tooltips leverage the
+ * [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) using `popover="hint"`, which
+ * falls back to `popover="manual"` in browsers that do not support it.
+ *
+ * Typically, tooltips are used to describe elements, but in some cases, like icon-only buttons, they can be used
+ * to label elements too. To assist with this, `Tooltip.getTooltipTriggerProps` can be used to set the correct
+ * ARIA attributes on the trigger based on the tooltip's purpose.
+ */
+export function Tooltip({
+  children,
+  id,
+  maxWidth = '--size-100',
+  placement = 'top',
+  triggerId,
+  truncationTargetId,
+  ...rest
+}: TooltipProps) {
+  useTooltipController({ tooltipId: id, triggerId, truncationTargetId })
+
+  return (
+    <Popover
+      {...rest}
+      anchorId={triggerId}
+      className={elTooltip}
+      elevation="none"
+      gap="var(--spacing-1)"
+      id={id}
+      maxWidth={`var(${maxWidth})`}
+      placement={placement}
+      positionTryFallbacks="flip-block, flip-inline"
+      popover="hint"
+      role="tooltip"
+    >
+      {children}
+    </Popover>
+  )
+}
+
+Tooltip.getTooltipTriggerProps = getTooltipTriggerProps

--- a/src/core/tooltip/use-tooltip-controller.ts
+++ b/src/core/tooltip/use-tooltip-controller.ts
@@ -1,0 +1,70 @@
+import { isTooltipNeeded } from './is-tooltip-needed'
+import { useEffect } from 'react'
+
+interface UseTooltipControllerInput {
+  /** The ID of the tooltip element. Must be a popover (i.e. have the `popover` attribute). */
+  tooltipId: string
+  /** The ID of the element for which the tooltip is displayed. */
+  triggerId: string
+  /**
+   * The ID of the element to measure for truncation. When supplied, the tooltip will only be
+   * shown if this element is currently truncated.
+   */
+  truncationTargetId?: string
+}
+
+/**
+ * A React hook that sets up tooltip behavior for an element (the "trigger") using the
+ * [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API).
+ * This hook automatically shows/hides a tooltip popover when the trigger element is:
+ * - Focused/blurred (for keyboard accessibility)
+ * - Hovered/unhovered (for mouse interaction)
+ */
+export function useTooltipController({ tooltipId, triggerId, truncationTargetId }: UseTooltipControllerInput): void {
+  useEffect(
+    function subscribeToAnchorEvents() {
+      if (!isTooltipNeeded(truncationTargetId)) {
+        return
+      }
+
+      // TODO: We are relying on element IDs instead of refs because we want to avoid the
+      // complexity of using `forwardRef` in Tooltip. Once we're on React 19 and refs are a normal prop,
+      // we'll be able to pass a ref directly to Tooltip without any extra cost.
+      //
+      // Until then, we simply get the tooltip and trigger elements via their IDs.
+      const tooltipElement = document.getElementById(tooltipId)
+      const triggerElement = document.getElementById(triggerId)
+
+      // Because we're setting up multiple event listeners, we're using an abort AbortController
+      // to unsubscribe them all in the effect's cleanup function.
+      const abortController = new AbortController()
+      const signal = abortController.signal
+
+      if (tooltipElement instanceof HTMLElement && triggerElement instanceof HTMLElement) {
+        // Keyboard accessibility
+        triggerElement.addEventListener('focus', () => tooltipElement.showPopover(), { signal })
+        triggerElement.addEventListener('blur', () => tooltipElement.hidePopover(), { signal })
+
+        // Mouse interaction
+        triggerElement.addEventListener('mouseenter', () => tooltipElement.showPopover(), { signal })
+        triggerElement.addEventListener(
+          'mouseleave',
+          () => {
+            // NOTE: we only want to hide the tooltip if its trigger doesn't currently have focus
+            // from keyboard navigation. We don't care if it's focused due to interaction.
+            if (!triggerElement.matches(':focus-visible')) {
+              tooltipElement.hidePopover()
+            }
+          },
+          { signal },
+        )
+      }
+
+      return () => {
+        // Clean up all the event listeners in a single hit.
+        abortController.abort()
+      }
+    },
+    [triggerId, tooltipId],
+  )
+}

--- a/src/deprecated/tooltip/tooltip.stories.tsx
+++ b/src/deprecated/tooltip/tooltip.stories.tsx
@@ -7,7 +7,7 @@ import { useId } from 'react'
 import { FlexContainer } from '../../deprecated/layout'
 
 const meta: Meta<typeof DeprecatedTooltip> = {
-  title: 'Core/Tooltip',
+  title: 'Deprecated/Tooltip',
   component: DeprecatedTooltip,
   argTypes: {
     description: {

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -25,6 +25,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add new `Menu`. See [Menu](?path=/docs/core-menu--docs) for details.
 - **chore:** Use new `Menu` in `BottomBar.MenuItem`.
 - **chore!:** Deprecate `Tooltip` component. It is still available, but is now called `DeprecatedTooltip`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from `@reapit/elements/deprecated/tooltip`, as well as the root entry point, `@reapit/elements`.
+- **feat:** Add new `Tooltip`. See [Tooltip](?path=/docs/core-tooltip--docs) for details.
 
 ### **5.0.0-beta.39 - 23/07/25**
 

--- a/src/utils/popover/index.ts
+++ b/src/utils/popover/index.ts
@@ -1,3 +1,5 @@
 export * from './get-popover-trigger-props'
 export * from './popover'
 export * from './styles'
+
+export type { PopoverPlacement } from './map-placement-to-css'

--- a/src/utils/popover/popover.tsx
+++ b/src/utils/popover/popover.tsx
@@ -44,12 +44,14 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
    * [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover)
    * for more details.
    *
+   * For browsers that do not support `hint`, they will fallback to `manual`.
+   *
    * A special value of `null` allows the popover to not be a popover. This can be useful when you need
    * to display a popover element permanently in the UI (such as in documentation or example code). Just
    * note that the absence of the `popover` attribute means the element will not be displayed within the
    * top-layer, so may be susceptible to z-index issues.
    */
-  popover?: 'auto' | 'manual' | null
+  popover?: 'auto' | 'hint' | 'manual' | null
   /** Where the popover should be placed relative to its anchor. */
   placement: PopoverPlacement
   /**


### PR DESCRIPTION
### Context

- We want to leverage the new Popover utility component for our tooltips.
- The existing Tooltip component has a number of API choices that make it awkward to maintain backwards compatibility with if it's internal implementation moves to Popover.
- Thus we want to deprecate the existing Tooltip and implement a new replacement.
- Previous work includes:
  - #649 

### This PR

- Adds new `Tooltip` component.

<img width="817" height="662" alt="Screenshot 2025-07-31 at 4 39 00 pm" src="https://github.com/user-attachments/assets/2770fefb-9168-4fef-9fa3-393523c24df3" />
<img width="819" height="548" alt="Screenshot 2025-07-31 at 4 39 09 pm" src="https://github.com/user-attachments/assets/d50ea1c0-f6c4-43da-b2f5-35dc93fcac4d" />
<img width="817" height="379" alt="Screenshot 2025-07-31 at 4 39 13 pm" src="https://github.com/user-attachments/assets/22ff3bc6-1813-42b8-b128-f6890f22b449" />
