### PR TITLE
feat: add new `matchPath` utility

### DIFF
--- a/src/utils/path/__tests__/compile-path-pattern.test.ts
+++ b/src/utils/path/__tests__/compile-path-pattern.test.ts
@@ -1,0 +1,69 @@
+import { compilePathPattern } from '../compile-path-pattern'
+
+test('compiles and matches static paths', () => {
+  const regex = compilePathPattern('/api/v1/users')
+  expect(regex.test('/api/v1/users')).toBe(true)
+  expect(regex.test('/api/v2/users')).toBe(false)
+  expect(regex.test('/api/v1/users/extra')).toBe(false) // exact match required
+})
+
+test('compiles and matches single path parameter', () => {
+  const regex = compilePathPattern('/users/:id')
+
+  const match = '/users/123'.match(regex)
+  expect(match?.groups?.id).toBe('123')
+
+  expect(regex.test('/users/abc_123')).toBe(true) // underscores allowed
+  expect(regex.test('/users/abc-def')).toBe(true) // hyphens allowed
+  expect(regex.test('/users/user.123')).toBe(true) // dots allowed
+  expect(regex.test('/users/hello world')).toBe(true) // spaces allowed
+  expect(regex.test('/users/user/extra')).toBe(false) // forward slashes not allowed (path separator)
+})
+
+test('compiles and matches multiple path parameters', () => {
+  const regex = compilePathPattern('/users/:userId/posts/:postId')
+
+  const match = '/users/abc-123/posts/456'.match(regex)
+  expect(match?.groups?.userId).toBe('abc-123')
+  expect(match?.groups?.postId).toBe('456')
+})
+
+test('compiles and matches splat parameter', () => {
+  const regex = compilePathPattern('/files/*')
+
+  const match1 = '/files/docs/readme.txt'.match(regex)
+  expect(match1?.[1]).toBe('docs/readme.txt')
+
+  const match2 = '/files/'.match(regex)
+  expect(match2?.[1]).toBe('') // empty remaining path
+
+  const match3 = '/files'.match(regex)
+  expect(match3?.[1]).toBe('') // empty remaining path
+})
+
+test('compiles and matches combined path parameter and splat', () => {
+  const regex = compilePathPattern('/users/:id/*')
+
+  const match = '/users/123/posts/456/comments'.match(regex)
+  expect(match?.groups?.id).toBe('123')
+  expect(match?.at(-1)).toBe('posts/456/comments')
+})
+
+test('handles root path correctly', () => {
+  const regex = compilePathPattern('/')
+  expect(regex.test('/')).toBe(true)
+  expect(regex.test('/users')).toBe(false)
+  expect(regex.test('')).toBe(false)
+})
+
+test('handles empty pattern', () => {
+  const regex = compilePathPattern('')
+  expect(regex.test('')).toBe(true)
+  expect(regex.test('/')).toBe(false)
+})
+
+test('is case insensitive', () => {
+  const regex = compilePathPattern('/Users/:ID')
+  expect(regex.test('/users/123')).toBe(true)
+  expect(regex.test('/USERS/abc')).toBe(true)
+})

