### PR TITLE
fix: `Menu` now handles consumer-supplied `className`

### DIFF
--- a/src/core/menu/__tests__/menu.test.tsx
+++ b/src/core/menu/__tests__/menu.test.tsx
@@ -16,6 +16,15 @@ test('uses popover="auto"', () => {
   expect(screen.getByRole('menu')).toHaveAttribute('popover', 'auto')
 })
 
+test('accepts consumer-supplied class names', () => {
+  render(
+    <Menu {...requiredProps} className="custom-class">
+      Menu content
+    </Menu>,
+  )
+  expect(screen.getByRole('menu')).toHaveClass('custom-class')
+})
+
 test('forwards additional props to the menu', () => {
   render(
     <Menu {...requiredProps} data-testid="test-id">

--- a/src/core/menu/menu.tsx
+++ b/src/core/menu/menu.tsx
@@ -1,4 +1,5 @@
 import { AnchorMenuItem, MenuItem } from './item'
+import { cx } from '@linaria/core'
 import { elMenu } from './styles'
 import { Popover } from '#src/utils/popover'
 import { MenuDivider } from './divider'
@@ -35,6 +36,7 @@ export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, Attribut
 export function Menu({
   'aria-labelledby': ariaLabelledBy,
   children,
+  className,
   gap = '--spacing-1',
   maxHeight,
   maxWidth,
@@ -51,7 +53,7 @@ export function Menu({
       {...rest}
       aria-labelledby={ariaLabelledBy}
       anchorId={ariaLabelledBy}
-      className={elMenu}
+      className={cx(elMenu, className)}
       elevation="xl"
       gap={`var(${gap})`}
       maxHeight={`var(${maxHeight})`}

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -20,6 +20,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 - **chore:** Update design tokens to match latest changes in Figma
 - **feat:** Add new `FilterBar`. See [FilterBar](?path=/docs/core-filterbar--docs) for details.
+- **fix:** `Menu` now correctly handles consumer-supplied `className` prop.
 
 ### **5.0.0-beta.42 - 07/08/25**
 

--- a/src/utils/popover/styles.ts
+++ b/src/utils/popover/styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@linaria/core'
 
 export const elPopover = css`
-  /* NOTE: we place these styled inside an anonymous layer so they can border
+  /* NOTE: we place these styled inside an anonymous layer so they can be easily
    * overriden by the Popover's consumers even if the consumer's styles have the
    * same specificity. */
   @layer {


### PR DESCRIPTION
What is says on the tin.

Small bug fix. Menu was nuking the consumer-supplied `className`.