### PR TITLE
feat: #685 Add `FolderTabs`

### DIFF
--- a/src/core/folder-tabs/__story__/useFolderTabsContainerDecorator.tsx
+++ b/src/core/folder-tabs/__story__/useFolderTabsContainerDecorator.tsx
@@ -1,0 +1,11 @@
+import { FOLDER_TABS_CSS_CONTAINER_NAME } from '../constants'
+
+import type { Decorator } from '@storybook/react'
+
+export function useFolderTabsContainerDecorator(): Decorator {
+  return (Story) => (
+    <div style={{ containerName: FOLDER_TABS_CSS_CONTAINER_NAME, containerType: 'inline-size' }}>
+      <Story />
+    </div>
+  )
+}

--- a/src/core/folder-tabs/__tests__/folder-tabs.test.tsx
+++ b/src/core/folder-tabs/__tests__/folder-tabs.test.tsx
@@ -1,0 +1,29 @@
+import { FolderTabs } from '../folder-tabs'
+import { render, screen } from '@testing-library/react'
+import { FolderTab } from '../tab'
+import { FolderTabCountLabel } from '../count-label'
+
+test('renders a navigation element with a child group', () => {
+  render(<FolderTabs>Tabs</FolderTabs>)
+  expect(screen.getByRole('navigation')).toBeVisible()
+  expect(screen.getByRole('group')).toBeVisible()
+  expect(screen.getByRole('navigation').firstElementChild).toBe(screen.getByRole('group'))
+})
+
+test('displays provided content', () => {
+  render(<FolderTabs>Tabs</FolderTabs>)
+  expect(screen.getByText('Tabs')).toBeVisible()
+})
+
+test('forwards additional props to the navigation element', () => {
+  render(<FolderTabs data-testid="test-id">Tabs</FolderTabs>)
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('navigation'))
+})
+
+test('provides `FolderTabs.Item` subcomponent', () => {
+  expect(FolderTabs.Item).toBe(FolderTab)
+})
+
+test('provides `FolderTabs.CountLabel` subcomponent', () => {
+  expect(FolderTabs.CountLabel).toBe(FolderTabCountLabel)
+})

--- a/src/core/folder-tabs/constants.ts
+++ b/src/core/folder-tabs/constants.ts
@@ -1,0 +1,5 @@
+import { isWidthAtOrAbove, isWidthBelow } from '#src/utils/index'
+
+export const FOLDER_TABS_CSS_CONTAINER_NAME = '--folder-tabs-container'
+export const FOLDER_TABS_LARGE_CONTAINER_QUERY = `@container ${FOLDER_TABS_CSS_CONTAINER_NAME} ${isWidthAtOrAbove('SM')}`
+export const FOLDER_TABS_SMALL_CONTAINER_QUERY = `@container ${FOLDER_TABS_CSS_CONTAINER_NAME} ${isWidthBelow('SM')}`

--- a/src/core/folder-tabs/count-label/__tests__/count-label.test.tsx
+++ b/src/core/folder-tabs/count-label/__tests__/count-label.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { FolderTabCountLabel } from '../count-label'
+
+test('renders a span element', () => {
+  const { container } = render(<FolderTabCountLabel count="00">Label</FolderTabCountLabel>)
+  expect(container.firstElementChild?.tagName).toBe('SPAN')
+})
+
+test('displays count', () => {
+  render(<FolderTabCountLabel count="10">Label</FolderTabCountLabel>)
+  expect(screen.getByText('10')).toBeVisible()
+})
+
+test('displays children', () => {
+  render(<FolderTabCountLabel count="10">Label</FolderTabCountLabel>)
+  expect(screen.getByText('Label')).toBeVisible()
+})
+
+test('additional props are forwarded to the root span element', () => {
+  const { container } = render(
+    <FolderTabCountLabel data-testid="test-id" count="00">
+      Label
+    </FolderTabCountLabel>,
+  )
+  expect(screen.getByTestId('test-id')).toBe(container.firstElementChild)
+})