--- a/src/utils/path/__tests__/extract-path-params.test.ts
+++ b/src/utils/path/__tests__/extract-path-params.test.ts
@@ -1,0 +1,70 @@
+import { extractPathParams } from '../extract-path-params'
+
+test('returns null when pattern does not match pathname', () => {
+  const params = extractPathParams('/users', '/users/extra')
+
+  expect(params).toBeNull()
+  // NOTE: our types can't tell if we'll have a match or not, but they
+  // can tell what shape the params will have if there is a match
+  expectTypeOf(params).toEqualTypeOf<{} | null>()
+})
+
+test('returns empty object when pattern matches pathname but there are no params', () => {
+  const params = extractPathParams('/about', '/about')
+
+  expect(params).toEqual({})
+  expectTypeOf(params).toEqualTypeOf<{} | null>()
+})
+
+test('extracts single path parameter', () => {
+  const params = extractPathParams('/users/:userId', '/users/abc-123')
+
+  expect(params).toEqual({ userId: 'abc-123' })
+  expectTypeOf(params).toEqualTypeOf<{ userId: string } | null>()
+})
+
+test('extracts multiple path parameters', () => {
+  const params = extractPathParams('/users/:userId/posts/:postId', '/users/123/posts/456')
+
+  expect(params).toEqual({ userId: '123', postId: '456' })
+  expectTypeOf(params).toEqualTypeOf<{ userId: string; postId: string } | null>()
+})
+
+test('extracts splat parameter', () => {
+  const params = extractPathParams('/*', '/path/to/a resource') // space is permitted
+
+  expect(params).toEqual({ '*': 'path/to/a resource' })
+  expectTypeOf(params).toEqualTypeOf<{ '*': string } | null>()
+})
+
+test('extracts combined path parameters and splat', () => {
+  const params = extractPathParams('/:category/*', '/docs/guides/getting-started')
+
+  expect(params).toEqual({ category: 'docs', '*': 'guides/getting-started' })
+  expectTypeOf(params).toEqualTypeOf<{ category: string; '*': string } | null>()
+})
+
+test('handles special characters in parameter values', () => {
+  expect(extractPathParams('/users/:id', '/users/user_123')).toEqual({ id: 'user_123' })
+  expect(extractPathParams('/users/:id', '/users/user-123')).toEqual({ id: 'user-123' })
+  expect(extractPathParams('/users/:id', '/users/user.123')).toEqual({ id: 'user.123' })
+  expect(extractPathParams('/search/:query', '/search/hello world')).toEqual({ query: 'hello world' })
+})
+
+test('handles empty splat parameter', () => {
+  expect(extractPathParams('/files/*', '/files/')).toEqual({ '*': '' })
+  expect(extractPathParams('/users/:id/*', '/users/123/')).toEqual({
+    id: '123',
+    '*': '',
+  })
+})
+
+test('is case insensitive for pattern matching', () => {
+  expect(extractPathParams('/Users/:ID', '/users/123')).toEqual({ ID: '123' })
+  expect(extractPathParams('/api/V1/users/:id', '/API/v1/USERS/456')).toEqual({ id: '456' })
+})
+
+test('handles root path and empty string matches', () => {
+  expect(extractPathParams('/', '/')).toEqual({})
+  expect(extractPathParams('', '')).toEqual({})
+})

