### PR TITLE
feat: enhance `matchPath` to support leading splats

### DIFF
--- a/src/utils/path/__tests__/compile-path-pattern.test.ts
+++ b/src/utils/path/__tests__/compile-path-pattern.test.ts
@@ -28,17 +28,26 @@ test('compiles and matches multiple path parameters', () => {
   expect(match?.groups?.postId).toBe('456')
 })
 
-test('compiles and matches splat parameter', () => {
+test('compiles and matches leading splat parameter', () => {
+  const regex1 = compilePathPattern('*/files') // should only match paths ending with "/files"
+
+  expect(regex1.exec('/files')?.[1]).toBe('/')
+  expect(regex1.exec('/my/path/to/some/files')?.[1]).toBe('/my/path/to/some/')
+  expect(regex1.test('/my/path/to/some/files/and/things')).toBe(false)
+
+  const regex2 = compilePathPattern('*/') // should match any path
+
+  expect(regex2.test('')).toBe(false)
+  expect(regex2.exec('/')?.[1]).toBe('/')
+  expect(regex2.exec('/my/path/to/some/files')?.[1]).toBe('/my/path/to/some/files')
+})
+
+test('compiles and matches trailing splat parameter', () => {
   const regex = compilePathPattern('/files/*')
 
-  const match1 = '/files/docs/readme.txt'.match(regex)
-  expect(match1?.[1]).toBe('docs/readme.txt')
-
-  const match2 = '/files/'.match(regex)
-  expect(match2?.[1]).toBe('') // empty remaining path
-
-  const match3 = '/files'.match(regex)
-  expect(match3?.[1]).toBe('') // empty remaining path
+  expect(regex.exec('/files/docs/readme.txt')?.[1]).toBe('docs/readme.txt')
+  expect(regex.exec('/files/')?.[1]).toBe('') // empty remaining path
+  expect(regex.exec('/files')?.[1]).toBe('') // empty remaining path
 })
 
 test('compiles and matches combined path parameter and splat', () => {

--- a/src/utils/path/__tests__/extract-path-params.test.ts
+++ b/src/utils/path/__tests__/extract-path-params.test.ts
@@ -30,7 +30,19 @@ test('extracts multiple path parameters', () => {
   expectTypeOf(params).toEqualTypeOf<{ userId: string; postId: string } | null>()
 })
 
-test('extracts splat parameter', () => {
+test('extracts leading splat parameter', () => {
+  const params1 = extractPathParams('*/bob', '/path/to/a resource/called/bob') // space is permitted
+
+  expect(params1).toEqual({ '*': '/path/to/a resource/called' })
+  expectTypeOf(params1).toEqualTypeOf<{ '*': string } | null>()
+
+  const params2 = extractPathParams('*/bob', '/bob')
+
+  expect(params2).toEqual({ '*': '/' })
+  expectTypeOf(params2).toEqualTypeOf<{ '*': string } | null>()
+})
+
+test('extracts trailing splat parameter', () => {
   const params = extractPathParams('/*', '/path/to/a resource') // space is permitted
 
   expect(params).toEqual({ '*': 'path/to/a resource' })
@@ -52,7 +64,7 @@ test('handles special characters in parameter values', () => {
 })
 
 test('handles empty splat parameter', () => {
-  expect(extractPathParams('/files/*', '/files/')).toEqual({ '*': '' })
+  expect(extractPathParams('/files/*', '/files')).toEqual({ '*': '' })
   expect(extractPathParams('/users/:id/*', '/users/123/')).toEqual({
     id: '123',
     '*': '',

--- a/src/utils/path/extract-path-params.ts
+++ b/src/utils/path/extract-path-params.ts
@@ -1,4 +1,5 @@
 import { compilePathPattern } from './compile-path-pattern'
+import { normalisePath } from './normalise-path'
 
 /**
  * @see https://www.totaltypescript.com/concepts/the-prettify-helper
@@ -26,7 +27,11 @@ type ExtractRequiredPathParams<Pattern extends string> = {
 /**
  * Builds a type that has an optional "*" property if the given pattern ends with a splat (*) parameter.
  */
-type ExtractSplatPathParam<Pattern extends string> = Pattern extends `${string}*${'' | '/'}` ? { '*': string } : {}
+type ExtractSplatPathParam<Pattern extends string> = Pattern extends `*${string}` // Leading splat
+  ? { '*': string }
+  : Pattern extends `${string}*` // Trailing splat
+    ? { '*': string }
+    : {}
 
 type ExtractPathParams<Pattern extends string> = ExtractRequiredPathParams<Pattern> & ExtractSplatPathParam<Pattern>
 
@@ -60,9 +65,9 @@ export function extractPathParams<Pattern extends string, Params = PathParams<Pa
   }
 
   // Check if pattern has a splat and extract it from positional capture.
-  // It will always be the last capture group when present
+  // It will always be the last capture group when present.
   if (pattern.includes('*') && match.length > 1) {
-    params['*'] = match[match.length - 1] ?? ''
+    params['*'] = normalisePath(match[match.length - 1]) ?? ''
   }
 
   return params as Params


### PR DESCRIPTION
#664 introduced a new `matchPath` utility. This PR enhances that utility to support leading "splat" parameters (e.g., `*/overview`). This is likely to be needed for the URL search param routing logic we need for #661.