--- a/src/core/folder-tabs/count-label/count-label.stories.tsx
+++ b/src/core/folder-tabs/count-label/count-label.stories.tsx
@@ -1,0 +1,94 @@
+import { FOLDER_TABS_CSS_CONTAINER_NAME } from '../constants'
+import { FolderTabCountLabel } from './count-label'
+import { useFolderTabsContainerDecorator } from '../__story__/useFolderTabsContainerDecorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/FolderTabs/CountLabel',
+  component: FolderTabCountLabel,
+} satisfies Meta<typeof FolderTabCountLabel>
+
+export default meta
+
+type Story = StoryObj<typeof FolderTabCountLabel>
+
+/**
+ * By default, the count will expand to fill the available space of it's container.
+ */
+export const Example: Story = {
+  args: {
+    children: 'Label',
+    count: '00',
+  },
+  decorators: [useFolderTabsContainerDecorator()],
+}
+
+/**
+ * While labels should be concise to avoid overflow, if there is not enough space available, the label
+ * text will be permitted to wrap to a second line when the tabs container is large enough.
+ */
+export const Wrapping: Story = {
+  args: {
+    ...Example.args,
+    children: "A long tab label that will wrap to a second line but won't truncate",
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+          containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+          containerType: 'inline-size',
+          display: 'grid',
+          gridTemplateColumns: '50% 50%',
+          width: '768px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * If there is not enough space, even after wrapping is permitted in large containers, the text will
+ * be truncated.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    children: 'A very very very long tab label that will need to wrap to additional lines and may even be truncated',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
+        <div
+          style={{
+            boxSizing: 'content-box',
+            border: '1px solid #FA00FF',
+            containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+            containerType: 'inline-size',
+            display: 'grid',
+            gridTemplateColumns: '50% 50%',
+            width: '768px',
+          }}
+        >
+          <Story />
+        </div>
+        <div
+          style={{
+            boxSizing: 'content-box',
+            border: '1px solid #FA00FF',
+            containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+            containerType: 'inline-size',
+            width: '300px',
+          }}
+        >
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+}

--- a/src/core/folder-tabs/count-label/count-label.tsx
+++ b/src/core/folder-tabs/count-label/count-label.tsx
@@ -1,0 +1,23 @@
+import { ElFolderTabCountContainer, ElFolderTabCountLabel, ElFolderTabCountText } from './styles'
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface FolderTabCountLabelProps extends HTMLAttributes<HTMLSpanElement> {
+  /** The label text. */
+  children: ReactNode
+  /** The featured numerical count. */
+  count: ReactNode
+}
+
+/**
+ * Displays a numerical count alongside a label for a folder tab. Typically used via `FolderTabs.Count`.
+ * This is used to label tabs that need to indicate the number of associated items it contains, such as
+ * the number of transactions ready for processing.
+ */
+export function FolderTabCountLabel({ children, count, ...rest }: FolderTabCountLabelProps) {
+  return (
+    <ElFolderTabCountContainer {...rest}>
+      <ElFolderTabCountText>{count}</ElFolderTabCountText>
+      <ElFolderTabCountLabel>{children}</ElFolderTabCountLabel>
+    </ElFolderTabCountContainer>
+  )
+}

--- a/src/core/folder-tabs/count-label/index.ts
+++ b/src/core/folder-tabs/count-label/index.ts
@@ -1,0 +1,2 @@
+export * from './count-label'
+export * from './styles'

--- a/src/core/folder-tabs/count-label/styles.ts
+++ b/src/core/folder-tabs/count-label/styles.ts
@@ -1,0 +1,47 @@
+import { FOLDER_TABS_LARGE_CONTAINER_QUERY } from '../constants'
+import { font } from '#src/core/text'
+import { styled } from '@linaria/react'
+
+export const ElFolderTabCountContainer = styled.span`
+  position: relative;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+
+  ${FOLDER_TABS_LARGE_CONTAINER_QUERY} {
+    gap: var(--spacing-3);
+  }
+`
+
+export const ElFolderTabCountText = styled.span`
+  ${font('base', 'bold')}
+
+  ${FOLDER_TABS_LARGE_CONTAINER_QUERY} {
+    ${font('3xl', 'bold')}
+  }
+`
+
+export const ElFolderTabCountLabel = styled.span`
+  ${font('sm', 'medium')}
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  ${FOLDER_TABS_LARGE_CONTAINER_QUERY} {
+    /* NOTE: See https://developer.mozilla.org/en-US/docs/Web/CSS/line-clamp for more details.
+     * Specifically, all major browsers suppor the property, but explicitly with the -webkit-*
+     * prefix. Same deal with the -webkit-box display property and -webkit-box-orient.
+     *
+     * We could use -webkit-line-clamp: 1 for the small tab styles above, but it using standard
+     * inline text overflow is more reliable cross-browser. */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+
+    ${font('base', 'medium')}
+    white-space: normal;
+    text-align: start;
+  }
+`

--- a/src/core/folder-tabs/folder-tabs.stories.tsx
+++ b/src/core/folder-tabs/folder-tabs.stories.tsx
@@ -1,0 +1,90 @@
+import { FolderTabs } from './folder-tabs'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Core/FolderTabs',
+  component: FolderTabs,
+  argTypes: {
+    children: {
+      control: 'radio',
+      options: ['Two tabs', 'Three tabs', 'Many tabs', 'With counts'],
+      mapping: {
+        'Two tabs': buildTabs('Two tabs'),
+        'Three tabs': buildTabs('Three tabs'),
+        'Many tabs': buildTabs('Many tabs'),
+        'With counts': buildTabs('With counts'),
+      },
+    },
+  },
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+} satisfies Meta<typeof FolderTabs>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'Many tabs',
+  },
+}
+
+/**
+ * When the tabs are constrained by their container, they will display in a compact vertical layout
+ * that is appropriate for smaller screens. This occurs when the container's inline width is less than
+ * the equivalent `SM` breakpoint minimum width.
+ */
+export const Breakpoints: Story = {
+  args: {
+    children: 'With counts',
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ border: '1px solid #FA00FF', width: '397px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+}
+
+function buildTabs(type: 'Two tabs' | 'Three tabs' | 'Many tabs' | 'With counts') {
+  const renderLabel = (label: string) => {
+    return type === 'With counts' ? <FolderTabs.CountLabel count="00">{label}</FolderTabs.CountLabel> : label
+  }
+  return (
+    <>
+      <FolderTabs.Item key="apples" href={href} aria-current={false}>
+        {renderLabel('Apples')}
+      </FolderTabs.Item>
+      <FolderTabs.Item key="bananas" aria-current="page" href={href}>
+        {renderLabel('Bananas')}
+      </FolderTabs.Item>
+      {type !== 'Two tabs' && (
+        <>
+          <FolderTabs.Item key="peaches" aria-current={false} href={href}>
+            {renderLabel('Peaches')}
+          </FolderTabs.Item>
+          {type !== 'Three tabs' && (
+            <>
+              <FolderTabs.Item key="strawberries" aria-current={false} href={href}>
+                {renderLabel('Strawberries')}
+              </FolderTabs.Item>
+              <FolderTabs.Item key="watermelon" aria-current={false} href={href}>
+                {renderLabel('Watermelon')}
+              </FolderTabs.Item>
+            </>
+          )}
+        </>
+      )}
+    </>
+  )
+}

--- a/src/core/folder-tabs/folder-tabs.tsx
+++ b/src/core/folder-tabs/folder-tabs.tsx
@@ -1,0 +1,25 @@
+import { ElFolderTabs, ElFolderTabsGroup } from './styles'
+import { FolderTab } from './tab'
+import { FolderTabCountLabel } from './count-label'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface FolderTabsProps extends HTMLAttributes<HTMLElement> {
+  /** The tab items for primary navigation. Typically a collection of `FolderTabs.Item` components. */
+  children: ReactNode
+}
+
+/**
+ * A navigation container for primary tabs. Typically used with `FolderTabs.Item`
+ * and `FolderTabs.CountLabel`.
+ */
+export function FolderTabs({ children, ...rest }: FolderTabsProps) {
+  return (
+    <ElFolderTabs {...rest}>
+      <ElFolderTabsGroup role="group">{children}</ElFolderTabsGroup>
+    </ElFolderTabs>
+  )
+}
+
+FolderTabs.Item = FolderTab
+FolderTabs.CountLabel = FolderTabCountLabel

--- a/src/core/folder-tabs/index.ts
+++ b/src/core/folder-tabs/index.ts
@@ -1,0 +1,4 @@
+export * from './count-label'
+export * from './folder-tabs'
+export * from './styles'
+export * from './tab'

--- a/src/core/folder-tabs/styles.ts
+++ b/src/core/folder-tabs/styles.ts
@@ -1,0 +1,22 @@
+import { FOLDER_TABS_CSS_CONTAINER_NAME, FOLDER_TABS_LARGE_CONTAINER_QUERY } from './constants'
+import { styled } from '@linaria/react'
+
+export const ElFolderTabs = styled.nav`
+  container-name: ${FOLDER_TABS_CSS_CONTAINER_NAME};
+  container-type: inline-size;
+`
+
+export const ElFolderTabsGroup = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: start;
+
+  width: 100%;
+
+  ${FOLDER_TABS_LARGE_CONTAINER_QUERY} {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+  }
+`

--- a/src/core/folder-tabs/tab/__tests__/left-wave.test.tsx
+++ b/src/core/folder-tabs/tab/__tests__/left-wave.test.tsx
@@ -1,0 +1,21 @@
+import LeftWaveSvg from '../left-wave.svg?react'
+import { render } from '@testing-library/react'
+
+test('left mask matches snapshot', () => {
+  const { asFragment } = render(<LeftWaveSvg />)
+  expect(asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      <svg
+        fill="currentColor"
+        height="72"
+        viewBox="0 0 76 72"
+        width="76"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 72C43.7 64.2 14.804 0 76 0v72H0Z"
+        />
+      </svg>
+    </DocumentFragment>
+  `)
+})