--- a/src/utils/path/__tests__/match-path.test.ts
+++ b/src/utils/path/__tests__/match-path.test.ts
@@ -1,0 +1,186 @@
+import { matchPath } from '../match-path'
+
+test('returns null when pattern does not match pathname', () => {
+  const result = matchPath('/a', '/b')
+
+  expect(result).toBeNull()
+  expectTypeOf(result).toEqualTypeOf<{ params: {}; pathname: string; pattern: string } | null>()
+})
+
+test('returns match object when pattern matches pathname with no params', () => {
+  const result = matchPath('/a', '/a')
+
+  expect(result).toEqual({
+    params: {},
+    pathname: '/a',
+    pattern: '/a',
+  })
+  expectTypeOf(result).toEqualTypeOf<{ params: {}; pathname: string; pattern: string } | null>()
+})
+
+test('returns null when required parameter is missing', () => {
+  const result = matchPath('/a/:b', '/a')
+
+  expect(result).toBeNull()
+  expectTypeOf(result).toEqualTypeOf<{ params: { b: string }; pathname: string; pattern: string } | null>()
+})
+
+test('extracts single path parameter', () => {
+  const result = matchPath('/a/:b', '/a/abc123')
+
+  expect(result).toEqual({
+    params: { b: 'abc123' },
+    pathname: '/a/abc123',
+    pattern: '/a/:b',
+  })
+  expectTypeOf(result).toEqualTypeOf<{ params: { b: string }; pathname: string; pattern: string } | null>()
+})
+
+test('extracts splat parameter with empty value', () => {
+  const result = matchPath('/a/*', '/a')
+
+  expect(result).toEqual({
+    params: { '*': '' },
+    pathname: '/a',
+    pattern: '/a/*',
+  })
+  expectTypeOf(result).toEqualTypeOf<{ params: { '*': string }; pathname: string; pattern: string } | null>()
+})
+
+test('extracts splat parameter with value', () => {
+  const result = matchPath('/a/*', '/a/edit')
+
+  expect(result).toEqual({
+    params: { '*': 'edit' },
+    pathname: '/a/edit',
+    pattern: '/a/*',
+  })
+  expectTypeOf(result).toEqualTypeOf<{ params: { '*': string }; pathname: string; pattern: string } | null>()
+})
+
+test('extracts multiple path parameters', () => {
+  const result = matchPath('/users/:userId/posts/:postId', '/users/123/posts/456')
+
+  expect(result).toEqual({
+    params: { userId: '123', postId: '456' },
+    pathname: '/users/123/posts/456',
+    pattern: '/users/:userId/posts/:postId',
+  })
+  expectTypeOf(result).toEqualTypeOf<{
+    params: { userId: string; postId: string }
+    pathname: string
+    pattern: string
+  } | null>()
+})
+
+test('extracts combined path parameters and splat', () => {
+  const result = matchPath('/:category/*', '/docs/guides/getting-started')
+
+  expect(result).toEqual({
+    params: { category: 'docs', '*': 'guides/getting-started' },
+    pathname: '/docs/guides/getting-started',
+    pattern: '/:category/*',
+  })
+  expectTypeOf(result).toEqualTypeOf<{
+    params: { category: string; '*': string }
+    pathname: string
+    pattern: string
+  } | null>()
+})
+
+test('normalizes trailing slashes in both pattern and pathname', () => {
+  const result = matchPath('/users/', '/users/')
+
+  expect(result).toEqual({
+    params: {},
+    pathname: '/users',
+    pattern: '/users',
+  })
+})
+
+test('normalizes trailing slashes with parameters', () => {
+  const result = matchPath('/users/:id/', '/users/123/')
+
+  expect(result).toEqual({
+    params: { id: '123' },
+    pathname: '/users/123',
+    pattern: '/users/:id',
+  })
+  expectTypeOf(result).toEqualTypeOf<{ params: { id: string }; pathname: string; pattern: string } | null>()
+})
+
+test('handles root path matching', () => {
+  const result = matchPath('/', '/')
+
+  expect(result).toEqual({
+    params: {},
+    pathname: '/',
+    pattern: '/',
+  })
+})
+
+test('handles empty string patterns and pathnames', () => {
+  const result = matchPath('', '')
+
+  expect(result).toEqual({
+    params: {},
+    pathname: '',
+    pattern: '',
+  })
+})
+
+test('handles special characters in parameter values', () => {
+  const result = matchPath('/search/:query', '/search/hello world')
+
+  expect(result).toEqual({
+    params: { query: 'hello world' },
+    pathname: '/search/hello world',
+    pattern: '/search/:query',
+  })
+})
+
+test('handles complex splat paths', () => {
+  const result = matchPath('/files/*', '/files/docs/readme.txt')
+
+  expect(result).toEqual({
+    params: { '*': 'docs/readme.txt' },
+    pathname: '/files/docs/readme.txt',
+    pattern: '/files/*',
+  })
+})
+
+test('handles case insensitive matching', () => {
+  const result = matchPath('/API/:version/Users/:id', '/api/v1/users/123')
+
+  expect(result).toEqual({
+    params: { version: 'v1', id: '123' },
+    pathname: '/api/v1/users/123',
+    pattern: '/API/:version/Users/:id',
+  })
+})
+
+test('returns null for patterns longer than pathname', () => {
+  const result = matchPath('/users/:id/posts', '/users/123')
+
+  expect(result).toBeNull()
+})
+
+test('returns null for mismatched static segments', () => {
+  const result = matchPath('/users/:id', '/posts/123')
+
+  expect(result).toBeNull()
+})
+
+test('handles trailing slash differences correctly', () => {
+  expect(matchPath('/users', '/users/')).toEqual({
+    params: {},
+    pathname: '/users',
+    pattern: '/users',
+  })
+
+  expect(matchPath('/users/', '/users')).toEqual({
+    params: {},
+    pathname: '/users',
+    pattern: '/users',
+  })
+})

