### PR TITLE
feat: add tooltips to side bar items

### DIFF
--- a/src/core/side-bar/collapse-button/collapse-button.tsx
+++ b/src/core/side-bar/collapse-button/collapse-button.tsx
@@ -1,7 +1,8 @@
 import CollapseIcon from './icons/collapse.svg?react'
 import { ElSideBarCollapseButton, ElSideBarCollapseButtonIcon, ElSideBarCollapseLabel } from './styles'
+import { Tooltip } from '#src/core/tooltip'
+import { useCallback, useId } from 'react'
 import { useSideBarContext } from '../side-bar-context'
-import { useCallback } from 'react'
 
 import type { ComponentProps, MouseEventHandler } from 'react'
 
@@ -21,8 +22,13 @@ interface SideBarCollapseButtonProps extends Omit<ComponentProps<typeof ElSideBa
  * When the side bar is collapsed, the button's accessible name will be "Expand" (though this will not be visible), and
  * when the side bar is expanded, the button's accessible name will be "Collapse".
  */
-export function SideBarCollapseButton({ onClick, ...props }: SideBarCollapseButtonProps) {
+export function SideBarCollapseButton({ id, onClick, ...props }: SideBarCollapseButtonProps) {
   const sideBar = useSideBarContext()
+  const tooltipId = useId()
+  const triggerId = id ?? useId()
+  const truncationTargetId = useId()
+
+  const label = sideBar.state === 'expanded' ? 'Collapse' : 'Expand'
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     (event) => {
@@ -38,6 +44,7 @@ export function SideBarCollapseButton({ onClick, ...props }: SideBarCollapseButt
   return (
     <ElSideBarCollapseButton
       {...props}
+      {...Tooltip.getTriggerProps({ id: triggerId, tooltipId, tooltipPurpose: 'label' })}
       aria-controls={sideBar.id}
       aria-expanded={sideBar.state === 'expanded'}
       onClick={handleClick}
@@ -45,7 +52,10 @@ export function SideBarCollapseButton({ onClick, ...props }: SideBarCollapseButt
       <ElSideBarCollapseButtonIcon aria-hidden>
         <CollapseIcon />
       </ElSideBarCollapseButtonIcon>
-      <ElSideBarCollapseLabel>{sideBar.state === 'expanded' ? 'Collapse' : 'Expand'}</ElSideBarCollapseLabel>
+      <ElSideBarCollapseLabel id={truncationTargetId}>{label}</ElSideBarCollapseLabel>
+      <Tooltip id={tooltipId} placement="right" triggerId={triggerId} truncationTargetId={truncationTargetId}>
+        {label}
+      </Tooltip>
     </ElSideBarCollapseButton>
   )
 }

--- a/src/core/side-bar/menu-group/__tests__/menu-group.test.tsx
+++ b/src/core/side-bar/menu-group/__tests__/menu-group.test.tsx
@@ -26,11 +26,11 @@ test('has an accessible name when the `SideBar` is collapsed', () => {
   expect(screen.getByRole('group', { name: 'Group' })).toBeInTheDocument()
 })
 
-test('is labelled by the <summary> element', () => {
+test("is labelled by the <summary> element's tooltip", () => {
   render(<MenuGroupStories.Selected />)
   const detailsElement = screen.getByRole('group')
-  const summaryElement = detailsElement.firstElementChild
-  expect(detailsElement.getAttribute('aria-labelledby')).toBe(summaryElement?.id)
+  const tooltipElement = screen.getByRole('tooltip')
+  expect(detailsElement.getAttribute('aria-labelledby')).toBe(tooltipElement?.id)
 })
 
 test('is open by default when a descendant submenu item represents the current page', () => {

--- a/src/core/side-bar/menu-group/menu-group-summary.tsx
+++ b/src/core/side-bar/menu-group/menu-group-summary.tsx
@@ -1,18 +1,18 @@
 import { ChevronDownIcon } from '#src/icons/chevron-down'
 import { cx } from '@linaria/core'
 import {
-  elSideBarMenuGroup,
   elSideBarMenuGroupSummary,
   ElSideBarMenuGroupSummaryIcon,
   ElSideBarMenuGroupSummaryLabel,
   ElSideBarMenuGroupSummaryDropdownIcon,
 } from './styles'
 import { elSideBarMenuItem } from '../menu-item'
-import { useCallback } from 'react'
+import { shouldBeOpen } from './should-be-open'
+import { Tooltip } from '#src/core/tooltip'
+import { useCallback, useId } from 'react'
 import { useSideBarMenuGroupLabelIdContext } from './menu-group-label-id-context'
 
 import type { HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
-import { shouldBeOpen } from './should-be-open'
 
 interface SideBarMenuGroupSummaryProps extends HTMLAttributes<HTMLElement> {
   /**
@@ -40,7 +40,9 @@ export function SideBarMenuGroupSummary({
   onClick,
   ...props
 }: SideBarMenuGroupSummaryProps) {
-  const labelId = id ?? useSideBarMenuGroupLabelIdContext()
+  const tooltipId = useSideBarMenuGroupLabelIdContext()
+  const triggerId = id ?? useId()
+  const truncationTargetId = useId()
 
   // We need to prevent the parent menu group from closing if it is currently active (i.e. one of its descendants
   // represents the current page).
@@ -51,9 +53,9 @@ export function SideBarMenuGroupSummary({
     (event) => {
       onClick?.(event)
 
-      const detailsElement = event.currentTarget.closest(`details.${elSideBarMenuGroup}`)
+      const detailsElement = event.currentTarget.closest('details')
 
-      if (detailsElement instanceof HTMLDetailsElement && shouldBeOpen(detailsElement)) {
+      if (detailsElement && shouldBeOpen(detailsElement)) {
         event.preventDefault()
       }
     },
@@ -63,15 +65,18 @@ export function SideBarMenuGroupSummary({
   return (
     <summary
       {...props}
+      {...Tooltip.getTriggerProps({ id: triggerId, tooltipId, tooltipPurpose: 'label' })}
       className={cx(elSideBarMenuItem, elSideBarMenuGroupSummary, className)}
-      id={labelId}
       onClick={handleClick}
     >
       <ElSideBarMenuGroupSummaryIcon aria-hidden>{icon}</ElSideBarMenuGroupSummaryIcon>
-      <ElSideBarMenuGroupSummaryLabel>{children}</ElSideBarMenuGroupSummaryLabel>
+      <ElSideBarMenuGroupSummaryLabel id={truncationTargetId}>{children}</ElSideBarMenuGroupSummaryLabel>
       <ElSideBarMenuGroupSummaryDropdownIcon aria-hidden>
         <ChevronDownIcon />
       </ElSideBarMenuGroupSummaryDropdownIcon>
+      <Tooltip id={tooltipId} placement="right" triggerId={triggerId} truncationTargetId={truncationTargetId}>
+        {children}
+      </Tooltip>
     </summary>
   )
 }

--- a/src/core/side-bar/menu-item/menu-item.tsx
+++ b/src/core/side-bar/menu-item/menu-item.tsx
@@ -1,5 +1,7 @@
 import { cx } from '@linaria/core'
 import { elSideBarMenuItem, ElSideBarMenuItemIcon, ElSideBarMenuItemLabel } from './styles'
+import { Tooltip } from '#src/core/tooltip'
+import { useId } from 'react'
 
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
@@ -42,12 +44,25 @@ export function SideBarMenuItem({
   children,
   className,
   icon,
+  id,
   ...rest
 }: SideBarMenuItemProps) {
+  const tooltipId = useId()
+  const triggerId = id ?? useId()
+  const truncationTargetId = useId()
+
   return (
-    <a {...rest} aria-current={ariaCurrent} className={cx(elSideBarMenuItem, className)}>
+    <a
+      {...rest}
+      {...Tooltip.getTriggerProps({ id: triggerId, tooltipId, tooltipPurpose: 'label' })}
+      aria-current={ariaCurrent}
+      className={cx(elSideBarMenuItem, className)}
+    >
       <ElSideBarMenuItemIcon aria-hidden>{icon}</ElSideBarMenuItemIcon>
-      <ElSideBarMenuItemLabel>{children}</ElSideBarMenuItemLabel>
+      <ElSideBarMenuItemLabel id={truncationTargetId}>{children}</ElSideBarMenuItemLabel>
+      <Tooltip id={tooltipId} placement="right" triggerId={triggerId} truncationTargetId={truncationTargetId}>
+        {children}
+      </Tooltip>
     </a>
   )
 }

--- a/src/core/side-bar/use-keyboard-navigation/__tests__/handle-arrow-navigation.test.tsx
+++ b/src/core/side-bar/use-keyboard-navigation/__tests__/handle-arrow-navigation.test.tsx
@@ -8,6 +8,13 @@ import { determineSideBarStateFromViewport } from '../../use-side-bar-match-medi
 vi.mock('../../use-side-bar-match-media-effect')
 vi.mocked(determineSideBarStateFromViewport).mockReturnValue('expanded')
 
+beforeEach(() => {
+  // NOTE: Unclear why, but without this, we see a test runtime error from the blur event listener added
+  // by `use-menu-group-controller.ts` about `hidePopover` not existing
+  // not existing on the tooltipElement. Suspect its a bug in Happy DOM w.r.t to event handling.
+  HTMLElement.prototype.hidePopover = () => void 0
+})
+
 test('navigates through list items when arrow keys are pressed', async () => {
   render(<TestSideBar />)
 

--- a/src/core/tooltip/__tests__/use-tooltip-controller.test.tsx
+++ b/src/core/tooltip/__tests__/use-tooltip-controller.test.tsx
@@ -155,15 +155,14 @@ test('does not show tooltip when isTooltipNeeded returns false', () => {
     }),
   )
 
-  // Try all the trigger events
   triggerElement.dispatchEvent(new Event('focus'))
-  triggerElement.dispatchEvent(new Event('mouseenter'))
   triggerElement.dispatchEvent(new Event('blur'))
-  triggerElement.dispatchEvent(new Event('mouseleave'))
 
-  expect(mockIsTooltipNeeded).toHaveBeenCalledWith('test-truncation-target')
-
-  // None of the popover methods should be called
   expect(mockShowPopover).not.toHaveBeenCalled()
-  expect(mockHidePopover).not.toHaveBeenCalled()
+
+  // Simulate change in `isTooltipNeeded` result
+  mockIsTooltipNeeded.mockReturnValue(true)
+
+  triggerElement.dispatchEvent(new Event('focus'))
+  expect(mockShowPopover).toHaveBeenCalled()
 })

--- a/src/core/tooltip/tooltip.tsx
+++ b/src/core/tooltip/tooltip.tsx
@@ -55,6 +55,7 @@ export function Tooltip({
       {...rest}
       anchorId={triggerId}
       className={elTooltip}
+      data-truncation-target-id={truncationTargetId}
       elevation="none"
       gap="var(--spacing-1)"
       id={id}

--- a/src/core/tooltip/use-tooltip-controller.ts
+++ b/src/core/tooltip/use-tooltip-controller.ts
@@ -23,10 +23,6 @@ interface UseTooltipControllerInput {
 export function useTooltipController({ tooltipId, triggerId, truncationTargetId }: UseTooltipControllerInput): void {
   useEffect(
     function subscribeToAnchorEvents() {
-      if (!isTooltipNeeded(truncationTargetId)) {
-        return
-      }
-
       // TODO: We are relying on element IDs instead of refs because we want to avoid the
       // complexity of using `forwardRef` in Tooltip. Once we're on React 19 and refs are a normal prop,
       // we'll be able to pass a ref directly to Tooltip without any extra cost.
@@ -42,11 +38,15 @@ export function useTooltipController({ tooltipId, triggerId, truncationTargetId 
 
       if (tooltipElement instanceof HTMLElement && triggerElement instanceof HTMLElement) {
         // Keyboard accessibility
-        triggerElement.addEventListener('focus', () => tooltipElement.showPopover(), { signal })
+        triggerElement.addEventListener('focus', () => showTooltipIfNeeded(tooltipElement, truncationTargetId), {
+          signal,
+        })
         triggerElement.addEventListener('blur', () => tooltipElement.hidePopover(), { signal })
 
         // Mouse interaction
-        triggerElement.addEventListener('mouseenter', () => tooltipElement.showPopover(), { signal })
+        triggerElement.addEventListener('mouseenter', () => showTooltipIfNeeded(tooltipElement, truncationTargetId), {
+          signal,
+        })
         triggerElement.addEventListener(
           'mouseleave',
           () => {
@@ -67,4 +67,17 @@ export function useTooltipController({ tooltipId, triggerId, truncationTargetId 
     },
     [triggerId, tooltipId],
   )
+}
+
+/**
+ * Shows the specified popover if the truncation target has truncated content.
+ *
+ * @param tooltipElement the popover element to show, if needed.
+ * @param truncationTargetId the ID of the element to measure for truncation.
+ */
+function showTooltipIfNeeded(tooltipElement: HTMLElement, truncationTargetId?: string) {
+  if (!isTooltipNeeded(truncationTargetId)) {
+    return
+  }
+  tooltipElement.showPopover()
 }

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -19,6 +19,8 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 ### **5.0.0-beta.42 - ??/??/25**
 
 - **fix:** [#662](https://github.com/reapit/elements/issues/662) Side bar menu groups will now remain closed when the side bar is collapsed, even when a child becomes the current page.
+- **fix:** Tooltip conditional display now works correctly when the truncation target's size changes.
+- **feat:** Side bar menu items and menu group summaries now display a tooltip when their label is truncated.
 
 ### **5.0.0-beta.41 - 01/08/25**
 


### PR DESCRIPTION
Side bar item's, when collapsed, have no visual label. This isn't great for sighted users. This PR adds conditionally-displayed tooltips to the `SideBar.MenuItem`, `SideBar.MenuGroupSummary` and `SideBar.CollapseButton` components.

In doing this, it was noticed that the tooltip's conditional display (via `truncationTargetId`) was not working as expected. This has also been improved.