### PR TITLE
fix: `Checkbox` now supports consumer-supplied refs

### DIFF
--- a/src/core/checkbox/checkbox.tsx
+++ b/src/core/checkbox/checkbox.tsx
@@ -1,6 +1,7 @@
-import React, { InputHTMLAttributes, useEffect, useRef } from 'react'
+import React, { forwardRef, InputHTMLAttributes, useEffect, useRef } from 'react'
 import { ElCheckboxIcon, ElCheckboxSelectedIcon, ElCheckboxIndeterminateIcon } from './checkbox.atoms'
 import { ElCheckbox, ElCheckboxInput, ElCheckboxLabelText, ElCheckboxSupplementaryInfo } from './styles'
+import mergeRefs from '#src/helpers/mergeRefs'
 
 /**
  * Interface for the Checkbox component props.
@@ -27,38 +28,33 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
  * This component combines the atomic checkbox components (ElCheckbox, ElCheckboxInput, etc.)
  * into a single, reusable checkbox component.
  */
-export const Checkbox: React.FC<CheckboxProps> = ({
-  label,
-  supplementaryInfo,
-  required,
-  isIndeterminate = false,
-  className,
-  ...rest
-}) => {
-  const inputRef = useRef<HTMLInputElement>(null)
-  useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.indeterminate = !!isIndeterminate // Use prop value
-    }
-  }, [isIndeterminate]) // Run effect when isIndeterminate changes
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ label, supplementaryInfo, required, isIndeterminate = false, className, ...rest }, ref) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = !!isIndeterminate // Use prop value
+      }
+    }, [isIndeterminate]) // Run effect when isIndeterminate changes
 
-  return (
-    <ElCheckbox className={className}>
-      {/* The actual checkbox input element. Forwards the ref and other input props. */}
-      <ElCheckboxInput type="checkbox" ref={inputRef} {...rest} aria-hidden />
-      {/* Icons for different checkbox states (unchecked, checked, indeterminate). */}
-      {/* aria-hidden is used to prevent screen readers from announcing these decorative icons. */}
-      <ElCheckboxIcon aria-hidden />
-      <ElCheckboxSelectedIcon aria-hidden />
-      {isIndeterminate && <ElCheckboxIndeterminateIcon aria-hidden />}
-      {/* Label text for the checkbox. Styled using data attributes for variant and size. */}
-      <ElCheckboxLabelText variant="strong" size="medium" isRequired={required}>
-        {label}
-      </ElCheckboxLabelText>
-      {/* Supplementary information displayed below the label. Styled using data attributes. */}
-      <ElCheckboxSupplementaryInfo variant="soft" size="small">
-        {supplementaryInfo}
-      </ElCheckboxSupplementaryInfo>
-    </ElCheckbox>
-  )
-}
+    return (
+      <ElCheckbox className={className}>
+        {/* The actual checkbox input element. Forwards the ref and other input props. */}
+        <ElCheckboxInput type="checkbox" ref={mergeRefs(inputRef, ref)} {...rest} aria-hidden />
+        {/* Icons for different checkbox states (unchecked, checked, indeterminate). */}
+        {/* aria-hidden is used to prevent screen readers from announcing these decorative icons. */}
+        <ElCheckboxIcon aria-hidden />
+        <ElCheckboxSelectedIcon aria-hidden />
+        {isIndeterminate && <ElCheckboxIndeterminateIcon aria-hidden />}
+        {/* Label text for the checkbox. Styled using data attributes for variant and size. */}
+        <ElCheckboxLabelText variant="strong" size="medium" isRequired={required}>
+          {label}
+        </ElCheckboxLabelText>
+        {/* Supplementary information displayed below the label. Styled using data attributes. */}
+        <ElCheckboxSupplementaryInfo variant="soft" size="small">
+          {supplementaryInfo}
+        </ElCheckboxSupplementaryInfo>
+      </ElCheckbox>
+    )
+  },
+)

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,16 +16,19 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
-### **5.0.0-beta.40 - ??/??/25**
+### **5.0.0-beta.40 - 01/08/25**
 
 - **chore!:** Deprecate `Menu` component. It is still available, but is now called `DeprecatedMenu`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from
 - **chore:** Update design tokens to match latest changes in Figma
 - **chore!:** Renamed `ElipsisIcon` to `MoreVertIcon` to align with Design System changes.
 - **feat:** Add new `Popover` utility component. See [Popover](?path=/docs/utils-popover--docs) for details.
 - **feat:** Add new `Menu`. See [Menu](?path=/docs/core-menu--docs) for details.
-- **chore:** Use new `Menu` in `BottomBar.MenuItem`.
 - **chore!:** Deprecate `Tooltip` component. It is still available, but is now called `DeprecatedTooltip`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from `@reapit/elements/deprecated/tooltip`, as well as the root entry point, `@reapit/elements`.
 - **feat:** Add new `Tooltip`. See [Tooltip](?path=/docs/core-tooltip--docs) for details.
+- **chore:** Use new `Tooltip` in all core components.
+- **chore:** Use new `Menu` in all core components.
+- **chore:** Upgraded Storybook, Vite and TypeScript to latest versions.
+- **fix:** `Checkbox` now supports consumer-supplied refs.
 
 ### **5.0.0-beta.39 - 23/07/25**
 


### PR DESCRIPTION
The Checkbox does not currently support consumer-supplied refs. This PR updates it to use `forwardRef`.

Also scouted some changes to the change log that were missed in recent commits.