### PR TITLE
fix: `Tooltip` only shows on focus when tabbed to

### DIFF
--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -22,6 +22,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Add new `FilterBar`. See [FilterBar](?path=/docs/core-filterbar--docs) for details.
 - **fix:** `Menu` now correctly handles consumer-supplied `className` prop.
 - **chore!:** Refactored `StatusIndicator`. The `el-status-indicator-shape` class has been removed and  the `variant` prop is no longer defaulted.
+- **fix:** `Tooltip` only shows when the trigger is focused through keyboard navigation. Previously, it would show when the trigger was programmatically focused, such as when a menu controlled by the trigger was closed.
 
 ### **5.0.0-beta.42 - 07/08/25**
 


### PR DESCRIPTION
Fixes small bug with Tooltip display behaviour.

`Tooltip` only shows when the trigger is focused through keyboard navigation. Previously, it would show when the trigger was programmatically focused, such as when a menu controlled by the trigger was closed.