--- a/src/core/folder-tabs/tab/__tests__/right-wave.test.tsx
+++ b/src/core/folder-tabs/tab/__tests__/right-wave.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import RightWaveSvg from '../right-wave.svg?react'
+
+test('right mask matches snapshot', () => {
+  const { asFragment } = render(<RightWaveSvg />)
+  expect(asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      <svg
+        fill="currentColor"
+        height="72"
+        viewBox="0 0 76 72"
+        width="76"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M76.25 72c-43.7-7.8-14.804-72-76-72v72h76Z"
+        />
+      </svg>
+    </DocumentFragment>
+  `)
+})

--- a/src/core/folder-tabs/tab/__tests__/tab.test.tsx
+++ b/src/core/folder-tabs/tab/__tests__/tab.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { FolderTab } from '../tab'
+
+test('renders a link element', () => {
+  render(
+    <FolderTab aria-current={false} href="https://fake.url">
+      Label
+    </FolderTab>,
+  )
+  expect(screen.getByRole('link')).toBeVisible()
+})
+
+test('children act as the accessible name of the link', () => {
+  render(
+    <FolderTab aria-current={false} href="https://fake.url">
+      Label
+    </FolderTab>,
+  )
+  expect(screen.getByRole('link', { name: 'Label' })).toBeVisible()
+})
+
+test('aria-current is forwarded to the link element', () => {
+  render(
+    <FolderTab aria-current="page" href="https://fake.url">
+      Label
+    </FolderTab>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'page')
+})
+
+test('href is forwarded to the link element', () => {
+  render(
+    <FolderTab aria-current="page" href="https://fake.url">
+      Label
+    </FolderTab>,
+  )
+  expect(screen.getByRole('link')).toHaveAttribute('href', 'https://fake.url')
+})
+
+test('additional props are forwarded to the link element', () => {
+  render(
+    <FolderTab aria-current="page" data-testid="test-id" href="https://fake.url">
+      Label
+    </FolderTab>,
+  )
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('link'))
+})

--- a/src/core/folder-tabs/tab/index.ts
+++ b/src/core/folder-tabs/tab/index.ts
@@ -1,0 +1,2 @@
+export * from './styles'
+export * from './tab'

--- a/src/core/folder-tabs/tab/left-wave.svg
+++ b/src/core/folder-tabs/tab/left-wave.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="76" height="72" fill="currentColor" viewBox="0 0 76 72">
+  <path d="M0 72C43.7 64.2 14.804 0 76 0v72H0Z"/>
+</svg>

--- a/src/core/folder-tabs/tab/right-wave.svg
+++ b/src/core/folder-tabs/tab/right-wave.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="76" height="72" fill="currentColor" viewBox="0 0 76 72">
+  <path d="M76.25 72c-43.7-7.8-14.804-72-76-72v72h76Z"/>
+</svg>

--- a/src/core/folder-tabs/tab/styles.ts
+++ b/src/core/folder-tabs/tab/styles.ts
@@ -1,0 +1,131 @@
+import { css } from '@linaria/core'
+import { FOLDER_TABS_LARGE_CONTAINER_QUERY, FOLDER_TABS_SMALL_CONTAINER_QUERY } from '../constants'
+import { font } from '#src/core/text'
+import { styled } from '@linaria/react'
+
+interface ElFolderTabProps {
+  'aria-current': 'page' | false
+}
+
+export const ElFolderTab = styled.a<ElFolderTabProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  height: var(--size-14);
+  width: 100%;
+  padding: var(--spacing-4) var(--spacing-5);
+  margin: 0;
+
+  text-decoration: none;
+
+  /* Background and text colours are the same regardless of container size */
+  background: var(--comp-folder_tab-colour-fill-default);
+  color: var(--comp-folder_tab-colour-text-default);
+  outline: none;
+
+  /* Focus and hover styles are the same regardless of container size */
+  &:focus-visible,
+  &:hover {
+    background: var(--comp-folder_tab-colour-fill-hover);
+    color: var(--comp-folder_tab-colour-text-hover);
+  }
+
+  &[aria-current='page'] {
+    background: var(--comp-folder_tab-colour-fill-selected);
+    color: var(--comp-folder_tab-colour-text-selected);
+  }
+
+  ${FOLDER_TABS_SMALL_CONTAINER_QUERY} {
+    /* Top border provides subtle visual separation between vertically stacked tabs */
+    border-block-start: var(--comp-folder_tab-border-width, 1px) solid var(--comp-folder_tab-colour-border);
+    border-start-end-radius: var(--comp-folder_tab-border-radius-XS_SM);
+    border-start-start-radius: var(--comp-folder_tab-border-radius-XS_SM);
+
+    ${font('base', 'medium')}
+
+    /* All but the first tab in a small container have a negative top margin */
+    &:not(:first-of-type) {
+      margin-block-start: calc(0px - var(--spacing-4)); /* -16x */
+    }
+  }
+
+  ${FOLDER_TABS_LARGE_CONTAINER_QUERY} {
+    /* Allow the waves to be absolutely positioned relative to their tab */
+    position: relative;
+
+    border-block-start: none;
+    border-start-end-radius: var(--comp-folder_tab-border-radius-MD_2XL);
+    border-start-start-radius: var(--comp-folder_tab-border-radius-MD_2XL);
+
+    height: var(--size-18);
+    /* Don't need the negative top margins used in small containers */
+    margin-block: 0;
+
+    ${font('lg', 'medium')}
+
+    &[aria-current='page'] {
+      z-index: 1;
+    }
+  }
+`
+
+export const ElFolderTabContentContainer = styled.span`
+  display: inline-block;
+  white-space: nowrap;
+  text-align: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  /* Ensures the tab content is stacked above the tab's waves, if they're visible */
+  transform: translateX(0px);
+`
+
+export const elFolderTabWave = css`
+  /* Waves are always hidden, unless the container is large enough */
+  display: none;
+
+  ${FOLDER_TABS_LARGE_CONTAINER_QUERY} {
+    position: absolute;
+    display: block;
+
+    color: var(--comp-folder_tab-colour-fill-default);
+
+    ${ElFolderTab}:focus-visible > &,
+    ${ElFolderTab}:hover > & {
+      color: var(--comp-folder_tab-colour-fill-hover);
+    }
+
+    ${ElFolderTab}[aria-current='page'] > & {
+      color: var(--comp-folder_tab-colour-fill-selected);
+    }
+
+    /* Left wave */
+    &:first-of-type {
+      left: 0;
+      transform: translateX(-50%);
+    }
+
+    /* Right wave */
+    &:last-of-type {
+      right: 0;
+      transform: translateX(50%);
+    }
+
+    /* First tab */
+    ${ElFolderTab}:first-of-type > & {
+      /* Left wave should be hidden in the first tab */
+      &:first-of-type {
+        display: none;
+      }
+    }
+
+    /* Last tab */
+    ${ElFolderTab}:last-of-type > & {
+      /* Right wave should be hidden in the last tab */
+      &:last-of-type {
+        display: none;
+      }
+    }
+  }
+`

--- a/src/core/folder-tabs/tab/tab.stories.tsx
+++ b/src/core/folder-tabs/tab/tab.stories.tsx
@@ -1,0 +1,271 @@
+import { FOLDER_TABS_CSS_CONTAINER_NAME } from '../constants'
+import { ElFolderTab } from './styles'
+import { FolderTab } from './tab'
+import { FolderTabCountLabel } from '../count-label'
+import { useFolderTabsContainerDecorator } from '../__story__/useFolderTabsContainerDecorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/FolderTabs/Tab',
+  component: FolderTab,
+  argTypes: {
+    'aria-current': {
+      options: ['page', false],
+      mapping: {
+        page: 'page',
+        false: false,
+      },
+    },
+    children: {
+      control: 'text',
+    },
+    href: {
+      control: false,
+    },
+  },
+  globals: {
+    backgrounds: {
+      value: 'light',
+    },
+  },
+} satisfies Meta<typeof FolderTab>
+
+export default meta
+
+type Story = StoryObj<typeof FolderTab>
+
+/**
+ * The visual appearance of a folder tab will change based on it's container's size. For small
+ * containers (XS breakpoint only), the tab will be more compact and designed to stack vertically.
+ * For larger containers (SM breakpoint and above), the tab will be wider and designed to stack
+ * horizontally.
+ *
+ * For solitary tabs, which will be rare in practice, the visual difference is subtle.
+ */
+export const Example: Story = {
+  args: {
+    'aria-current': false,
+    children: 'Label',
+    href: globalThis.top?.location.href!,
+  },
+  decorators: [useFolderTabsContainerDecorator()],
+}
+
+/**
+ * When there are multiple siblings (i.e., they all share the same parent element), tabs in larger
+ * containers feature "waves" on their ends that overlap adjacent tabs while tabs in smaller containers
+ * feature subtle top borders. In both cases, some tabs will have negative margins to cause them to
+ * overlap their siblings.
+ *
+ * These differences are because tabs are designed to be stacked horizontally in larger containers, but
+ * vertically in smaller containers. This behaviour is more clearly seen in the stories for
+ * [FolderTabs](?/docs/core-foldertabs--example).
+ */
+export const FirstTab: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+          containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+          containerType: 'inline-size',
+          display: 'grid',
+          gridTemplateColumns: '1fr 0 0',
+          alignItems: 'center',
+        }}
+      >
+        <Story />
+        <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+        <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * When the tab is neither the first nor the last sibling, a "wave" will be featured on both sides in
+ * larger containers. It will also have a negative right margin, though this is not visible here.
+ * On smaller containers, the tab will feature a subtle top border and negative top margin.
+ */
+export const MiddleTab: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+          containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+          containerType: 'inline-size',
+          display: 'grid',
+          gridTemplateColumns: '0 1fr 0',
+          alignItems: 'center',
+        }}
+      >
+        <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+        <Story />
+        <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Finally, when the tab is neither the last sibling, a "wave" will be featured on its left side in
+ * larger containers. On smaller containers, the tab will feature a subtle top border and negative
+ * top margin.
+ */
+export const LastTab: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+          containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+          containerType: 'inline-size',
+          display: 'grid',
+          gridTemplateColumns: '0 0 1fr',
+          alignItems: 'stretch',
+        }}
+      >
+        <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+        <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * When the tab represents the current page, `aria-current="page"` should be supplied to communicate to
+ * visual and accessible users that the tab is currently "selected". The selected tab, in large containers
+ * only, will sit above all other tabs. This behaviour is more clearly seen in the stories for
+ * [FolderTabs](?/docs/core-foldertabs--example).
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    'aria-current': 'page',
+  },
+  decorators: [useFolderTabsContainerDecorator()],
+}
+
+/**
+ * The [FolderTabs.CountLabel](?/docs/core-foldertabs-countlabel-example) component can be used to
+ * display a numerical count alongside the tab label. This is typically used to indicate the number
+ * of items associated with the tab, such as the number of transactions ready for processing.
+ */
+export const WithCount: Story = {
+  args: {
+    ...Example.args,
+    children: <FolderTabCountLabel count="00">Label</FolderTabCountLabel>,
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  decorators: [useFolderTabsContainerDecorator()],
+}
+
+/**
+ * By default, tabs can contain any content, though this will typically be plain text or a
+ * [FolderTabs.CountLabel](?/docs/core-foldertabs-countlabel--example). When plain text is displayed,
+ * it will be truncated if it is too long to fit within the available space.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    children: 'A very very very long tab label that will need to wrap to additional lines and may even be truncated',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
+        <div
+          style={{
+            boxSizing: 'content-box',
+            border: '1px solid #FA00FF',
+            containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+            containerType: 'inline-size',
+            display: 'grid',
+            gridTemplateColumns: '50% 50%',
+            width: '768px',
+          }}
+        >
+          <Story />
+          <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+        </div>
+        <div
+          style={{
+            boxSizing: 'content-box',
+            border: '1px solid #FA00FF',
+            containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+            containerType: 'inline-size',
+            width: '300px',
+          }}
+        >
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+}
+
+/**
+ * When [FolderTabs.CountLabel](?/docs/core-foldertabs-countlabel-example) is used for the tab content,
+ * the label text will still truncate if there's not enough space, but tabs in large containers will
+ * allow two lines of text before truncation is applied.
+ */
+export const OverflowWithCount: Story = {
+  name: 'Overflow w/ count',
+  args: {
+    ...Example.args,
+    children: (
+      <FolderTabCountLabel count="00">
+        A very very very long tab label that will need to wrap to additional lines and may even be truncated
+      </FolderTabCountLabel>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
+        <div
+          style={{
+            boxSizing: 'content-box',
+            border: '1px solid #FA00FF',
+            containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+            containerType: 'inline-size',
+            display: 'grid',
+            gridTemplateColumns: '50% 50%',
+            width: '768px',
+          }}
+        >
+          <Story />
+          <ElFolderTab aria-current={false} style={{ opacity: 0 }} />
+        </div>
+        <div
+          style={{
+            boxSizing: 'content-box',
+            border: '1px solid #FA00FF',
+            containerName: FOLDER_TABS_CSS_CONTAINER_NAME,
+            containerType: 'inline-size',
+            width: '300px',
+          }}
+        >
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+}

--- a/src/core/folder-tabs/tab/tab.tsx
+++ b/src/core/folder-tabs/tab/tab.tsx
@@ -1,0 +1,33 @@
+import { ElFolderTab, ElFolderTabContentContainer, elFolderTabWave } from './styles'
+import LeftWave from './left-wave.svg?react'
+import RightWave from './right-wave.svg?react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+
+interface FolderTabProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Whether this tab represents the current page or not. */
+  'aria-current': 'page' | false
+  /**
+   * The tab's label text. Typically plain text or a
+   * [FolderTabs.Count](?/docs/core-foldertabcount--example) element.
+   */
+  children: ReactNode
+  /** The page this tab should navigate to. */
+  href: string
+}
+
+/**
+ * Folder tabs let users switch between related sections of content within the same screen.
+ * Typically used via `FolderTabs.Item`.
+ */
+export function FolderTab({ children, ...rest }: FolderTabProps) {
+  return (
+    <ElFolderTab {...rest}>
+      <LeftWave aria-hidden className={elFolderTabWave} />
+      <RightWave aria-hidden className={elFolderTabWave} />
+      {/* NOTE: The content container comes last in the DOM because we want its content to appear above
+       * the left and right waves. This is because the waves are absolutely positioned in such a way
+       * that they may overlap the content. */}
+      <ElFolderTabContentContainer>{children}</ElFolderTabContentContainer>
+    </ElFolderTab>
+  )
+}

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -24,6 +24,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore!:** Moved `@reapit/elements/core/container-query` to `@reapit/elements/utils/css-container-query` to align with it's actual name (`CSSContainerQuery`) and the fact its not a "core" component.
 - **chore:** Updated all core components to use the `font` helper instead of duplicated font styles.
 - **chore!:** Moved Table components from `@reapit/elements/core/table` to `@reapit/elements/lab/table` and the related CSS classes are all prefixed with `el-experimental-*` now. Importantly, they are no longer available via the main `@reapit/elements` entry point. The deprecated v4 Table components are still available via `@reapit/elements/deprecated/table`.
+- **feat:** Added `FolderTabs`. See [FolderTabs](?path=/docs/core-foldertabs--docs) for details.
 
 ### **5.0.0-beta.43 - 12/08/25**
 

--- a/src/tokens/Semantics.PayProp.tokens.json
+++ b/src/tokens/Semantics.PayProp.tokens.json
@@ -1250,11 +1250,15 @@
     },
     "folder_tab": {
       "border": {
-        "$type": "color",
-        "$value": "{neutral-500}",
         "radius": {
-          "$type": "dimension",
-          "$value": "{unit-4}"
+          "MD_2XL": {
+            "$type": "dimension",
+            "$value": "{unit-4}"
+          },
+          "XS_SM": {
+            "$type": "dimension",
+            "$value": "{unit-4}"
+          }
         },
         "width": {
           "$type": "dimension",

--- a/src/tokens/Semantics.Reapit.tokens.json
+++ b/src/tokens/Semantics.Reapit.tokens.json
@@ -1250,11 +1250,15 @@
     },
     "folder_tab": {
       "border": {
-        "$type": "color",
-        "$value": "{neutral-500}",
         "radius": {
-          "$type": "dimension",
-          "$value": "{unit-4}"
+          "MD_2XL": {
+            "$type": "dimension",
+            "$value": "{unit-8}"
+          },
+          "XS_SM": {
+            "$type": "dimension",
+            "$value": "{unit-4}"
+          }
         },
         "width": {
           "$type": "dimension",

--- a/src/tokens/dist/payprop.css
+++ b/src/tokens/dist/payprop.css
@@ -266,7 +266,9 @@
   --comp-file_uploader-colour-text-hover-primary: #222b33;
   --comp-file_uploader-colour-text-info-error: #f01830;
   --comp-file_uploader-colour-text-info-helper: #607890;
-  --comp-folder_tab-border: #607890;
+  --comp-folder_tab-border-radius-MD_2XL: 16px;
+  --comp-folder_tab-border-radius-XS_SM: 16px;
+  --comp-folder_tab-border-width: 1px;
   --comp-folder_tab-colour-border: #c5ced6;
   --comp-folder_tab-colour-fill-default: #d8dee4;
   --comp-folder_tab-colour-fill-hover: #0294d2;

--- a/src/tokens/dist/reapit.css
+++ b/src/tokens/dist/reapit.css
@@ -266,7 +266,9 @@
   --comp-file_uploader-colour-text-hover-primary: #222b33;
   --comp-file_uploader-colour-text-info-error: #f01830;
   --comp-file_uploader-colour-text-info-helper: #607890;
-  --comp-folder_tab-border: #607890;
+  --comp-folder_tab-border-radius-MD_2XL: 32px;
+  --comp-folder_tab-border-radius-XS_SM: 16px;
+  --comp-folder_tab-border-width: 1px;
   --comp-folder_tab-colour-border: #c5ced6;
   --comp-folder_tab-colour-fill-default: #d8dee4;
   --comp-folder_tab-colour-fill-hover: #4e56ea;


### PR DESCRIPTION
### Context

- FolderTabs is ready for dev: https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=12202-1719&m=dev
- We want to add it to Elements.

### This PR

- Resolves #685 
- Adds `FolderTabs`, `FolderTabs.Item` and `FolderTabs.CountLabel`

<img width="817" height="647" alt="Screenshot 2025-08-18 at 1 12 20 pm" src="https://github.com/user-attachments/assets/043ea98d-cd2b-4582-abc6-3cd69f823a5c" />
<img width="817" height="349" alt="Screenshot 2025-08-18 at 1 12 24 pm" src="https://github.com/user-attachments/assets/c24f1244-a83f-4f89-996d-3a90253316e7" />
<img width="822" height="671" alt="Screenshot 2025-08-18 at 1 12 39 pm" src="https://github.com/user-attachments/assets/d1887799-d13c-44d9-9ff4-9c4506c6d0f7" />
<img width="814" height="686" alt="Screenshot 2025-08-18 at 1 12 46 pm" src="https://github.com/user-attachments/assets/21381750-1f9a-47c6-8ab3-c4b3a243c291" />
<img width="818" height="481" alt="Screenshot 2025-08-18 at 1 12 53 pm" src="https://github.com/user-attachments/assets/d73b997b-0ade-41c1-ab77-24ab13c83357" />
<img width="816" height="536" alt="Screenshot 2025-08-18 at 1 13 01 pm" src="https://github.com/user-attachments/assets/a210de23-4e8d-4f07-b6e8-f97997d26378" />
<img width="816" height="288" alt="Screenshot 2025-08-18 at 1 13 05 pm" src="https://github.com/user-attachments/assets/8e985ab9-f1f4-43d1-b99d-0b0c5ca8ffe6" />
<img width="816" height="649" alt="Screenshot 2025-08-18 at 1 13 19 pm" src="https://github.com/user-attachments/assets/805be1b5-e3e8-46c1-b506-022f10879f5e" />
<img width="812" height="456" alt="Screenshot 2025-08-18 at 1 13 23 pm" src="https://github.com/user-attachments/assets/c0fc6bfc-47a7-4565-a76d-0e2a63567826" />