--- a/src/utils/path/__tests__/normalise-path.test.ts
+++ b/src/utils/path/__tests__/normalise-path.test.ts
@@ -1,0 +1,19 @@
+import { normalisePath } from '../normalise-path'
+
+test('preserves empty string', () => {
+  expect(normalisePath('')).toBe('')
+})
+
+test('preserves root path', () => {
+  expect(normalisePath('/')).toBe('/')
+})
+
+test('leaves paths without trailing slash unchanged', () => {
+  expect(normalisePath('/users')).toBe('/users')
+  expect(normalisePath('/users/123')).toBe('/users/123')
+})
+
+test('removes single trailing slash non-root paths', () => {
+  expect(normalisePath('/users/')).toBe('/users')
+  expect(normalisePath('/users/123/')).toBe('/users/123')
+})

--- a/src/utils/path/compile-path-pattern.mdx
+++ b/src/utils/path/compile-path-pattern.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# compilePathPattern
+
+<Meta title="Utils/Path/compilePathPattern" />
+
+Compiles a path pattern into a regular expression that can be used to match real pathnames. Path parameters in the pattern (e.g., `:id`) become named capture groups in the regular expression, allowing their values to be extracted from matched pathnames.
+
+The splat (*) parameter, if present in the pattern, will always be the last capture group. It is not be available as a named capture group.
+
+The compiled regular expression is always case-insensitive.
+
+## Syntax
+
+```ts
+compilePathPattern(pattern)
+```
+
+- `pattern`: The path pattern to compile into a regular expression. Should not have a trailing slash.
+
+Returns a `RegExp` object that can be used to test and match pathnames against the compiled pattern. Named parameters become named capture groups, and splat parameters become positional capture groups.
+
+## Example
+
+```ts
+import { compilePathPattern } from '@reapit/elements/utils/path'
+
+const regex = compilePathPattern('/users/:id')
+
+// Test if a pathname matches
+regex.test('/users/123') // => true
+regex.test('/users') // => false
+regex.test('/posts/123') // => false
+
+// Path parameter available as a named capture group
+const match = '/users/123'.match(regex)
+if (match) {
+  console.log(match.groups?.id) // => '123'
+}
+```

--- a/src/utils/path/compile-path-pattern.ts
+++ b/src/utils/path/compile-path-pattern.ts
@@ -1,0 +1,48 @@
+/**
+ * Regular expression patterns used for path pattern compilation.
+ */
+const REGEX_PATTERNS = {
+  FORWARD_SLASH: /\//g,
+  PATH_PARAM: /:(\w+)/g,
+  SPLAT_PARAM: /\/\*/g,
+} as const
+
+/**
+ * Named capture group templates for different parameter types.
+ */
+const CAPTURE_GROUPS = {
+  PATH_PARAM: '(?<$1>[^/]+)',
+  SPLAT_PARAM: '/?([\\w \\/.~-]*)',
+} as const
+
+/**
+ * Returns a regular expression that can be used to match a real pathname. Path parameters in
+ * the pattern (e.g., ':id') will become named capture groups in the regular expression so that
+ * their value can be captured.
+ *
+ * The compiled regular expression will always be insensitive to case.
+ *
+ * @param pattern the path pattern to compile into a regular expression. Should not have a trailing slash.
+ *
+ * @example
+ * ```ts
+ * compilePathPattern('/a') // => /\/a$/i
+ * compilePathPattern('/a/b') // => /\/a\/b$/i
+ * compilePathPattern('/a/:b') // => /\/a\/(?<b>[^/]+)$/i
+ * compilePathPattern('/a/:b/c') // => /\/a\/(?<b>[^/]+)\/c$/i
+ * compilePathPattern('/a/:b/*') // => /\/a\/(?<b>[^/]+)\/([\w\/]*)$/i
+ * ```
+ */
+export function compilePathPattern(pathPattern: string): RegExp {
+  // If our pattern is an empty string, we return a regex that only matches empty strings
+  if (pathPattern === '') {
+    return /^$/i
+  }
+
+  const regexPattern = pathPattern
+    .replace(REGEX_PATTERNS.SPLAT_PARAM, CAPTURE_GROUPS.SPLAT_PARAM) // Replace /* with optional splat capture group
+    .replace(REGEX_PATTERNS.FORWARD_SLASH, '\\/') // Escape forward slashes
+    .replace(REGEX_PATTERNS.PATH_PARAM, CAPTURE_GROUPS.PATH_PARAM) // Replace :param with named capture groups
+
+  return new RegExp(`${regexPattern}$`, 'i')
+}

