### PR TITLE
chore: use new `Menu` in core components

### DIFF
--- a/src/core/app-switcher/__tests__/app-switcher.test.tsx
+++ b/src/core/app-switcher/__tests__/app-switcher.test.tsx
@@ -4,12 +4,17 @@ import * as stories from '../app-switcher.stories'
 
 const AppSwitcherStories = composeStories(stories)
 
-test('menu is not visible by default', () => {
+test('app switcher button will open the menu when clicked', () => {
   render(<AppSwitcherStories.Example />)
-  // NOTE: the underlying menu component currently assigns role="menu" to the content of the popover
-  // which is not rendered when the menu is closed, hence our use of `queryByRole and `toBeInTheDocument`
-  // instead of `getByRole` and `toBeVisible`.
-  expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+  const trigger = screen.getByRole('button', { name: 'App Switcher' })
+  const menu = screen.getByRole('menu')
+  expect(trigger).toHaveAttribute('popovertarget', menu.id)
+})
+
+test('menu is labelled by the trigger button', () => {
+  render(<AppSwitcherStories.Example />)
+  expect(screen.getByRole('menu', { name: 'App Switcher' })).toBeVisible()
 })
 
 test('menu trigger button is visible', () => {

--- a/src/core/app-switcher/app-avatar/__test__/__snapshots__/app-avatar.test.tsx.snap
+++ b/src/core/app-switcher/app-avatar/__test__/__snapshots__/app-avatar.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`renders agentBox icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -63,7 +62,6 @@ exports[`renders agentBox icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -121,7 +119,6 @@ exports[`renders autoResponder icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -147,7 +144,6 @@ exports[`renders autoResponder icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -173,7 +169,6 @@ exports[`renders consoleCloud icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -228,7 +223,6 @@ exports[`renders consoleCloud icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -282,7 +276,6 @@ exports[`renders ireWeb icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -323,7 +316,6 @@ exports[`renders ireWeb icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -363,7 +355,6 @@ exports[`renders keywhere icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -401,7 +392,6 @@ exports[`renders keywhere icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -439,7 +429,6 @@ exports[`renders lettingsBDM icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -465,7 +454,6 @@ exports[`renders lettingsBDM icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -491,7 +479,6 @@ exports[`renders reapitForms icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -529,7 +516,6 @@ exports[`renders reapitForms icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -567,7 +553,6 @@ exports[`renders reapitProposals icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -593,7 +578,6 @@ exports[`renders reapitProposals icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -619,7 +603,6 @@ exports[`renders reapitWebsites icon when \`hasAccess\` is false 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"
@@ -661,7 +644,6 @@ exports[`renders reapitWebsites icon when \`hasAccess\` is true 1`] = `
 <DocumentFragment>
   <svg
     fill="none"
-    font-size="40"
     height="40"
     viewBox="0 0 40 40"
     width="40"

--- a/src/core/app-switcher/app-avatar/app-avatar.tsx
+++ b/src/core/app-switcher/app-avatar/app-avatar.tsx
@@ -31,25 +31,24 @@ interface AppAvatarProps {
  * access to the product. When user's do not have access, the avatar will be greyed out.
  */
 export function AppAvatar({ hasAccess, productId }: AppAvatarProps) {
-  const fontSize = '40'
   switch (productId) {
     case 'consoleCloud':
-      return hasAccess ? <ReapitPM fontSize={fontSize} /> : <ReapitPMDisabled fontSize={fontSize} />
+      return hasAccess ? <ReapitPM /> : <ReapitPMDisabled />
     case 'agentBox':
-      return hasAccess ? <ReapitSales fontSize={fontSize} /> : <ReapitSalesDisabled fontSize={fontSize} />
+      return hasAccess ? <ReapitSales /> : <ReapitSalesDisabled />
     case 'ireWeb':
-      return hasAccess ? <ReapitLettings fontSize={fontSize} /> : <ReapitLettingsDisabled fontSize={fontSize} />
+      return hasAccess ? <ReapitLettings /> : <ReapitLettingsDisabled />
     case 'reapitForms':
-      return hasAccess ? <ReapitForms fontSize={fontSize} /> : <ReapitFormsDisabled fontSize={fontSize} />
+      return hasAccess ? <ReapitForms /> : <ReapitFormsDisabled />
     case 'reapitWebsites':
-      return hasAccess ? <ReapitWebsites fontSize={fontSize} /> : <ReapitWebsitesDisabled fontSize={fontSize} />
+      return hasAccess ? <ReapitWebsites /> : <ReapitWebsitesDisabled />
     case 'reapitProposals':
-      return hasAccess ? <ReapitProposals fontSize={fontSize} /> : <ReapitProposalsDisabled fontSize={fontSize} />
+      return hasAccess ? <ReapitProposals /> : <ReapitProposalsDisabled />
     case 'keywhere':
-      return hasAccess ? <KeyWhere fontSize={fontSize} /> : <KeyWhereDisabled fontSize={fontSize} />
+      return hasAccess ? <KeyWhere /> : <KeyWhereDisabled />
     case 'autoResponder':
-      return hasAccess ? <AutoResponder fontSize={fontSize} /> : <AutoResponderDisabled fontSize={fontSize} />
+      return hasAccess ? <AutoResponder /> : <AutoResponderDisabled />
     case 'lettingsBDM':
-      return hasAccess ? <LettingsBDM fontSize={fontSize} /> : <LettingsBDMDisabled fontSize={fontSize} />
+      return hasAccess ? <LettingsBDM /> : <LettingsBDMDisabled />
   }
 }

--- a/src/core/app-switcher/app-switcher.stories.tsx
+++ b/src/core/app-switcher/app-switcher.stories.tsx
@@ -36,19 +36,13 @@ export const Example: Story = {
       <AppSwitcher.YourAppsMenuGroup key="1">
         <AppSwitcher.ProductMenuItem href={href} productId="ireWeb" />
       </AppSwitcher.YourAppsMenuGroup>,
-      <AppSwitcher.ExploreMenuGroup key="2">
+      <AppSwitcher.Divider key="2" />,
+      <AppSwitcher.ExploreMenuGroup key="3">
         <AppSwitcher.ProductMenuItem href={href} productId="consoleCloud" />
         <AppSwitcher.ProductMenuItem href={href} productId="keywhere" />
       </AppSwitcher.ExploreMenuGroup>,
     ],
   },
-  decorators: [
-    (Story) => (
-      <div style={{ width: '400px', height: '400px' }}>
-        <Story />
-      </div>
-    ),
-  ],
 }
 
 /**
@@ -95,11 +89,14 @@ export const AllAccessible: StoryObj<{ accessibleProductIds: string[] }> = {
     return (
       <>
         {displayableProductsForYourAppsGroup.length > 0 && (
-          <AppSwitcher.YourAppsMenuGroup>
-            {displayableProductsForYourAppsGroup.map((productId) => (
-              <AppSwitcher.ProductMenuItem key={productId} href={href} productId={productId} />
-            ))}
-          </AppSwitcher.YourAppsMenuGroup>
+          <>
+            <AppSwitcher.YourAppsMenuGroup>
+              {displayableProductsForYourAppsGroup.map((productId) => (
+                <AppSwitcher.ProductMenuItem key={productId} href={href} productId={productId} />
+              ))}
+            </AppSwitcher.YourAppsMenuGroup>
+            <AppSwitcher.Divider />
+          </>
         )}
         {displayableProductsForExploreGroup.length > 0 && (
           <AppSwitcher.ExploreMenuGroup>

--- a/src/core/app-switcher/app-switcher.tsx
+++ b/src/core/app-switcher/app-switcher.tsx
@@ -4,10 +4,10 @@ import { AppSwitcherMenuItem } from './menu-item'
 import { AppSwitcherNavIconButton } from './nav-icon-button'
 import { AppSwitcherProductMenuItem } from './product-menu-item'
 import { AppSwitcherYourAppsMenuGroup } from './your-apps-menu-group'
-import { ElAppSwitcherSectionDivider } from './styles'
 import { getDisplayableProductsForYourAppsGroup } from './get-displayable-products-for-your-apps-group'
 import { getDisplayableProductsForExploreGroup } from './get-displayable-products-for-explore-group'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
+import { useId } from 'react'
 
 import type { ReactNode } from 'react'
 
@@ -24,20 +24,23 @@ interface AppSwitcherProps {
  * Explore group).
  */
 export function AppSwitcher({ children }: AppSwitcherProps) {
+  const triggerId = useId()
+  const menuId = useId()
+
   return (
-    <DeprecatedMenu>
-      <DeprecatedMenu.Trigger>
-        {({ getTriggerProps }) => <AppSwitcherNavIconButton {...getTriggerProps()} />}
-      </DeprecatedMenu.Trigger>
-      <DeprecatedMenu.Popover>
-        <DeprecatedMenu.List>{children}</DeprecatedMenu.List>
-      </DeprecatedMenu.Popover>
-    </DeprecatedMenu>
+    <>
+      <AppSwitcherNavIconButton
+        {...Menu.getMenuTriggerProps({ id: triggerId, popoverTarget: menuId, popoverTargetAction: 'toggle' })}
+      />
+      <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-start">
+        {children}
+      </Menu>
+    </>
   )
 }
 
 AppSwitcher.AppAvatar = AppAvatar
-AppSwitcher.Divider = ElAppSwitcherSectionDivider
+AppSwitcher.Divider = Menu.Divider
 AppSwitcher.ExploreMenuGroup = AppSwitcherExploreMenuGroup
 AppSwitcher.MenuItem = AppSwitcherMenuItem
 AppSwitcher.ProductMenuItem = AppSwitcherProductMenuItem

--- a/src/core/app-switcher/explore-menu-group/__test__/__snapshots__/explore-menu-group.test.tsx.snap
+++ b/src/core/app-switcher/explore-menu-group/__test__/__snapshots__/explore-menu-group.test.tsx.snap
@@ -3,20 +3,17 @@
 exports[`renders AppSwitcherExploreMenuGroup properly 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-10 el-deprecated-menu-item-group"
+    aria-labelledby=":r0:"
+    class="mocked-styled-1 el-menu-group"
     role="group"
   >
     <div
-      class="mocked-styled-9 el-deprecated-menu-item-group-title"
+      class="mocked-styled-2 el-menu-group-label-container"
+      id=":r0:"
     >
       EXPLORE
     </div>
-    <div
-      class="mocked-styled-11 el-deprecated-menu-item-group-list"
-      style="max-height: var(undefined);"
-    >
-      Fake child
-    </div>
+    Fake child
   </div>
 </DocumentFragment>
 `;

--- a/src/core/app-switcher/explore-menu-group/explore-menu-group.tsx
+++ b/src/core/app-switcher/explore-menu-group/explore-menu-group.tsx
@@ -1,5 +1,5 @@
 import { AppSwitcherMenuGroupHasAccessContext } from '../menu-group-has-access-context'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 
 import type { ReactNode } from 'react'
 
@@ -9,11 +9,11 @@ interface AppSwitcherMenuGroupProps {
 
 function AppSwitcherExploreMenuGroup({ children }: AppSwitcherMenuGroupProps) {
   return (
-    <DeprecatedMenu.Group label={'EXPLORE'}>
+    <Menu.Group label={'EXPLORE'}>
       <AppSwitcherMenuGroupHasAccessContext.Provider value={false}>
         {children}
       </AppSwitcherMenuGroupHasAccessContext.Provider>
-    </DeprecatedMenu.Group>
+    </Menu.Group>
   )
 }
 

--- a/src/core/app-switcher/index.ts
+++ b/src/core/app-switcher/index.ts
@@ -1,4 +1,3 @@
-export * from './styles'
 export * from './app-avatar'
 export * from './app-switcher'
 export * from './explore-menu-group'

--- a/src/core/app-switcher/menu-item/__test__/__snapshots__/menu-item.test.tsx.snap
+++ b/src/core/app-switcher/menu-item/__test__/__snapshots__/menu-item.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`renders the provided logo, app name and supplementary info 1`] = `
     >
       <svg
         fill="none"
-        font-size="40"
         height="40"
         viewBox="0 0 40 40"
         width="40"

--- a/src/core/app-switcher/nav-icon-button/nav-icon-button.tsx
+++ b/src/core/app-switcher/nav-icon-button/nav-icon-button.tsx
@@ -4,7 +4,7 @@ import { TopBarNavIconItemButton } from '../../top-bar'
 import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
 
 interface AppSwitcherNavIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  onClick: MouseEventHandler<HTMLButtonElement>
+  onClick?: MouseEventHandler<HTMLButtonElement>
 }
 
 export function AppSwitcherNavIconButton({ 'aria-label': ariaLabel, ...rest }: AppSwitcherNavIconButtonProps) {

--- a/src/core/app-switcher/styles.ts
+++ b/src/core/app-switcher/styles.ts
@@ -1,6 +1,0 @@
-import { styled } from '@linaria/react'
-
-export const ElAppSwitcherSectionDivider = styled.div`
-  border-bottom: var(--border-width-default) solid var(--colour-border-light_default);
-  margin: var(--size-1) 0;
-`

--- a/src/core/app-switcher/your-apps-menu-group/__test__/__snapshots__/your-apps-menu-group.test.tsx.snap
+++ b/src/core/app-switcher/your-apps-menu-group/__test__/__snapshots__/your-apps-menu-group.test.tsx.snap
@@ -3,20 +3,17 @@
 exports[`renders AppSwitcherYourAppsMenuGroup properly 1`] = `
 <DocumentFragment>
   <div
-    class="mocked-styled-10 el-deprecated-menu-item-group"
+    aria-labelledby=":r0:"
+    class="mocked-styled-1 el-menu-group"
     role="group"
   >
     <div
-      class="mocked-styled-9 el-deprecated-menu-item-group-title"
+      class="mocked-styled-2 el-menu-group-label-container"
+      id=":r0:"
     >
       YOUR APPS
     </div>
-    <div
-      class="mocked-styled-11 el-deprecated-menu-item-group-list"
-      style="max-height: var(undefined);"
-    >
-      Fake child
-    </div>
+    Fake child
   </div>
 </DocumentFragment>
 `;

--- a/src/core/app-switcher/your-apps-menu-group/your-apps-menu-group.tsx
+++ b/src/core/app-switcher/your-apps-menu-group/your-apps-menu-group.tsx
@@ -1,5 +1,5 @@
 import { AppSwitcherMenuGroupHasAccessContext } from '../menu-group-has-access-context'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 
 import type { ReactNode } from 'react'
 
@@ -9,11 +9,11 @@ interface AppSwitcherMenuGroupProps {
 
 function AppSwitcherYourAppsMenuGroup({ children }: AppSwitcherMenuGroupProps) {
   return (
-    <DeprecatedMenu.Group label={'YOUR APPS'}>
+    <Menu.Group label={'YOUR APPS'}>
       <AppSwitcherMenuGroupHasAccessContext.Provider value={true}>
         {children}
       </AppSwitcherMenuGroupHasAccessContext.Provider>
-    </DeprecatedMenu.Group>
+    </Menu.Group>
   )
 }
 

--- a/src/core/split-button/__tests__/split-button-menu.test.tsx
+++ b/src/core/split-button/__tests__/split-button-menu.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
+import { render, screen } from '@testing-library/react'
 import { SplitButtonContext } from '../context'
 import { SplitButtonMenu } from '../split-button-menu'
 
@@ -8,9 +8,9 @@ import type { ReactNode } from 'react'
 test('renders as a button', () => {
   render(
     <SplitButtonMenu aria-label="More">
-      <DeprecatedMenu.Item label="Item 1" />
-      <DeprecatedMenu.Item label="Item 2" />
-      <DeprecatedMenu.Item label="Item 3" />
+      <Menu.Item>Item 1</Menu.Item>
+      <Menu.Item>Item 2</Menu.Item>
+      <Menu.Item>Item 3</Menu.Item>
     </SplitButtonMenu>,
     { wrapper },
   )
@@ -30,24 +30,25 @@ test('forwards props to the underlying button', () => {
   expect(screen.getByTestId('nav-item')).toBeInstanceOf(HTMLButtonElement)
 })
 
-test('opens the menu when clicked', () => {
+test('will open the menu when clicked', () => {
   render(
     <SplitButtonMenu aria-label="More">
-      <DeprecatedMenu.Item label="Item 1" />
-      <DeprecatedMenu.Item label="Item 2" />
-      <DeprecatedMenu.Item label="Item 3" />
+      <Menu.Item>Item 1</Menu.Item>
+      <Menu.Item>Item 2</Menu.Item>
+      <Menu.Item>Item 3</Menu.Item>
     </SplitButtonMenu>,
     { wrapper },
   )
 
   const button = screen.getByRole('button')
+  const menu = screen.getByRole('menu')
 
-  fireEvent.click(button)
+  expect(button).toHaveAttribute('popovertarget', menu.id)
+})
 
-  expect(button).toHaveAttribute('aria-expanded', 'true')
-  expect(screen.getByText('Item 1')).toBeVisible()
-  expect(screen.getByText('Item 2')).toBeVisible()
-  expect(screen.getByText('Item 3')).toBeVisible()
+test('menu is labelled by the button', () => {
+  render(<SplitButtonMenu aria-label="More">Fake item</SplitButtonMenu>, { wrapper })
+  expect(screen.getByRole('menu', { name: 'More' })).toBeVisible()
 })
 
 interface WrapperProps {

--- a/src/core/split-button/menu-button/__tests__/menu-button.test.tsx
+++ b/src/core/split-button/menu-button/__tests__/menu-button.test.tsx
@@ -7,9 +7,6 @@ import type { ReactNode } from 'react'
 vi.mock('#src/icons/chevron-down', () => ({
   ChevronDownIcon: () => <span data-testid="chevron-down-icon" />,
 }))
-vi.mock('#src/icons/chevron-up', () => ({
-  ChevronUpIcon: () => <span data-testid="chevron-up-icon" />,
-}))
 
 test('renders a button element', () => {
   render(<SplitButtonMenuButton aria-label="Open menu" />, { wrapper })
@@ -26,14 +23,9 @@ test('forwards additional props to the underlying button', () => {
   expect(screen.getByTestId('menu-btn')).toBeVisible()
 })
 
-test('shows `ChevronDownIcon` when aria-expanded is false or not set', () => {
+test('shows `ChevronDownIcon`', () => {
   render(<SplitButtonMenuButton aria-label="Menu" />, { wrapper })
   expect(screen.getByTestId('chevron-down-icon')).toBeVisible()
-})
-
-test('shows `ChevronUpIcon` when aria-expanded is true', () => {
-  render(<SplitButtonMenuButton aria-label="Menu" aria-expanded={true} />, { wrapper })
-  expect(screen.getByTestId('chevron-up-icon')).toBeVisible()
 })
 
 test('applies size and variant from `SplitButtonContext`', () => {

--- a/src/core/split-button/menu-button/menu-button.tsx
+++ b/src/core/split-button/menu-button/menu-button.tsx
@@ -1,6 +1,5 @@
 import { Button } from '#src/core/button/index'
 import { ChevronDownIcon } from '#src/icons/chevron-down'
-import { ChevronUpIcon } from '#src/icons/chevron-up'
 import { cx } from '@linaria/core'
 import { elSplitButtonMenuButton } from './styles'
 import { useSplitButtonContext } from '../context'
@@ -15,8 +14,6 @@ interface SplitButtonMenuButtonProps extends Omit<ButtonHTMLAttributes<HTMLButto
    * to allow a tooltip to be displayed that explains why the action is disabled.
    */
   'aria-disabled'?: boolean | 'true' | 'false'
-  /** Whether the menu this button controls is expanded */
-  'aria-expanded'?: boolean | 'true' | 'false'
   /** The button's label */
   'aria-label': string
   /**
@@ -32,18 +29,13 @@ interface SplitButtonMenuButtonProps extends Omit<ButtonHTMLAttributes<HTMLButto
  * The `SplitButton.MenuButton` component is used to represent the menu button in a `SplitButton`. It will typically
  * be used via `SplitButton.Menu`, which includes the `Menu` component baked-in.
  */
-export function SplitButtonMenuButton({
-  'aria-expanded': ariaExpanded,
-  className,
-  ...rest
-}: SplitButtonMenuButtonProps) {
+export function SplitButtonMenuButton({ className, ...rest }: SplitButtonMenuButtonProps) {
   const { size, variant } = useSplitButtonContext()
   return (
     <Button
       {...rest}
-      aria-expanded={ariaExpanded}
       className={cx(elSplitButtonMenuButton, className)}
-      iconLeft={ariaExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+      iconLeft={<ChevronDownIcon />}
       size={size}
       variant={variant}
     />

--- a/src/core/split-button/menu-button/styles.ts
+++ b/src/core/split-button/menu-button/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@linaria/core'
+import { ElButtonIconContainer } from '../../button'
 
 // NOTE: This class is designed to be used in conjunction with the ElButton class.
 export const elSplitButtonMenuButton = css`
@@ -57,5 +58,9 @@ export const elSplitButtonMenuButton = css`
   * still elevate it, as it is focusable. */
   &:focus-visible:not(:disabled) {
     z-index: 1;
+  }
+
+  &:has(+ :popover-open) ${ElButtonIconContainer}:first-child {
+    transform: rotate(180deg);
   }
 `

--- a/src/core/split-button/split-button-menu.tsx
+++ b/src/core/split-button/split-button-menu.tsx
@@ -1,7 +1,7 @@
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 import { SplitButtonMenuButton } from './menu-button'
 
-import type { ComponentProps, ReactNode } from 'react'
+import { useId, type ComponentProps, type ReactNode } from 'react'
 
 interface SplitButtonMenuProps extends ComponentProps<typeof SplitButtonMenuButton> {
   /** The menu items to display in the menu */
@@ -11,15 +11,18 @@ interface SplitButtonMenuProps extends ComponentProps<typeof SplitButtonMenuButt
 /**
  * The menu for a `SplitButton`.
  */
-export function SplitButtonMenu({ children, ...rest }: SplitButtonMenuProps) {
+export function SplitButtonMenu({ children, id, ...rest }: SplitButtonMenuProps) {
+  const triggerId = id ?? useId()
+  const menuId = useId()
   return (
-    <DeprecatedMenu data-alignment="right">
-      <DeprecatedMenu.Trigger>
-        {({ getTriggerProps }) => <SplitButtonMenuButton {...getTriggerProps(rest)} />}
-      </DeprecatedMenu.Trigger>
-      <DeprecatedMenu.Popover>
-        <DeprecatedMenu.List>{children}</DeprecatedMenu.List>
-      </DeprecatedMenu.Popover>
-    </DeprecatedMenu>
+    <>
+      <SplitButtonMenuButton
+        {...rest}
+        {...Menu.getMenuTriggerProps({ id: triggerId, popoverTarget: menuId, popoverTargetAction: 'toggle' })}
+      />
+      <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-end">
+        {children}
+      </Menu>
+    </>
   )
 }

--- a/src/core/split-button/split-button.stories.tsx
+++ b/src/core/split-button/split-button.stories.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 import { SplitButton } from './split-button'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
@@ -22,10 +22,8 @@ const meta = {
       mapping: {
         Default: (
           <SplitButton.Menu aria-label="More actions">
-            <DeprecatedMenu.Group>
-              <DeprecatedMenu.Item label="Action 1" />
-              <DeprecatedMenu.Item label="Action 2" />
-            </DeprecatedMenu.Group>
+            <Menu.Item>Action 1</Menu.Item>
+            <Menu.Item>Action 2</Menu.Item>
           </SplitButton.Menu>
         ),
         Disabled: (
@@ -43,13 +41,6 @@ const meta = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <div style={{ height: '150px' }}>
-        <Story />
-      </div>
-    ),
-  ],
 } satisfies Meta<typeof SplitButton>
 
 export default meta

--- a/src/core/top-bar/main-nav/__tests__/main-nav-menu-list-item.test.tsx
+++ b/src/core/top-bar/main-nav/__tests__/main-nav-menu-list-item.test.tsx
@@ -1,9 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { render, screen } from '@testing-library/react'
 import { TopBarMainNavMenuListItem } from '../main-nav-menu-list-item'
 
 test('renders as a list item containing a button', () => {
-  render(<TopBarMainNavMenuListItem label="More">More</TopBarMainNavMenuListItem>)
+  render(<TopBarMainNavMenuListItem label="More">Fake child</TopBarMainNavMenuListItem>)
 
   const listItem = screen.getByRole('listitem')
   expect(listItem).toBeVisible()
@@ -23,21 +22,16 @@ test('forwards props to the underlying nav item', () => {
   expect(button).toBeVisible()
 })
 
-test('opens the menu when clicked', () => {
-  render(
-    <TopBarMainNavMenuListItem label="More">
-      <DeprecatedMenu.Item label="Item 1" />
-      <DeprecatedMenu.Item label="Item 2" />
-      <DeprecatedMenu.Item label="Item 3" />
-    </TopBarMainNavMenuListItem>,
-  )
+test('will open the menu when clicked', () => {
+  render(<TopBarMainNavMenuListItem label="More">Fake child</TopBarMainNavMenuListItem>)
 
   const button = screen.getByRole('button')
+  const menu = screen.getByRole('menu')
 
-  fireEvent.click(button)
+  expect(button).toHaveAttribute('popovertarget', menu.id)
+})
 
-  expect(button).toHaveAttribute('aria-expanded', 'true')
-  expect(screen.getByText('Item 1')).toBeVisible()
-  expect(screen.getByText('Item 2')).toBeVisible()
-  expect(screen.getByText('Item 3')).toBeVisible()
+test('menu is labelled by the button', () => {
+  render(<TopBarMainNavMenuListItem label="More">Fake child</TopBarMainNavMenuListItem>)
+  expect(screen.getByRole('menu', { name: 'More' })).toBeVisible()
 })

--- a/src/core/top-bar/main-nav/main-nav-menu-list-item.tsx
+++ b/src/core/top-bar/main-nav/main-nav-menu-list-item.tsx
@@ -1,6 +1,7 @@
 import { ElTopBarMainNavListItem } from './styles'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 import { TopBarNavDropdownButton } from '../nav-dropdown-button'
+import { useId } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
@@ -15,19 +16,20 @@ interface TopBarMainNavMenuListItemProps extends ButtonHTMLAttributes<HTMLButton
  * A combination of a `TopBar.NavDropdownButton` and `Menu` that is contained within a list item (`<li>`) for
  * correct semantics and accessibility when used with `TopBar.MainNav`.
  */
-export function TopBarMainNavMenuListItem({ children, label, ...rest }: TopBarMainNavMenuListItemProps) {
+export function TopBarMainNavMenuListItem({ children, id, label, ...rest }: TopBarMainNavMenuListItemProps) {
+  const triggerId = id ?? useId()
+  const menuId = useId()
   return (
     <ElTopBarMainNavListItem>
-      <DeprecatedMenu>
-        <DeprecatedMenu.Trigger>
-          {({ getTriggerProps }) => (
-            <TopBarNavDropdownButton {...getTriggerProps(rest)}>{label}</TopBarNavDropdownButton>
-          )}
-        </DeprecatedMenu.Trigger>
-        <DeprecatedMenu.Popover>
-          <DeprecatedMenu.List>{children}</DeprecatedMenu.List>
-        </DeprecatedMenu.Popover>
-      </DeprecatedMenu>
+      <TopBarNavDropdownButton
+        {...rest}
+        {...Menu.getMenuTriggerProps({ id: triggerId, popoverTarget: menuId, popoverTargetAction: 'toggle' })}
+      >
+        {label}
+      </TopBarNavDropdownButton>
+      <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-end">
+        {children}
+      </Menu>
     </ElTopBarMainNavListItem>
   )
 }

--- a/src/core/top-bar/main-nav/main-nav.stories.tsx
+++ b/src/core/top-bar/main-nav/main-nav.stories.tsx
@@ -48,13 +48,6 @@ export const WithMenu: Story = {
   args: {
     children: 'With menu',
   },
-  decorators: [
-    (Story) => (
-      <div style={{ height: '300px' }}>
-        <Story />
-      </div>
-    ),
-  ],
 }
 
 function buildNav(type: 'No selected item' | 'Selected item' | 'With menu') {

--- a/src/core/top-bar/nav-dropdown-button/nav-dropdown-button.stories.tsx
+++ b/src/core/top-bar/nav-dropdown-button/nav-dropdown-button.stories.tsx
@@ -18,20 +18,7 @@ type Story = StoryObj<typeof meta>
 
 export const Example: Story = {
   args: {
-    'aria-expanded': false,
     children: 'More',
-  },
-}
-
-/**
- * When the dropdown's menu is expanded, `aria-expanded` should be `true`. In this case, the button's chevron icon will
- * be rotated to visually communicate the "openness" of the menu. For accessible users, this is communicated via the
- * `aria-expanded` attribute itself.
- */
-export const Expanded: Story = {
-  args: {
-    ...Example.args,
-    'aria-expanded': true,
   },
 }
 

--- a/src/core/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
+++ b/src/core/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
@@ -1,13 +1,10 @@
 import { ChevronDownIcon } from '#src/icons/chevron-down'
-import { ElTopBarNavDropdownButton, ElTopBarNavDropdownButtonIcon, ElTopBarNavDropdownButtonLabel } from './styles'
+import { cx } from '@linaria/core'
+import { elTopBarNavDropdownButton, ElTopBarNavDropdownButtonIcon, ElTopBarNavDropdownButtonLabel } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
 export interface TopBarNavDropdownButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  /**
-   * Whether the dropdown is expanded or not. This will typically be controlled by a `Menu.Trigger` component.
-   */
-  'aria-expanded': boolean
   /**
    * The label of the dropdown button.
    */
@@ -25,17 +22,13 @@ export interface TopBarNavDropdownButtonProps extends HTMLAttributes<HTMLButtonE
  * is correctly wrapped by a list item (`<li>`) to ensure good semantics and accessibility when used with
  * `TopBar.MainNav`.
  */
-export function TopBarNavDropdownButton({
-  'aria-expanded': ariaExpanded,
-  children,
-  ...rest
-}: TopBarNavDropdownButtonProps) {
+export function TopBarNavDropdownButton({ children, className, ...rest }: TopBarNavDropdownButtonProps) {
   return (
-    <ElTopBarNavDropdownButton {...rest} aria-expanded={ariaExpanded}>
+    <button {...rest} className={cx(elTopBarNavDropdownButton, className)}>
       <ElTopBarNavDropdownButtonLabel>{children}</ElTopBarNavDropdownButtonLabel>
       <ElTopBarNavDropdownButtonIcon aria-hidden>
         <ChevronDownIcon />
       </ElTopBarNavDropdownButtonIcon>
-    </ElTopBarNavDropdownButton>
+    </button>
   )
 }

--- a/src/core/top-bar/nav-dropdown-button/styles.ts
+++ b/src/core/top-bar/nav-dropdown-button/styles.ts
@@ -1,8 +1,11 @@
-import { styled } from '@linaria/react'
+import { css } from '@linaria/core'
 import { ElDeprecatedIcon } from '../../../deprecated/icon'
 import { font } from '#src/core/text/index'
+import { styled } from '@linaria/react'
 
-export const ElTopBarNavDropdownButton = styled.button`
+// NOTE: We can't use styled.button here because Linaria's styled elements silently drop
+// Popover API attributes 😤
+export const elTopBarNavDropdownButton = css`
   --__padding-block: calc(var(--spacing-half) + var(--spacing-1));
   --__padding-inline: calc(var(--spacing-half) + var(--spacing-3));
 
@@ -52,7 +55,7 @@ export const ElTopBarNavDropdownButtonIcon = styled.span`
   width: var(--icon_size-s);
   height: var(--icon_size-s);
 
-  [aria-expanded='true'] & {
+  .${elTopBarNavDropdownButton}:has(~ :popover-open) & {
     transform: rotate(180deg);
   }
 `

--- a/src/core/top-bar/nav-icon-item/nav-icon-item-button.tsx
+++ b/src/core/top-bar/nav-icon-item/nav-icon-item-button.tsx
@@ -10,7 +10,7 @@ export interface TopBarNavIconItemButtonProps extends Omit<ButtonHTMLAttributes<
   /** The nav item's icon. */
   icon: ReactNode
   /** The click handler for the nav item. */
-  onClick: MouseEventHandler<HTMLButtonElement>
+  onClick?: MouseEventHandler<HTMLButtonElement>
 }
 
 /**

--- a/src/core/top-bar/secondary-nav/__tests__/secondary-nav-menu-list-item.test.tsx
+++ b/src/core/top-bar/secondary-nav/__tests__/secondary-nav-menu-list-item.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { render, screen } from '@testing-library/react'
 import { StarIcon } from '#src/icons/star'
 import { TopBarSecondaryNavMenuListItem } from '../secondary-nav-menu-list-item'
 
@@ -31,18 +30,21 @@ test('forwards props to the underlying nav item', () => {
 test('opens the menu when clicked', () => {
   render(
     <TopBarSecondaryNavMenuListItem aria-label="More" icon={<StarIcon />}>
-      <DeprecatedMenu.Item label="Item 1" />
-      <DeprecatedMenu.Item label="Item 2" />
-      <DeprecatedMenu.Item label="Item 3" />
+      Fake item
     </TopBarSecondaryNavMenuListItem>,
   )
 
   const button = screen.getByRole('button')
+  const menu = screen.getByRole('menu')
 
-  fireEvent.click(button)
+  expect(button).toHaveAttribute('popovertarget', menu.id)
+})
 
-  expect(button).toHaveAttribute('aria-expanded', 'true')
-  expect(screen.getByText('Item 1')).toBeVisible()
-  expect(screen.getByText('Item 2')).toBeVisible()
-  expect(screen.getByText('Item 3')).toBeVisible()
+test('menu is labelled by the button', () => {
+  render(
+    <TopBarSecondaryNavMenuListItem aria-label="More" icon={<StarIcon />}>
+      Fake child
+    </TopBarSecondaryNavMenuListItem>,
+  )
+  expect(screen.getByRole('menu', { name: 'More' })).toBeVisible()
 })

--- a/src/core/top-bar/secondary-nav/secondary-nav-menu-list-item.tsx
+++ b/src/core/top-bar/secondary-nav/secondary-nav-menu-list-item.tsx
@@ -1,6 +1,7 @@
 import { ElTopBarSecondaryNavListItem } from './styles'
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 import { TopBarNavIconItemButton } from '../nav-icon-item/nav-icon-item-button'
+import { useId } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
@@ -20,20 +21,23 @@ export function TopBarSecondaryNavMenuListItem({
   'aria-label': ariaLabel,
   children,
   icon,
+  id,
   ...rest
 }: TopBarSecondaryNavMenuListItemProps) {
+  const triggerId = id ?? useId()
+  const menuId = useId()
+
   return (
     <ElTopBarSecondaryNavListItem>
-      <DeprecatedMenu>
-        <DeprecatedMenu.Trigger>
-          {({ getTriggerProps }) => (
-            <TopBarNavIconItemButton {...getTriggerProps(rest)} aria-label={ariaLabel} icon={icon} />
-          )}
-        </DeprecatedMenu.Trigger>
-        <DeprecatedMenu.Popover>
-          <DeprecatedMenu.List>{children}</DeprecatedMenu.List>
-        </DeprecatedMenu.Popover>
-      </DeprecatedMenu>
+      <TopBarNavIconItemButton
+        {...rest}
+        {...Menu.getMenuTriggerProps({ id: triggerId, popoverTarget: menuId, popoverTargetAction: 'toggle' })}
+        aria-label={ariaLabel}
+        icon={icon}
+      />
+      <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-end">
+        {children}
+      </Menu>
     </ElTopBarSecondaryNavListItem>
   )
 }

--- a/src/utils/popover/__tests__/get-popover-trigger-props.test.ts
+++ b/src/utils/popover/__tests__/get-popover-trigger-props.test.ts
@@ -1,7 +1,8 @@
 import { getPopoverTriggerProps } from '../get-popover-trigger-props'
 
 test('maps popover attributes to React 18 compatible attributes', () => {
-  expect(getPopoverTriggerProps({ popoverTarget: 'target', popoverTargetAction: 'toggle' })).toEqual({
+  expect(getPopoverTriggerProps({ id: 'trigger', popoverTarget: 'target', popoverTargetAction: 'toggle' })).toEqual({
+    id: 'trigger',
     popovertarget: 'target',
     popovertargetaction: 'toggle',
   })

--- a/src/utils/popover/get-popover-trigger-props.ts
+++ b/src/utils/popover/get-popover-trigger-props.ts
@@ -1,9 +1,11 @@
 interface GetPopoverTriggerPropsInput {
+  id: string
   popoverTarget: string
   popoverTargetAction: 'hide' | 'show' | 'toggle'
 }
 
 interface GetPopoverTriggerPropsOutput {
+  id: string
   popovertarget: string
   popovertargetaction: 'hide' | 'show' | 'toggle'
 }
@@ -23,10 +25,12 @@ interface GetPopoverTriggerPropsOutput {
  * @returns popover trigger attributes for use in React 18 consumers.
  */
 export function getPopoverTriggerProps({
+  id,
   popoverTarget,
   popoverTargetAction,
 }: GetPopoverTriggerPropsInput): GetPopoverTriggerPropsOutput {
   return {
+    id,
     popovertarget: popoverTarget,
     popovertargetaction: popoverTargetAction,
   }


### PR DESCRIPTION
### Context

- We recently implemented a new `Menu` component.
- Many existing core components are still using `DeprecatedMenu`.
- We need to update the new components to use the new one.

### This PR

- Updates the remaining core components using `DeprecatedMenu` to now use `Menu`