### PR TITLE
fix: `AppSwitcher` now supports standard button attributes

### DIFF
--- a/src/core/app-switcher/__tests__/app-switcher.test.tsx
+++ b/src/core/app-switcher/__tests__/app-switcher.test.tsx
@@ -28,3 +28,8 @@ test('the menu is visible when the trigger button is clicked', () => {
   fireEvent.click(button)
   expect(screen.getByRole('menu')).toBeVisible()
 })
+
+test('additional props are forwarded to the trigger button', () => {
+  render(<AppSwitcherStories.Example data-testid="test-id" />)
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('button'))
+})

--- a/src/core/app-switcher/app-switcher.tsx
+++ b/src/core/app-switcher/app-switcher.tsx
@@ -9,9 +9,9 @@ import { getDisplayableProductsForExploreGroup } from './get-displayable-product
 import { Menu } from '#src/core/menu'
 import { useId } from 'react'
 
-import type { ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface AppSwitcherProps {
+interface AppSwitcherProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * The menu groups and their items. Should typically be `AppSwitcher.ExploreMenuGroup`,
    * `AppSwitcher.YourAppsMenuGroup`, and `AppSwitcher.ProductMenuItem` components */
@@ -23,13 +23,14 @@ interface AppSwitcherProps {
  * the products the current user has access to (in the Your Apps group), and other apps from Reapit (in the
  * Explore group).
  */
-export function AppSwitcher({ children }: AppSwitcherProps) {
-  const triggerId = useId()
+export function AppSwitcher({ children, id, ...rest }: AppSwitcherProps) {
+  const triggerId = id ?? useId()
   const menuId = useId()
 
   return (
     <>
       <AppSwitcherNavIconButton
+        {...rest}
         {...Menu.getTriggerProps({ id: triggerId, popoverTarget: menuId, popoverTargetAction: 'toggle' })}
       />
       <Menu aria-labelledby={triggerId} id={menuId} placement="bottom-start">

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.44 - ??/??/25**
 
-- TBC
+- **fix:** App Switcher now accepts standard button attributes and fowards them to the underlying trigger button.
 
 ### **5.0.0-beta.43 - 12/08/25**
 


### PR DESCRIPTION
What it says on the tin.