--- a/src/utils/path/extract-path-params.mdx
+++ b/src/utils/path/extract-path-params.mdx
@@ -1,0 +1,59 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# extractPathParams
+
+<Meta title="Utils/Path/extractPathParams" />
+
+Extracts path parameters from a pathname according to the provided path pattern. If the pattern matches the pathname, an object containing the extracted parameter values, if any, will be returned.
+
+Optional path parameters are not supported.
+
+The shape of the parameters object is automatically inferred from the path pattern.
+
+## Syntax
+
+```ts
+extractPathParams(pattern, pathname)
+```
+
+- `pattern`: A path pattern string that may contain named parameters (`:param`) and/or splat parameters (`*`)
+- `pathname`: The pathname to extract parameters from
+
+Returns an object containing the extracted path parameters if the pattern matches the pathname, or `null` if no match is found.
+
+The returned object type is automatically inferred from the pattern:
+- Named parameters (`:paramName`) become required string properties
+- Splat parameters (`*`) become a `'*'` property containing the captured path segment
+- If no parameters are defined in the pattern, returns an empty object `{}`
+
+## Type Safety
+
+The function includes sophisticated TypeScript types that extract parameter names from the pattern string:
+
+```ts
+// Type is inferred as { id: string } | null
+extractPathParams('/foo/:fooId', '...')
+
+// Type is inferred as { fooId: string; barId: string } | null
+extractPathParams('/foo/:fooId/bar/:barId', '...')
+
+// Type is inferred as { '*': string } | null
+extractPathParams('/foo/*', '...')
+
+// Type is inferred as { fooId: string; '*': string } | null
+extractPathParams('/foo/:fooId/*', '...')
+```
+
+## Example
+
+```ts
+import { extractPathParams } from '@reapit/elements/utils/path'
+
+// Named parameter with splat
+extractPathParams('/foo/:fooId/*', '/foo/123/bar/baz')
+// => { fooId: '123', '*': 'bar/baz' }
+
+// Multiple named parameters with splat
+extractPathParams('/foo/:fooId/bar/:barId/*', '/foo/123/bar/abc/baz/qux')
+// => { fooId: '123', barId: 'abc', '*': 'baz/qux' }
+```

--- a/src/utils/path/extract-path-params.ts
+++ b/src/utils/path/extract-path-params.ts
@@ -1,0 +1,69 @@
+import { compilePathPattern } from './compile-path-pattern'
+
+/**
+ * @see https://www.totaltypescript.com/concepts/the-prettify-helper
+ */
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+/**
+ * Splits the provided string type by '/' and returns a tuple of all resulting segments.
+ */
+type Split<TString extends string> = TString extends `${infer Prefix}/${infer Suffix}`
+  ? [Prefix, ...Split<Suffix>]
+  : [TString]
+
+/**
+ * Builds a type where each key is a required parameter from the given pattern. Required parameters are segments
+ * that have the format `:${string}`. If there are no parameters or required parameters in the given path pattern,
+ * the type will be empty.
+ */
+type ExtractRequiredPathParams<Pattern extends string> = {
+  [K in Split<Pattern>[number] as K extends `:${infer Param}` ? Param : never]: string
+}
+
+/**
+ * Builds a type that has an optional "*" property if the given pattern ends with a splat (*) parameter.
+ */
+type ExtractSplatPathParam<Pattern extends string> = Pattern extends `${string}*${'' | '/'}` ? { '*': string } : {}
+
+type ExtractPathParams<Pattern extends string> = ExtractRequiredPathParams<Pattern> & ExtractSplatPathParam<Pattern>
+
+/**
+ * Extracts an object of the parameters defined in the provided path.
+ */
+export type PathParams<Pattern extends string> = Prettify<ExtractPathParams<Pattern>>
+
+/**
+ * Extracts path parameters, if they exist, from the path, so long as the pattern match the path. If the pattern
+ * does not match the path, or if it does match but there are no path parameters defined, returns null.
+ */
+export function extractPathParams<Pattern extends string, Params = PathParams<Pattern>>(
+  pattern: Pattern,
+  pathname: string,
+): Params | null {
+  const regex = compilePathPattern(pattern)
+  const match = pathname.match(regex)
+
+  if (!match) {
+    return null
+  }
+
+  const params: Record<string, string> = {}
+
+  // Process named capture groups (path parameters)
+  if (match.groups) {
+    for (const [key, value] of Object.entries(match.groups)) {
+      params[key] = value
+    }
+  }
+
+  // Check if pattern has a splat and extract it from positional capture.
+  // It will always be the last capture group when present
+  if (pattern.includes('*') && match.length > 1) {
+    params['*'] = match[match.length - 1] ?? ''
+  }
+
+  return params as Params
+}

