### PR TITLE
feat: new `TopBar.AvatarMenu`

### DIFF
--- a/src/core/top-bar/avatar-button/avatar-button.stories.tsx
+++ b/src/core/top-bar/avatar-button/avatar-button.stories.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedMenu } from '#src/deprecated/menu'
+import { Menu } from '#src/core/menu'
 import { TopBarAvatarButton } from './avatar-button'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
@@ -19,18 +19,9 @@ export const Example: Story = {
 }
 
 /**
- * The following example demonstrates the use of `TopBar.AvatarButton` with the `Menu` component. The code
- * snippet does not work well with the `Menu.Trigger` component's render-prop, but it works as follows:
- *
- * ```tsx
- * <Menu.Trigger>
- *  {({ getTriggerProps }) => (
- *    <TopBar.AvatarButton {...getTriggerProps()}>KD</TopBar.AvatarButton>
- *  )}
- * </Menu.Trigger>
- * ```
+ * The following example demonstrates the use of `TopBar.AvatarButton` with the `Menu` component.
  */
-export const WithAMenu: Story = {
+export const WithMenu: Story = {
   name: 'With a Menu',
   args: {
     ...Example.args,
@@ -40,25 +31,21 @@ export const WithAMenu: Story = {
       control: false,
     },
   },
-  decorators: [
-    (Story) => (
-      <div style={{ height: '200px' }}>
-        <Story />
-      </div>
-    ),
-  ],
+  parameters: {
+    layout: 'centered',
+  },
   render: ({ children }) => (
-    <DeprecatedMenu>
-      <DeprecatedMenu.Trigger>
-        {({ getTriggerProps }) => <TopBarAvatarButton {...getTriggerProps()}>{children}</TopBarAvatarButton>}
-      </DeprecatedMenu.Trigger>
-      <DeprecatedMenu.Popover>
-        <DeprecatedMenu.List>
-          <DeprecatedMenu.Item label="Menu Item 1" />
-          <DeprecatedMenu.Item label="Menu Item 2" />
-          <DeprecatedMenu.Item label="Menu Item 3" />
-        </DeprecatedMenu.List>
-      </DeprecatedMenu.Popover>
-    </DeprecatedMenu>
+    <>
+      <TopBarAvatarButton
+        {...Menu.getTriggerProps({ id: 'trigger', popoverTarget: 'menu', popoverTargetAction: 'toggle' })}
+      >
+        {children}
+      </TopBarAvatarButton>
+      <Menu aria-labelledby="trigger" id="menu" placement="bottom-end">
+        <Menu.Item>Menu Item 1</Menu.Item>
+        <Menu.Item>Menu Item 2</Menu.Item>
+        <Menu.Item>Menu Item 3</Menu.Item>
+      </Menu>
+    </>
   ),
 }

--- a/src/core/top-bar/avatar-button/avatar-button.tsx
+++ b/src/core/top-bar/avatar-button/avatar-button.tsx
@@ -1,9 +1,10 @@
+import { cx } from '@linaria/core'
 import { Avatar } from '../../avatar/avatar'
-import { ElTopBarAvatarButton } from './styles'
+import { elTopBarAvatarButton } from './styles'
 
-import type { ComponentProps, ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-export interface AvatarButtonProps extends ComponentProps<typeof ElTopBarAvatarButton> {
+export interface AvatarButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** The accessible name of the button. */
   'aria-label'?: string
   /** The avatar's text. Typically the initials of the current user. */
@@ -14,13 +15,20 @@ export interface AvatarButtonProps extends ComponentProps<typeof ElTopBarAvatarB
  * A simple avatar button that should open a menu with items that relate to the current user. These menu items will
  * typically include the ability to manage their Reapit Connect user account, preferences, and logout of their
  * current session.
+ *
+ * Typically, `TopBar.AvatarMenu` will be used as it combines `TopBar.AvatarButton` and `Menu` together.
  */
-export function TopBarAvatarButton({ 'aria-label': ariaLabel = 'Profile menu', children, ...rest }: AvatarButtonProps) {
+export function TopBarAvatarButton({
+  'aria-label': ariaLabel = 'Profile menu',
+  children,
+  className,
+  ...rest
+}: AvatarButtonProps) {
   return (
-    <ElTopBarAvatarButton {...rest} aria-label={ariaLabel}>
+    <button {...rest} aria-label={ariaLabel} className={cx(elTopBarAvatarButton, className)}>
       <Avatar size="small" shape="circle" colour="purple">
         {children}
       </Avatar>
-    </ElTopBarAvatarButton>
+    </button>
   )
 }

--- a/src/core/top-bar/avatar-button/styles.ts
+++ b/src/core/top-bar/avatar-button/styles.ts
@@ -1,7 +1,7 @@
-import { styled } from '@linaria/react'
+import { css } from '@linaria/core'
 import { ElAvatar } from '../../avatar/styles'
 
-export const ElTopBarAvatarButton = styled.button`
+export const elTopBarAvatarButton = css`
   cursor: pointer;
   background: none;
   border: none;

--- a/src/core/top-bar/avatar-menu/__tests__/avatar-menu.test.tsx
+++ b/src/core/top-bar/avatar-menu/__tests__/avatar-menu.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { TopBarAvatarMenu } from '../avatar-menu'
+
+test('renders a button element', () => {
+  render(<TopBarAvatarMenu initials="AA">Fake child</TopBarAvatarMenu>)
+
+  const button = screen.getByRole('button', { name: 'Profile menu' })
+  expect(button).toBeVisible()
+})
+
+test('forwards props to the underlying button', () => {
+  render(
+    <TopBarAvatarMenu data-testid="nav-item" initials="AA">
+      Fake child
+    </TopBarAvatarMenu>,
+  )
+
+  const button = screen.getByTestId('nav-item')
+  expect(button.tagName).toBe('BUTTON')
+  expect(button).toBeVisible()
+})
+
+test('will open the menu when clicked', () => {
+  render(<TopBarAvatarMenu initials="AA">Fake child</TopBarAvatarMenu>)
+
+  const button = screen.getByRole('button')
+  const menu = screen.getByRole('menu')
+
+  expect(button).toHaveAttribute('popovertarget', menu.id)
+})
+
+test('menu is labelled by the button', () => {
+  render(<TopBarAvatarMenu initials="AA">Fake child</TopBarAvatarMenu>)
+  expect(screen.getByRole('menu', { name: 'Profile menu' })).toBeVisible()
+})

--- a/src/core/top-bar/avatar-menu/avatar-menu.stories.tsx
+++ b/src/core/top-bar/avatar-menu/avatar-menu.stories.tsx
@@ -1,0 +1,34 @@
+import { Menu } from '#src/core/menu'
+import { TopBarAvatarMenu } from './avatar-menu'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof TopBarAvatarMenu> = {
+  component: TopBarAvatarMenu,
+  title: 'Core/TopBar/AvatarMenu',
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    initials: 'KD',
+    children: (
+      <>
+        <Menu.Item>Item 1</Menu.Item>
+        <Menu.Item>Item 2</Menu.Item>
+        <Menu.Item>Item 3</Menu.Item>
+      </>
+    ),
+  },
+}

--- a/src/core/top-bar/avatar-menu/avatar-menu.tsx
+++ b/src/core/top-bar/avatar-menu/avatar-menu.tsx
@@ -1,0 +1,35 @@
+import { Menu } from '#src/core/menu'
+import { TopBarAvatarButton } from '../avatar-button'
+import { useId } from 'react'
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+export interface AvatarMenuProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** The menu items. */
+  children: ReactNode
+  /** The avatar's text. Typically the initials of the current user. */
+  initials: ReactNode
+  maxWidth?: `--size-${string}`
+  maxHeight?: `--size-${string}`
+}
+
+/**
+ * A combination of a `TopBar.AvatarButton` and `Menu`.
+ */
+export function TopBarAvatarMenu({ children, id, initials, maxWidth, maxHeight, ...rest }: AvatarMenuProps) {
+  const triggerId = id ?? useId()
+  const menuId = useId()
+  return (
+    <>
+      <TopBarAvatarButton
+        {...rest}
+        {...Menu.getTriggerProps({ id: triggerId, popoverTarget: menuId, popoverTargetAction: 'toggle' })}
+      >
+        {initials}
+      </TopBarAvatarButton>
+      <Menu aria-labelledby={triggerId} id={menuId} maxWidth={maxWidth} maxHeight={maxHeight} placement="bottom-end">
+        {children}
+      </Menu>
+    </>
+  )
+}

--- a/src/core/top-bar/avatar-menu/index.ts
+++ b/src/core/top-bar/avatar-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './avatar-menu'

--- a/src/core/top-bar/index.ts
+++ b/src/core/top-bar/index.ts
@@ -1,3 +1,6 @@
+export * from './avatar-button'
+export * from './avatar-menu'
+export * from './brand-logo'
 export * from './main-nav'
 export * from './nav-dropdown-button'
 export * from './nav-icon-item'

--- a/src/core/top-bar/top-bar.tsx
+++ b/src/core/top-bar/top-bar.tsx
@@ -10,6 +10,7 @@ import {
   ElTopBarSecondaryNavContainer,
 } from './styles'
 import { TopBarAvatarButton } from './avatar-button'
+import { TopBarAvatarMenu } from './avatar-menu'
 import { TopBarMainNav } from './main-nav'
 import { TopBarNavSearch } from './nav-search'
 import { TopBarSecondaryNav } from './secondary-nav'
@@ -22,7 +23,7 @@ interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> 
    */
   appSwitcher?: ReactNode
   /**
-   * The user's profile menu. Typically an `AvatarButton`.
+   * The user's profile menu. Typically an `AvatarMenu`.
    */
   avatar?: ReactNode
   /**
@@ -55,8 +56,7 @@ interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> 
  * Only the logo and user avatar are required; all other regions are optional.
  *
  * - **App switcher:** [AppSwitcher](/docs/core-appswitcher--docs)
- * - **Avatar:** [Menu](/docs/core-menu--docs),
- *   [TopBar.AvatarButton](/docs/core-topbar-avatarbutton--docs)
+ * - **Avatar:** [TopBar.AvatarMenu](/docs/core-topbar-avatarmenu--docs)
  * - **Logo:** [TopBar.BrandLogo](/docs/core-topbar-brandlogo--docs)
  * - **Main navigation:** [TopBar.MainNav](/docs/core-topbar-mainnav--docs),
  *   [TopBar.NavItem](/docs/core-topbar-navitem--docs),
@@ -100,3 +100,4 @@ TopBar.NavSearchButton = TopBarNavSearch.Button
 TopBar.NavSearchIconItem = TopBarNavSearch.IconItem
 
 TopBar.AvatarButton = TopBarAvatarButton
+TopBar.AvatarMenu = TopBarAvatarMenu

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -22,6 +22,8 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **fix:** Tooltip conditional display now works correctly when the truncation target's size changes.
 - **feat:** Side bar menu items and menu group summaries now display a tooltip when their label is truncated.
 - **fix:** Menu anchor items now display "selected" state correctly.
+- **fix:** Top bar avatar button can now be the trigger for a Menu.
+- **feat:** Added new `TopBar.AvatarMenu` component that combines `TopBar.AvatarButton` with `Menu`.
 
 ### **5.0.0-beta.41 - 01/08/25**
 


### PR DESCRIPTION
What it says on the tin.

Adds a new `TopBar.AvatarMenu` component. This provides a more convenient option for consumers than direct use of `TopBar.AvatarButton` and `Menu`.

Plus:
- Fixes `TopBar.AvatarButton` so that it supports `Menu.getTriggerProps`.
- Exports missing top bar components.

<img width="829" height="482" alt="Screenshot 2025-08-07 at 4 09 52 pm" src="https://github.com/user-attachments/assets/6a3d0b84-1714-4c23-9d20-b52fe0b17727" />
