### PR TITLE
chore: upgrade Storybook, Vite and TypeScript

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,19 +1,15 @@
+import { defineMain } from '@storybook/react-vite/node'
 import path from 'path'
 
 module.exports = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
 
-  addons: [
-    '@storybook/addon-links',
-    '@storybook/addon-a11y',
-    '@storybook/addon-designs',
-    '@storybook/addon-docs'
-  ],
+  addons: ['@storybook/addon-links', '@storybook/addon-a11y', '@storybook/addon-designs', '@storybook/addon-docs'],
 
   loader: { '.js': 'jsx' },
 
   framework: {
     name: '@storybook/react-vite',
     options: {},
-  }
+  },
 }

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -4,6 +4,9 @@ import { create } from 'storybook/theming'
 import brandImage from './public/reapitLogo.svg'
 
 addons.setConfig({
+  sidebar: {
+    collapsedRoots: ['deprecated'],
+  },
   theme: create({
     base: 'light',
     colorPrimary: '#4e56ea',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,13 +1,16 @@
+import addonDocs from "@storybook/addon-docs";
+import addonA11y from "@storybook/addon-a11y";
+import addonLinks from "@storybook/addon-links";
+import { definePreview } from '@storybook/react-vite'
 import React from 'react'
 import { ThemeProvider } from '#src/core/theme-provider'
 
 import '../src/styles/globals'
 import './preview.css'
 
-import type { Preview } from '@storybook/react-vite'
 import type { Theme } from '../src/tokens'
 
-const preview: Preview = {
+export default definePreview({
   decorators: [
     // NOTE: This decorator is used to wrap all stories with the ThemeProvider
     // and apply the selected `theme` from the Storybook toolbar.
@@ -95,6 +98,5 @@ const preview: Preview = {
   },
 
   tags: ['autodocs'],
-}
-
-export default preview
+  addons: [addonLinks(), addonA11y(), addonDocs()]
+})

--- a/package.json
+++ b/package.json
@@ -24,7 +24,14 @@
         "./src/*/index.js"
       ],
       "import": "./src/*"
-    }
+    },
+    "#*": [
+      "./*",
+      "./*.ts",
+      "./*.tsx",
+      "./*.js",
+      "./*.jsx"
+    ]
   },
   "exports": {
     ".": {
@@ -101,14 +108,14 @@
     "@linaria/postcss-linaria": "^6.3.0",
     "@mdx-js/react": "^3.0.1",
     "@playwright/test": "^1.43.0",
-    "@storybook/addon-a11y": "^9.0.15",
-    "@storybook/addon-designs": "^10.0.1",
-    "@storybook/addon-docs": "^9.0.15",
-    "@storybook/addon-links": "^9.0.15",
-    "@storybook/cli": "^9.0.15",
+    "@storybook/addon-a11y": "^9.1.0",
+    "@storybook/addon-designs": "^10.0.2",
+    "@storybook/addon-docs": "^9.1.0",
+    "@storybook/addon-links": "^9.1.0",
+    "@storybook/cli": "^9.1.0",
     "@storybook/icons": "^1.4.0",
-    "@storybook/react-dom-shim": "^9.0.15",
-    "@storybook/react-vite": "^9.0.15",
+    "@storybook/react-dom-shim": "^9.1.0",
+    "@storybook/react-vite": "^9.1.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -120,7 +127,7 @@
     "@types/react-syntax-highlighter": "^15.5.11",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
-    "@vitejs/plugin-react": "^4.6.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@wyw-in-js/babel-preset": "^0.7.0",
     "@wyw-in-js/vite": "^0.7.0",
@@ -137,7 +144,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-storybook": "^9.0.15",
+    "eslint-plugin-storybook": "^9.1.0",
     "happy-dom": "^18.0.1",
     "move-file-cli": "^3.0.0",
     "postcss": "^8.5.6",
@@ -150,12 +157,12 @@
     "rollup": "^4.14.1",
     "rollup-plugin-css-only": "^4.5.2",
     "snyk": "^1.1288.0",
-    "storybook": "^9.0.15",
+    "storybook": "^9.1.0",
     "style-dictionary": "^4.3.3",
     "stylelint": "^16.21.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3",
-    "vite": "^7.0.1",
+    "typescript": "^5.9.2",
+    "vite": "^7.0.6",
     "vite-plugin-svgr": "^4.3.0",
     "vitest": "^3.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/core@npm:7.28.0"
+  dependencies:
+    "@ampproject/remapping": "npm:^2.2.0"
+    "@babel/code-frame": "npm:^7.27.1"
+    "@babel/generator": "npm:^7.28.0"
+    "@babel/helper-compilation-targets": "npm:^7.27.2"
+    "@babel/helper-module-transforms": "npm:^7.27.3"
+    "@babel/helpers": "npm:^7.27.6"
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/template": "npm:^7.27.2"
+    "@babel/traverse": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.0"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10/1c86eec8d76053f7b1c5f65296d51d7b8ac00f80d169ff76d3cd2e7d85ab222eb100d40cc3314f41b96c8cc06e9abab21c63d246161f0f3f70ef14c958419c33
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.23.5, @babel/generator@npm:^7.24.1":
   version: 7.24.4
   resolution: "@babel/generator@npm:7.24.4"
@@ -208,6 +231,19 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jsesc: "npm:^3.0.2"
   checksum: 10/f5e6942670cb32156b3ac2d75ce09b373558823387f15dd1413c27fe9eb5756a7c6011fc7f956c7acc53efb530bfb28afffa24364d46c4e9ffccc4e5c8b3b094
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/generator@npm:7.28.0"
+  dependencies:
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.0"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10/064c5ba4c07ecd7600377bd0022d5f6bdb3b35e9ff78d9378f6bd1e656467ca902c091647222ab2f0d2967f6d6c0ca33157d37dd9b1c51926c9b0e1527ab9b92
   languageName: node
   linkType: hard
 
@@ -305,6 +341,13 @@ __metadata:
     "@babel/template": "npm:^7.22.15"
     "@babel/types": "npm:^7.23.0"
   checksum: 10/7b2ae024cd7a09f19817daf99e0153b3bf2bc4ab344e197e8d13623d5e36117ed0b110914bc248faa64e8ccd3e97971ec7b41cc6fd6163a2b980220c58dcdf6d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-globals@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/helper-globals@npm:7.28.0"
+  checksum: 10/91445f7edfde9b65dcac47f4f858f68dc1661bf73332060ab67ad7cc7b313421099a2bfc4bda30c3db3842cfa1e86fffbb0d7b2c5205a177d91b22c8d7d9cb47
   languageName: node
   linkType: hard
 
@@ -566,6 +609,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.27.6":
+  version: 7.28.2
+  resolution: "@babel/helpers@npm:7.28.2"
+  dependencies:
+    "@babel/template": "npm:^7.27.2"
+    "@babel/types": "npm:^7.28.2"
+  checksum: 10/09fd7965e83d4777a4331a082677a1a2261cec451bf3307cb0fb62b2d32c83d55fb1cac494a5dab5c6ad9da459883b8d4e49142812b10ef3e36b54022b2de3a4
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.23.4":
   version: 7.23.4
   resolution: "@babel/highlight@npm:7.23.4"
@@ -646,6 +699,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/0ad671be7994dba7d31ec771bd70ea5090aa34faf73e93b1b072e3c0a704ab69f4a7a68ebfb9d6a7fa455e0aa03dfa65619c4df6bae1cf327cba925b1d233fc4
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/parser@npm:7.28.0"
+  dependencies:
+    "@babel/types": "npm:^7.28.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/2c14a0d2600bae9ab81924df0a85bbd34e427caa099c260743f7c6c12b2042e743e776043a0d1a2573229ae648f7e66a80cfb26fc27e2a9eb59b55932d44c817
   languageName: node
   linkType: hard
 
@@ -1097,6 +1161,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/traverse@npm:7.28.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@babel/generator": "npm:^7.28.0"
+    "@babel/helper-globals": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/template": "npm:^7.27.2"
+    "@babel/types": "npm:^7.28.0"
+    debug: "npm:^4.3.1"
+  checksum: 10/c1c24b12b6cb46241ec5d11ddbd2989d6955c282715cbd8ee91a09fe156b3bdb0b88353ac33329c2992113e3dfb5198f616c834f8805bb3fa85da1f864bec5f3
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.6, @babel/types@npm:^7.23.9, @babel/types@npm:^7.8.3":
   version: 7.23.9
   resolution: "@babel/types@npm:7.23.9"
@@ -1146,6 +1225,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: 10/39e9f05527ef0771dfb6220213a9ef2ca35c2b6d531e3310c8ffafb53aa50362e809f75af8feb28bd6abb874a00c02b05ac00e3063ee239db5c6f1653eab19c5
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.28.0, @babel/types@npm:^7.28.2":
+  version: 7.28.2
+  resolution: "@babel/types@npm:7.28.2"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.27.1"
+  checksum: 10/a8de404a2e3109651f346d892dc020ce2c82046068f4ce24de7f487738dfbfa7bd716b35f1dcd6d6c32dde96208dc74a56b7f56a2c0bcb5af0ddc56cbee13533
   languageName: node
   linkType: hard
 
@@ -1628,6 +1717,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.12":
+  version: 0.3.12
+  resolution: "@jridgewell/gen-mapping@npm:0.3.12"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10/151667531566417a940d4dd0a319724979f7a90b9deb9f1617344e1183887d78c835bc1a9209c1ee10fc8a669cdd7ac8120a43a2b6bc8d0d5dd18a173059ff4b
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.5
   resolution: "@jridgewell/gen-mapping@npm:0.3.5"
@@ -1708,6 +1807,16 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.28":
+  version: 0.3.29
+  resolution: "@jridgewell/trace-mapping@npm:0.3.29"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10/64e1ce0dc3a9e56b0118eaf1b2f50746fd59a36de37516cc6855b5370d5f367aa8229e1237536d738262e252c70ee229619cb04e3f3b822146ee3eb1b7ab297f
   languageName: node
   linkType: hard
 
@@ -1927,14 +2036,14 @@ __metadata:
     "@mdx-js/react": "npm:^3.0.1"
     "@oddbird/css-anchor-positioning": "npm:^0.6.1"
     "@playwright/test": "npm:^1.43.0"
-    "@storybook/addon-a11y": "npm:^9.0.15"
-    "@storybook/addon-designs": "npm:^10.0.1"
-    "@storybook/addon-docs": "npm:^9.0.15"
-    "@storybook/addon-links": "npm:^9.0.15"
-    "@storybook/cli": "npm:^9.0.15"
+    "@storybook/addon-a11y": "npm:^9.1.0"
+    "@storybook/addon-designs": "npm:^10.0.2"
+    "@storybook/addon-docs": "npm:^9.1.0"
+    "@storybook/addon-links": "npm:^9.1.0"
+    "@storybook/cli": "npm:^9.1.0"
     "@storybook/icons": "npm:^1.4.0"
-    "@storybook/react-dom-shim": "npm:^9.0.15"
-    "@storybook/react-vite": "npm:^9.0.15"
+    "@storybook/react-dom-shim": "npm:^9.1.0"
+    "@storybook/react-vite": "npm:^9.1.0"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
@@ -1946,7 +2055,7 @@ __metadata:
     "@types/react-syntax-highlighter": "npm:^15.5.11"
     "@typescript-eslint/eslint-plugin": "npm:^7.6.0"
     "@typescript-eslint/parser": "npm:^7.6.0"
-    "@vitejs/plugin-react": "npm:^4.6.0"
+    "@vitejs/plugin-react": "npm:^4.7.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
     "@wyw-in-js/babel-preset": "npm:^0.7.0"
     "@wyw-in-js/vite": "npm:^0.7.0"
@@ -1963,7 +2072,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-react: "npm:^7.34.1"
     eslint-plugin-react-hooks: "npm:^4.6.0"
-    eslint-plugin-storybook: "npm:^9.0.15"
+    eslint-plugin-storybook: "npm:^9.1.0"
     happy-dom: "npm:^18.0.1"
     move-file-cli: "npm:^3.0.0"
     postcss: "npm:^8.5.6"
@@ -1976,12 +2085,12 @@ __metadata:
     rollup: "npm:^4.14.1"
     rollup-plugin-css-only: "npm:^4.5.2"
     snyk: "npm:^1.1288.0"
-    storybook: "npm:^9.0.15"
+    storybook: "npm:^9.1.0"
     style-dictionary: "npm:^4.3.3"
     stylelint: "npm:^16.21.0"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:^5.8.3"
-    vite: "npm:^7.0.1"
+    typescript: "npm:^5.9.2"
+    vite: "npm:^7.0.6"
     vite-plugin-svgr: "npm:^4.3.0"
     vitest: "npm:^3.2.4"
   peerDependencies:
@@ -1992,10 +2101,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rolldown/pluginutils@npm:1.0.0-beta.19":
-  version: 1.0.0-beta.19
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.19"
-  checksum: 10/3b09ebf03e0f30b48770bcd7075c3092c6be09f60e6cb320142a37ae651cfc03974186b24cd7df5bd8110561c1da9d3e8bb4ecff0f2459ca4370da3d62c6806e
+"@rolldown/pluginutils@npm:1.0.0-beta.27":
+  version: 1.0.0-beta.27
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.27"
+  checksum: 10/4f7da788d88b33d029d5acf84c63be27c62d7c53017476f2e3026172cf94062cb399cd15194c89574578f192016bbcb1e040ce6811b3bb9ec4d4faa2ad386459
   languageName: node
   linkType: hard
 
@@ -2332,21 +2441,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-a11y@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/addon-a11y@npm:9.0.15"
+"@storybook/addon-a11y@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/addon-a11y@npm:9.1.0"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     axe-core: "npm:^4.2.0"
   peerDependencies:
-    storybook: ^9.0.15
-  checksum: 10/d01fb79aa55ef1b58c11bf2a8a05a38f0282835a91bfdd99cd907cf91d35201b0d5f6729d61bebc2aa4537540750d8845b7b6b43f06e82622d2825af3075632a
+    storybook: ^9.1.0
+  checksum: 10/39c147528a53fcefc5c613d5e235bc6915e8735d2703d1c6e9ddb2fa27016431c1a3a360bda24ce7a0e35c3c0fc22fcc515cb87b7239126fefa418b548d4645d
   languageName: node
   linkType: hard
 
-"@storybook/addon-designs@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "@storybook/addon-designs@npm:10.0.1"
+"@storybook/addon-designs@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@storybook/addon-designs@npm:10.0.2"
   dependencies:
     "@figspec/react": "npm:^1.0.0"
   peerDependencies:
@@ -2361,76 +2470,76 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10/5deb72183c0f1e9c38f7ec63dbcb6c7fedfd66801127e66bd40f86b6b7646ae5baa95ae4954f5e56d2e62842839a17b72c552be10d64e23ce380f9e7204a6d48
+  checksum: 10/7ab697582b6063f264ce505acfb2f9bb506262242083e6b2268435c7b9e49f72663c630343bb514598ccfd75e1c74227d45350656923898e161e0fb820df2da9
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/addon-docs@npm:9.0.15"
+"@storybook/addon-docs@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/addon-docs@npm:9.1.0"
   dependencies:
     "@mdx-js/react": "npm:^3.0.0"
-    "@storybook/csf-plugin": "npm:9.0.15"
-    "@storybook/icons": "npm:^1.2.12"
-    "@storybook/react-dom-shim": "npm:9.0.15"
+    "@storybook/csf-plugin": "npm:9.1.0"
+    "@storybook/icons": "npm:^1.4.0"
+    "@storybook/react-dom-shim": "npm:9.1.0"
     react: "npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     react-dom: "npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^9.0.15
-  checksum: 10/0b3c75f0410f09d1094db55659560c7ca789f3b4d796c3a137a7fb9ca70961a0cef4368873c4bf245667de5c68f6f6c1c0682da3c75cfb4430e9c8b6eca5c6a5
+    storybook: ^9.1.0
+  checksum: 10/a249a6fd89fcc4b2ccbdfe089632b65f80616f20e251d655f6b0459dec4065ab73a349c9fa41ccbcca178f4c341e08aac9fa784515b075c67023541fc210aff5
   languageName: node
   linkType: hard
 
-"@storybook/addon-links@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/addon-links@npm:9.0.15"
+"@storybook/addon-links@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/addon-links@npm:9.1.0"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^9.0.15
+    storybook: ^9.1.0
   peerDependenciesMeta:
     react:
       optional: true
-  checksum: 10/797fa5ef3e2cdf3301a4e0d0faff2ee27e3eca74df504d92ba38f5a4df501d2e01f3e3e9c013f67ca3d1fb88fae475857ab66dc7fdb751b5389e31fd16fd4f03
+  checksum: 10/41542f169a625d2ff0a4d82c4b6b4242cb7c56569da6a944e2fef21e1b4d3088540df0746a079cb53197b0aac7bf36f6ac20937e6d9fd84cccce97a7af3552d5
   languageName: node
   linkType: hard
 
-"@storybook/builder-vite@npm:9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/builder-vite@npm:9.0.15"
+"@storybook/builder-vite@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/builder-vite@npm:9.1.0"
   dependencies:
-    "@storybook/csf-plugin": "npm:9.0.15"
+    "@storybook/csf-plugin": "npm:9.1.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^9.0.15
+    storybook: ^9.1.0
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10/2704f61939305d956a1cc193058633466145cd5d1c00a75b3f1af7f8ed60d8c24f2135afc37b36825caeb90e8c5c343eb47f1be4aabb6d18dffe783f73926bb8
+  checksum: 10/ec4b3263c84c17a8375af5c4dada473df526d4a6221f4ca57e6c09d7c665301a5db8b3c825db7756dc3cddb59d252c583c5bec81fdd4aea56526a8e730018ef1
   languageName: node
   linkType: hard
 
-"@storybook/cli@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/cli@npm:9.0.15"
+"@storybook/cli@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/cli@npm:9.1.0"
   dependencies:
-    "@storybook/codemod": "npm:9.0.15"
+    "@storybook/codemod": "npm:9.1.0"
     "@types/semver": "npm:^7.3.4"
     commander: "npm:^12.1.0"
-    create-storybook: "npm:9.0.15"
+    create-storybook: "npm:9.1.0"
     giget: "npm:^1.0.0"
     jscodeshift: "npm:^0.15.1"
-    storybook: "npm:9.0.15"
+    storybook: "npm:9.1.0"
     ts-dedent: "npm:^2.0.0"
   bin:
     cli: ./bin/index.cjs
-  checksum: 10/6897c5744ddcdecb6f6aa300bca6f8a2bce578373264f8ba94d9cff3a06c02ce45d78364ce024246a53c1e406210109ef62c941ed17d6b75952d9d898de45ad7
+  checksum: 10/d3335ca530ff4dfeb6deb88b7ea82e8c767c283a91c2d21d1dd5d9eb6380597ac5bf67dd2a1329daf361b2ff99ecd608e0a27a881757076d93d124650ecd01b1
   languageName: node
   linkType: hard
 
-"@storybook/codemod@npm:9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/codemod@npm:9.0.15"
+"@storybook/codemod@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/codemod@npm:9.1.0"
   dependencies:
     "@types/cross-spawn": "npm:^6.0.6"
     cross-spawn: "npm:^7.0.6"
@@ -2438,20 +2547,20 @@ __metadata:
     globby: "npm:^14.0.1"
     jscodeshift: "npm:^0.15.1"
     prettier: "npm:^3.5.3"
-    storybook: "npm:9.0.15"
+    storybook: "npm:9.1.0"
     tiny-invariant: "npm:^1.3.1"
-  checksum: 10/c2127e2b62c2a2768b62a5ac43038a7f2573f14f949b27976c3e6df0e6ddf12178523057f5b55142137006f1d9ee0ba720ac05bf897f71b619db0d04ca83b702
+  checksum: 10/4313ed1df89298049356094f2ad5ebfe59cd5c68e1ad4dcbac986423fc4379260fa732c7b2b2488abef364614afeeff396fd0269ef6f10b03c6d2cae90e1a937
   languageName: node
   linkType: hard
 
-"@storybook/csf-plugin@npm:9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/csf-plugin@npm:9.0.15"
+"@storybook/csf-plugin@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/csf-plugin@npm:9.1.0"
   dependencies:
     unplugin: "npm:^1.3.1"
   peerDependencies:
-    storybook: ^9.0.15
-  checksum: 10/a8e6ac17c3b51a59c6dda264b64efa4b09f51e095e0b4c148b13d4dd78a454d4b108e0c510e33a02efc96d95338d3f0ae5b308a35265b87cbabadf21b27f8b92
+    storybook: ^9.1.0
+  checksum: 10/6144f1039d091fa18515b0ecbedf1909951637ebe6d96170e59a5c35307ad2584e51f69ca0655245903ebaea12cddb9a3a935b1da06f257329fdacd976b691b8
   languageName: node
   linkType: hard
 
@@ -2462,7 +2571,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/icons@npm:^1.2.12, @storybook/icons@npm:^1.4.0":
+"@storybook/icons@npm:^1.4.0":
   version: 1.4.0
   resolution: "@storybook/icons@npm:1.4.0"
   peerDependencies:
@@ -2472,25 +2581,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-dom-shim@npm:9.0.15, @storybook/react-dom-shim@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/react-dom-shim@npm:9.0.15"
+"@storybook/react-dom-shim@npm:9.1.0, @storybook/react-dom-shim@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/react-dom-shim@npm:9.1.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^9.0.15
-  checksum: 10/f83d768ac21b9eb91e8e92a4c67a7757de49f3cc27d31e89ac165e47c6876dc309b12a2be3a545665c17622435a10688e7cf709b163aeb251eea8902bde3e428
+    storybook: ^9.1.0
+  checksum: 10/9d89a147893949c9db8eac5dcc4309e344f76cb02a4d1ca1a9cba13f0b7599e9cf293be33baf0190d2b898c48c60bf3883bc805ea8fe650038c86e564be29326
   languageName: node
   linkType: hard
 
-"@storybook/react-vite@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/react-vite@npm:9.0.15"
+"@storybook/react-vite@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/react-vite@npm:9.1.0"
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.6.1"
     "@rollup/pluginutils": "npm:^5.0.2"
-    "@storybook/builder-vite": "npm:9.0.15"
-    "@storybook/react": "npm:9.0.15"
+    "@storybook/builder-vite": "npm:9.1.0"
+    "@storybook/react": "npm:9.1.0"
     find-up: "npm:^7.0.0"
     magic-string: "npm:^0.30.0"
     react-docgen: "npm:^8.0.0"
@@ -2499,27 +2608,27 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^9.0.15
+    storybook: ^9.1.0
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10/366070d57b817c09f39ea2cb3b4398eb726995aaaf842a05292a5bdf3486623ef47058c3ad9a113212512d409b983bf3b60a5805489be6862d3d82c812e35137
+  checksum: 10/0bce474070ccce30eefda1e1a05a86a3b42a6ae41c4af80157db7659f6640717cc5571b400c184868a20998bbbf2845f56df4ebc02557fbc7439e860c7f9e01f
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:9.0.15":
-  version: 9.0.15
-  resolution: "@storybook/react@npm:9.0.15"
+"@storybook/react@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@storybook/react@npm:9.1.0"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/react-dom-shim": "npm:9.0.15"
+    "@storybook/react-dom-shim": "npm:9.1.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^9.0.15
+    storybook: ^9.1.0
     typescript: ">= 4.9.x"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/3a4c2a4a52d12c78787f5c67812d5d0f91accb9cbe88d935dcd5997a47c5221ad2dd5ec958dd7fdf8db71628e3a4cb65b13dbfa83b4f195c85c1cf9f8341831f
+  checksum: 10/e296e4cd2650e9ed90f8de24cbca60f48cfc369c25adce5058d7fd81aaee7034854ece922f695a5bfb1bb295cdfad8145437c9d17306ed49ed4907c76fc9ac37
   languageName: node
   linkType: hard
 
@@ -3247,19 +3356,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@vitejs/plugin-react@npm:4.6.0"
+"@vitejs/plugin-react@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@vitejs/plugin-react@npm:4.7.0"
   dependencies:
-    "@babel/core": "npm:^7.27.4"
+    "@babel/core": "npm:^7.28.0"
     "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
     "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.19"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.27"
     "@types/babel__core": "npm:^7.20.5"
     react-refresh: "npm:^0.17.0"
   peerDependencies:
-    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
-  checksum: 10/f05479b74070bcaa7aedfc0aefcfb40f732ccd0126b30885113719ff0c471b7a09626546c0a6b9404ce66245689b11cb3103c42e59c211ea518713d73c028b02
+    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10/619a5d650ce0e8e2f37dae369b803990c6647e81ec983a00e44a734b3feeefd5a32c20fbee56d496fbc239cad6b949797dddf7c6d9f23c48100c5b2b5dc41e1f
   languageName: node
   linkType: hard
 
@@ -4640,14 +4749,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-storybook@npm:9.0.15":
-  version: 9.0.15
-  resolution: "create-storybook@npm:9.0.15"
+"create-storybook@npm:9.1.0":
+  version: 9.1.0
+  resolution: "create-storybook@npm:9.1.0"
   dependencies:
     semver: "npm:^7.6.2"
   bin:
     create-storybook: ./bin/index.cjs
-  checksum: 10/8420220d75445bbe9e0befe933abf0d4aef84ef41bf30f320457170eb3bbb343081e3e8c5a654a858bd93787ca2dc72e6997c987e67472855b7ce78d447e72a9
+  checksum: 10/76044be4b45e0c3165b365143647f9f9cde34f0125314568fbec15672be0dc7a710eeb60fb22b842bf2d4d7c738ba376ac40f0a88db3071de1c4fd6dc02662a3
   languageName: node
   linkType: hard
 
@@ -5516,15 +5625,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-storybook@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "eslint-plugin-storybook@npm:9.0.15"
+"eslint-plugin-storybook@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "eslint-plugin-storybook@npm:9.1.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.8.1"
   peerDependencies:
     eslint: ">=8"
-    storybook: ^9.0.15
-  checksum: 10/21682d8bd72b9f6d7856246d3672057766bdbe48e052790bfe23f8804e8d68392eaafb6679752dce29e48d1b64fc84f01865c6b14f9ab3eeae4b5740d2aecd99
+    storybook: ^9.1.0
+  checksum: 10/804f2256eebc1fcceb359cf2f70ca554aca3020a14d7d40916c1678bf7f27710046dcd9910c1bf54d15d4da1fe1fc1f78fda5882cbb118f8bea04524a9763bbe
   languageName: node
   linkType: hard
 
@@ -8889,6 +8998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10/57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
+  languageName: node
+  linkType: hard
+
 "pify@npm:^4.0.1":
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
@@ -10352,14 +10468,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storybook@npm:9.0.15, storybook@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "storybook@npm:9.0.15"
+"storybook@npm:9.1.0, storybook@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "storybook@npm:9.1.0"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/user-event": "npm:^14.6.1"
     "@vitest/expect": "npm:3.2.4"
+    "@vitest/mocker": "npm:3.2.4"
     "@vitest/spy": "npm:3.2.4"
     better-opn: "npm:^3.0.2"
     esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0"
@@ -10374,7 +10491,7 @@ __metadata:
       optional: true
   bin:
     storybook: ./bin/index.cjs
-  checksum: 10/4ad21bd6cb9ff154ceb0d98360755727002c2ac9fb8ad8382e4abcf7be555d60fb43b5a60ee2ad820fedc3317c5505a704bb4f5ede159d0bda0dbd795bd652d2
+  checksum: 10/d11c54f146882086ffb70f2a9a9a16a4f8547cb3d1ccf68a6c0a614e146da7de691c1df7916e9c1bb0459b327ea8fdb5353369f83d7cfc52d955091edd97ecdd
   languageName: node
   linkType: hard
 
@@ -11251,23 +11368,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.8.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/65c40944c51b513b0172c6710ee62e951b70af6f75d5a5da745cb7fab132c09ae27ffdf7838996e3ed603bb015dadd099006658046941bd0ba30340cc563ae92
+  checksum: 10/cc2fe6c822819de5d453fa25aa9f32096bf70dde215d481faa1ad84a283dfb264e33988ed8f6d36bc803dd0b16dbe943efa311a798ef76d5b3892a05dfbfd628
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
+  checksum: 10/bd810ab13e8e557225a8b5122370385440b933e4e077d5c7641a8afd207fdc8be9c346e3c678adba934b64e0e70b0acf5eef9493ea05170a48ce22bef845fdc7
   languageName: node
   linkType: hard
 
@@ -11566,14 +11683,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "vite@npm:7.0.1"
+"vite@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "vite@npm:7.0.6"
   dependencies:
     esbuild: "npm:^0.25.0"
     fdir: "npm:^6.4.6"
     fsevents: "npm:~2.3.3"
-    picomatch: "npm:^4.0.2"
+    picomatch: "npm:^4.0.3"
     postcss: "npm:^8.5.6"
     rollup: "npm:^4.40.0"
     tinyglobby: "npm:^0.2.14"
@@ -11617,7 +11734,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/c4f5be940e5794cae0a62528c7e4b636334eaa2a3dac41ba199cdb51c4048ffe6760ee85e7f20e141bb10338f8dd35d6e5154071db4f62ae4814a8f1b9af0393
+  checksum: 10/729ddefd6710b0b5aa38a62a537f3dc28577edaf57958c815a1964f1e348a1c7cb17ce8f708675668d7e80d95fb62f7c433b718fe12d80dd8a756ccec519bc2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
What it says on the tin.

Also updates the Storybook config to collapse the "Deprecated" root node by default.