--- a/src/utils/path/index.mdx
+++ b/src/utils/path/index.mdx
@@ -1,0 +1,20 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# Working with Paths
+
+<Meta title="Utils/Path" />
+
+Path handling is typically the responsibility of a router like React Router. However, there are cases where we want path-like handling outside of the router's typical domain of responsiblity, such as URL search parameters. For instance, drawer's can benefit from having their open state, and perhaps some or all of their content, determined by a path-like URL search parameter.
+
+When dealing with paths, its common to need some level of path parameter matching, so that a path pattern like `/users/:id` can be used to match actual pathnames like `/users/abc-123`.
+
+Typically, these path utilities will not be used directly.
+
+---
+
+The main helper is [matchPath](?path=/docs/utils-path-matchpath--docs), which can be used to match a path pattern against a pathname. If a match is made, it will return the extracted parameters as an object, if any.
+
+It is built on top of the following, lower-level helpers.
+- [compilePathPattern](?path=/docs/utils-path-compilepathpattern--docs): Compiles a path pattern into a regular expression for efficient matching
+- [extractPathParams](?path=/docs/utils-path-extractpathparams--docs): Extracts parameter values from a pathname using a path pattern
+- [normalisePath](?path=/docs/utils-path-normalisepath--docs): Normalizes paths by removing trailing slashes for consistent comparison

--- a/src/utils/path/index.ts
+++ b/src/utils/path/index.ts
@@ -1,0 +1,4 @@
+export * from './compile-path-pattern'
+export * from './extract-path-params'
+export * from './match-path'
+export * from './normalise-path'

--- a/src/utils/path/match-path.mdx
+++ b/src/utils/path/match-path.mdx
@@ -1,0 +1,51 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# matchPath
+
+<Meta title="Utils/Path/matchPath" />
+
+Matches a path pattern against a pathname and, if successful, returns the parameters specified by the pattern. This function is the primary interface for path pattern matching, combining pattern compilation, normalization, and parameter extraction into a single convenient API.
+
+Trailing slashes in both the pattern and the pathname are ignored for consistent matching behavior. Optional parameters in patterns are not supported.
+
+## Syntax
+
+```ts
+matchPath(pattern, pathname)
+```
+
+- `pattern`: A pattern describing the path and, optionally, any path parameters it may include.
+- `pathname`: The current pathname to match the pattern against.
+
+Returns a `PathMatch` object if the pattern matches the pathname, or `null` if no match is found.
+
+The `PathMatch` object contains:
+- `params`: An object containing the extracted path parameters
+- `pathname`: The normalized pathname that was matched
+- `pattern`: The normalized pattern that was used for matching
+
+## Example
+
+```ts
+import { matchPath } from '@reapit/elements/utils/path'
+
+// No match
+matchPath('/users', '/posts')
+// => null
+
+// Exact match with no parameters
+matchPath('/users', '/users')
+// => { params: {}, pathname: '/users', pattern: '/users' }
+
+// Single parameter
+matchPath('/users/:id', '/users/123')
+// => { params: { id: '123' }, pathname: '/users/123', pattern: '/users/:id' }
+
+// Multiple parameters
+matchPath('/users/:userId/posts/:postId', '/users/456/posts/789')
+// => { params: { userId: '456', postId: '789' }, pathname: '/users/456/posts/789', pattern: '/users/:userId/posts/:postId' }
+
+// Splat matching remaining path
+matchPath('/docs/*', '/docs/api/users')
+// => { params: { '*': 'api/users' }, pathname: '/docs/api/users', pattern: '/docs/*' }
+```

