### PR TITLE
chore: rename `Popover` prop getter

### DIFF
--- a/src/core/badge/badge.tsx
+++ b/src/core/badge/badge.tsx
@@ -48,7 +48,7 @@ export function Badge({
   // tooltip, it'll be nuked by the `aria-labelledby` value we get from
   // `Tooltip.getTooltipTriggerProps`. 🤷‍♂️
   const a11yProps = useTooltip
-    ? Tooltip.getTooltipTriggerProps({ id: badgeId, tooltipId, tooltipPurpose: 'label' })
+    ? Tooltip.getTriggerProps({ id: badgeId, tooltipId, tooltipPurpose: 'label' })
     : {
         'aria-label': ariaLabel,
         id: badgeId,

--- a/src/core/chip/chip.stories.tsx
+++ b/src/core/chip/chip.stories.tsx
@@ -76,7 +76,7 @@ export const Disabled: Story = {
       <>
         <Chip
           {...args}
-          {...Tooltip.getTooltipTriggerProps({ id: chipId, tooltipId: 'tooltip', tooltipPurpose: 'describe' })}
+          {...Tooltip.getTriggerProps({ id: chipId, tooltipId: 'tooltip', tooltipPurpose: 'describe' })}
         />
         <Tooltip id="tooltip" triggerId={chipId}>
           Because reasons

--- a/src/core/menu/menu.tsx
+++ b/src/core/menu/menu.tsx
@@ -1,6 +1,6 @@
 import { AnchorMenuItem, MenuItem } from './item'
 import { elMenu } from './styles'
-import { getPopoverTriggerProps as getMenuTriggerProps, Popover } from '#src/utils/popover'
+import { Popover } from '#src/utils/popover'
 import { MenuDivider } from './divider'
 import { MenuGroup } from './group'
 import { useCloseMenuOnClick } from './use-close-menu-on-click'
@@ -74,4 +74,4 @@ Menu.Group = MenuGroup
 Menu.Item = MenuItem
 
 // Make this helper available for convenience.
-Menu.getTriggerProps = getMenuTriggerProps
+Menu.getTriggerProps = Popover.getTriggerProps

--- a/src/core/tooltip/tooltip.stories.tsx
+++ b/src/core/tooltip/tooltip.stories.tsx
@@ -51,7 +51,7 @@ const meta = {
     return (
       <>
         <button
-          {...Tooltip.getTooltipTriggerProps({ id: props.triggerId, tooltipId: props.id, tooltipPurpose: 'describe' })}
+          {...Tooltip.getTriggerProps({ id: props.triggerId, tooltipId: props.id, tooltipPurpose: 'describe' })}
           style={{
             whiteSpace: 'nowrap',
             overflow: 'hidden',

--- a/src/core/tooltip/tooltip.tsx
+++ b/src/core/tooltip/tooltip.tsx
@@ -69,4 +69,4 @@ export function Tooltip({
   )
 }
 
-Tooltip.getTooltipTriggerProps = getTooltipTriggerProps
+Tooltip.getTriggerProps = getTooltipTriggerProps

--- a/src/core/top-bar/nav-icon-item/nav-icon-item-base.tsx
+++ b/src/core/top-bar/nav-icon-item/nav-icon-item-base.tsx
@@ -44,7 +44,7 @@ export function TopBarNavIconItemBase({
   // NOTE: Yes, it's a bit weird to be using `aria-label` for a visual label (via the tooltip).
   // There's also some awkwardness here with `aria-labelledby`. If the consumer provides it,
   // it'll be nuked by the `aria-labelledby` value we get from `Tooltip.getTooltipTriggerProps`. 🤷‍♂️
-  const a11yProps = Tooltip.getTooltipTriggerProps({ id: triggerId, tooltipId, tooltipPurpose: 'label' })
+  const a11yProps = Tooltip.getTriggerProps({ id: triggerId, tooltipId, tooltipPurpose: 'label' })
 
   return (
     <Element

--- a/src/utils/popover/popover.tsx
+++ b/src/utils/popover/popover.tsx
@@ -2,6 +2,7 @@ import { applyCSSAnchorPositioningPolyfill } from '#src/polyfills/css-anchor-pos
 import { buildAnchorPositioningCSS } from './build-anchor-positioning-css'
 import { cx } from '@linaria/core'
 import { elPopover } from './styles'
+import { getPopoverTriggerProps } from './get-popover-trigger-props'
 import { useLayoutEffect, useRef } from 'react'
 
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
@@ -147,3 +148,5 @@ export function Popover({
     </div>
   )
 }
+
+Popover.getTriggerProps = getPopoverTriggerProps


### PR DESCRIPTION
- Exposes `getPopoverTriggerProps` via `Popover.getTriggerProps`
- Rename `Tooltip.getTooltipTriggerProps` to `Tooltip.getTriggerProps`