### PR TITLE
fix: minor post-release issues

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Create Pull Request For Version
         uses: peter-evans/create-pull-request@v5
         with:
-          commit_message: 'chore: bump version to ${{ steps.tagName.outputs.version }}'
+          commit-message: 'chore: bump version to ${{ steps.tagName.outputs.version }}'
           title: 'chore: bump version to ${{ steps.tagName.outputs.version }}'
           body: Update to version in package.json
           base: main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reapit/elements",
-  "version": "5.0.0-beta.40",
+  "version": "5.0.0-beta.41",
   "description": "A collection of React components and utilities for building apps for Reapit Marketplace",
   "homepage": "https://github.com/reapit/elements#readme",
   "bugs": {

--- a/src/core/menu/divider/styles.ts
+++ b/src/core/menu/divider/styles.ts
@@ -4,4 +4,5 @@ export const ElMenuDivider = styled.hr`
   height: 0;
   border: none;
   border-bottom: var(--comp-divider-border-width) solid var(--comp-divider-colour-border-solid);
+  margin: var(--spacing-2) 0;
 `

--- a/src/core/side-bar/menu-group/styles.ts
+++ b/src/core/side-bar/menu-group/styles.ts
@@ -41,6 +41,9 @@ export const ElSideBarMenuGroupSummaryLabel = styled(ElSideBarMenuItemLabel)`
 export const ElSideBarMenuGroupSummaryDropdownIcon = styled.span`
   grid-area: dropdown;
 
+  display: inline-flex;
+  align-items: center;
+
   color: var(--comp-navigation-colour-icon-sidebar-default);
 
   /* NOTE: We don't want the padding to reduce the content size as we want the icons to be

--- a/src/core/side-bar/menu-item/styles.ts
+++ b/src/core/side-bar/menu-item/styles.ts
@@ -51,6 +51,9 @@ export const ElSideBarMenuItemLabel = styled.span`
 export const ElSideBarMenuItemIcon = styled.span`
   grid-area: icon;
 
+  display: inline-flex;
+  align-items: center;
+
   /* NOTE: We don't want the padding to reduce the content size as we want the icons to be
    * exactly --icon_size-m */
   box-sizing: content-box;

--- a/src/core/top-bar/main-nav/main-nav-menu-list-item.tsx
+++ b/src/core/top-bar/main-nav/main-nav-menu-list-item.tsx
@@ -27,7 +27,7 @@ export function TopBarMainNavMenuListItem({ children, id, label, ...rest }: TopB
       >
         {label}
       </TopBarNavDropdownButton>
-      <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-end">
+      <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-start">
         {children}
       </Menu>
     </ElTopBarMainNavListItem>

--- a/src/icons/__tests__/__snapshots__/icons.test.tsx.snap
+++ b/src/icons/__tests__/__snapshots__/icons.test.tsx.snap
@@ -1035,25 +1035,6 @@ exports[`'EditIcon' renders the correct SVG 1`] = `
 </DocumentFragment>
 `;
 
-exports[`'ElipsisIcon' renders the correct SVG 1`] = `
-<DocumentFragment>
-  <svg
-    class="el-icon"
-    color="inherit"
-    data-size="100%"
-    fill="currentColor"
-    height="24"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M12 7a2 2 0 1 1 0-4 2 2 0 0 1 0 4Zm-2 5a2 2 0 1 0 4 0 2 2 0 0 0-4 0Zm0 7a2 2 0 1 0 4 0 2 2 0 0 0-4 0Z"
-    />
-  </svg>
-</DocumentFragment>
-`;
-
 exports[`'EmailDisabledIcon' renders the correct SVG 1`] = `
 <DocumentFragment>
   <svg

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export * from './core/table'
 export * from './core/tag'
 export * from './core/tag-group'
 export * from './core/text'
+export * from './core/textarea'
 export * from './core/tooltip'
 export * from './core/top-bar'
 

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,6 +16,13 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
+### **5.0.0-beta.41 - 01/08/25**
+
+- **fix:** Resolve regression in `SideBar.Item` and `SideBar.MenuGroupSummary` text and icon alignment.
+- **fix:** Prevent user-agent styles impacting `Menu.Divider`.
+- **fix:** Prerelease pipeline error in `Create Pull Request For Version` step.
+- **chore:** Tweak `TopBar.NavMenuItem` menu placement.
+
 ### **5.0.0-beta.40 - 01/08/25**
 
 - **chore!:** Deprecate `Menu` component. It is still available, but is now called `DeprecatedMenu`. All CSS classes related to this component have also been updated to use an `el-deprecated-...` prefix. It can now be imported from


### PR DESCRIPTION
- Bumps package version.
- Resolve regression in `SideBar.Item` and `SideBar.MenuGroupSummary` text and icon alignment. This was impacting Reapit PM.
- Prevent user-agent styles impacting `Menu.Divider`. This was impacting Reapit PM.
- Prerelease pipeline error in `Create Pull Request For Version` step.
- Tweaks `TopBar.NavMenuItem` menu placement from `bottom-end` to `bottom-start`.