--- a/src/utils/path/match-path.ts
+++ b/src/utils/path/match-path.ts
@@ -1,0 +1,48 @@
+import { extractPathParams } from './extract-path-params'
+import { normalisePath } from './normalise-path'
+
+import type { PathParams } from './extract-path-params'
+
+export interface PathMatch<PathParams> {
+  params: PathParams
+  pathname: string
+  pattern: string
+}
+
+/**
+ * Matches `pattern` against `pathname` and, if successful, returns the parameters specified
+ * by the pattern, if any. Trailing slashes in both the pattern and the pathname are ignored.
+ * Optional parameters in the pattern are not supported.
+ *
+ * @param pattern a pattern describing the path and, optionally, any path parameters it may include.
+ * @param pathname the current pathname to match the pattern against
+ *
+ * @example
+ * ```ts
+ * matchPath('/a', '/b') // => null
+ * matchPath('/a', '/a') // => { params: null, ... }
+ * matchPath('/a/:b', '/a') // => null
+ * matchPath('/a/:b', '/a/abc123') // => { params: { b: 'abc123' }, ... }
+ * matchPath('/a/*', '/a') // => { params: { '*': '' }, ... }
+ * matchPath('/a/*', '/a/edit') // => { params: { '*': 'edit' }, ... }
+ * ```
+ */
+export function matchPath<Pattern extends string, Params = PathParams<Pattern>>(
+  pattern: Pattern,
+  pathname: string,
+): PathMatch<Params> | null {
+  const normalisedPathname = normalisePath(pathname)
+  const normalisedPattern = normalisePath(pattern)
+  const params = extractPathParams(normalisedPattern, normalisedPathname)
+
+  // If params is null, our pattern didn't match the pathname.
+  if (params === null) {
+    return null
+  }
+
+  return {
+    params: params as Params,
+    pathname: normalisedPathname,
+    pattern: normalisedPattern,
+  }
+}

--- a/src/utils/path/normalise-path.mdx
+++ b/src/utils/path/normalise-path.mdx
@@ -1,0 +1,38 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+# normalisePath
+
+<Meta title="Utils/Path/normalisePath" />
+
+Normalises a path by removing trailing slashes, except for the root path.
+
+## Syntax
+
+```ts
+normalisePath(path)
+```
+
+- `path`: The path string to normalize
+
+Returns the normalized path as a string:
+- The root path "/" is returned unchanged
+- All other paths have trailing slashes removed
+- Paths without trailing slashes are returned unchanged
+
+## Example
+
+```ts
+import { normalisePath } from '@reapit/elements/utils/path'
+
+// Root path is preserved
+normalisePath('/')
+// => '/'
+
+// Trailing slashes are removed
+normalisePath('/users/')
+// => '/users'
+
+// Already normalized paths are unchanged
+normalisePath('/users')
+// => '/users'
+```

--- a/src/utils/path/normalise-path.ts
+++ b/src/utils/path/normalise-path.ts
@@ -1,0 +1,32 @@
+/**
+ * Regular expression for matching trailing slashes.
+ */
+const TRAILING_SLASH_REGEX = /\/$/
+
+/**
+ * The root path constant.
+ */
+const ROOT_PATH = '/'
+
+/**
+ * Normalizes a path by removing trailing slashes, except for the root path.
+ *
+ * This function ensures consistent path formatting across the application by:
+ * - Preserving the root path "/" as-is
+ * - Removing trailing slashes from all other paths
+ *
+ * @param path The path to normalize
+ * @returns The normalized path
+ *
+ * @example
+ * ```ts
+ * normalisePath('/') // => '/'
+ * normalisePath('/users/') // => '/users'
+ * normalisePath('/users/123/') // => '/users/123'
+ * normalisePath('/users') // => '/users'
+ * normalisePath('/api/v1/posts/') // => '/api/v1/posts'
+ * ```
+ */
+export function normalisePath(path: string): string {
+  return path === ROOT_PATH ? path : path.replace(TRAILING_SLASH_REGEX, '')
+}


### PR DESCRIPTION
### Context

- Part of #661 

### This PR

- Adds basic path matching utilities to `@reapit/elements/utils/path`