### PR TITLE
chore: use new breakpoint helpers in core components

### DIFF
--- a/src/core/bottom-bar/bottom-bar.stories.tsx
+++ b/src/core/bottom-bar/bottom-bar.stories.tsx
@@ -38,11 +38,13 @@ const meta = {
       <div
         ref={ref}
         style={{
-          overflow: 'auto',
-          height: '300px',
-          width: '100%',
           boxSizing: 'border-box',
           border: '1px solid #FA00FF',
+          containerType: 'inline-size',
+          height: '300px',
+          marginInline: 'auto',
+          overflow: 'auto',
+          width: '600px',
         }}
       >
         <Pattern height="100vh" />

--- a/src/core/bottom-bar/item/styles.ts
+++ b/src/core/bottom-bar/item/styles.ts
@@ -36,13 +36,12 @@ export const ElBottomBarItemIcon = styled.span`
   position: relative;
 
   color: var(--comp-navigation-colour-icon-bottom_bar-default);
-  font-size: var(--icon_size-l);
   width: var(--icon_size-l);
   height: var(--icon_size-l);
 
   ${ElDeprecatedIcon} {
     color: inherit;
-    font-size: inherit;
+    font-size: var(--icon_size-l);
     width: inherit;
     height: inherit;
   }

--- a/src/core/bottom-bar/styles.ts
+++ b/src/core/bottom-bar/styles.ts
@@ -1,4 +1,4 @@
-import { isTablet } from '#src/styles/deprecated-media'
+import { isWidthAtOrAbove, isWidthBelow } from '#src/utils/breakpoints'
 import { styled } from '@linaria/react'
 
 export const ElBottomBarContainer = styled.div`
@@ -10,16 +10,20 @@ export const ElBottomBarContainer = styled.div`
   container-type: inline-size;
 
   display: block;
-  @supports not (container-type: inline-size) {
-    ${isTablet} {
-      display: none;
-    }
+
+  @media screen and ${isWidthAtOrAbove('SM')} {
+    display: none;
   }
-  @supports (container-type: inline-size) {
-    /* NOTE: This is equivalent to the SM breakpoint */
-    @container (width >= 768px) {
-      display: none;
-    }
+
+  @container ${isWidthAtOrAbove('SM')} {
+    display: none;
+  }
+
+  /* NOTE: This container query will override the default media query behaviour above if there's
+   * an ancestor is a container. If there's no ancestral container, the media query will behave
+   * as defined above. */
+  @container ${isWidthBelow('SM')} {
+    display: block;
   }
 `
 

--- a/src/core/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/core/breadcrumbs/breadcrumbs.stories.tsx
@@ -59,10 +59,11 @@ export const Example: Story = {
 }
 
 /**
- * Overflowing should be avoided as much as possible. On SM screen sizes and larger, or when `overflow="truncate"` is
- * specified, each item's text will shrink as space becomes limited, using ellipses to indicate truncation has
- * occurred, but the breadcrumb separators should remain fully visible. In general, it's best to avoid this situation
- * altogether by limiting the number of breadcrumbs in the trail.
+ * Overflowing should be avoided as much as possible. On SM viewport or container sizes and larger, or
+ * when `overflow="truncate"` is specified, each item's text will shrink as space becomes limited, using
+ * ellipses to indicate truncation has occurred, but the breadcrumb separators should remain fully
+ * visible. In general, it's best to avoid this situation altogether by limiting the number of
+ * breadcrumbs in the trail.
  */
 export const Overflow: Story = {
   args: {
@@ -78,7 +79,7 @@ export const Overflow: Story = {
 }
 
 /**
- * On XS screen sizes (e.g. under 768px), or when `overflow="scroll"` is specified, the breadcrumbs will be
+ * In XS viewport or container sizes, or when `overflow="scroll"` is specified, the breadcrumbs will be
  * horizontally scrollable, albeit without any visible scrollbar. When scrolling occurs, the focus outlines will
  * be clipped; this is expected and considered acceptable.
  */

--- a/src/core/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/breadcrumbs/breadcrumbs.tsx
@@ -12,12 +12,14 @@ interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
 }
 
 /**
- * Breadcrumbs are used to indicate to the user their flow in the application and provide a navigation back step to
- * previous pages. By default, the breadcrumb trails behaviour changes based on screen size.
+ * Breadcrumbs are used to indicate to the user their flow in the application and provide
+ * a navigation back step to previous pages. By default, the breadcrumb trails behaviour changes
+ * based on screen size.
  *
- * - On XS screen sizes, the trail will grow to its maximum content width and be horizontally scrollable.
- * - On SM screen sizes and larger, the trail will grow to its parent container and truncate the text of each item
- *   using ellipses.
+ * - In XS viewport or container sizes, the trail will grow to its maximum content
+ *   width and be horizontally scrollable.
+ * - In SM-2XL viewport or container sizes, the trail will grow to its parent container
+ *   and truncate the text of each item using ellipses.
  *
  * This dynamic behaviour can be overridden by specifying the `width` property.
  */

--- a/src/core/breadcrumbs/styles.ts
+++ b/src/core/breadcrumbs/styles.ts
@@ -1,5 +1,5 @@
 import { styled } from '@linaria/react'
-import { isMobile } from '#src/styles/deprecated-media'
+import { isWidthAtOrAbove, isWidthBelow } from '#src/utils/breakpoints'
 
 interface ElBreadcrumbsProps {
   'data-overflow'?: 'scroll' | 'truncate'
@@ -8,10 +8,25 @@ interface ElBreadcrumbsProps {
 export const ElBreadcrumbs = styled.nav<ElBreadcrumbsProps>`
   width: 100%;
 
-  ${isMobile} {
+  /* NOTE: Media and container queries come before data-overflow attribute styles to allow
+   * the latter to take precedence */
+  @media screen and ${isWidthBelow('SM')} {
     /* NOTE: This is generally considered bad practice */
     scrollbar-width: none;
     overflow-x: auto;
+  }
+
+  @container ${isWidthBelow('SM')} {
+    scrollbar-width: none;
+    overflow-x: auto;
+  }
+
+  /* NOTE: This container query will override the default media query behaviour above if there's
+   * an ancestor is a container. If there's no ancestral container, the media query will behave
+   * as defined above. */
+  @container ${isWidthAtOrAbove('SM')} {
+    scrollbar-width: initial;
+    overflow-x: initial;
   }
 
   &[data-overflow='scroll'] {
@@ -34,8 +49,21 @@ export const ElBreadcrumbsList = styled.ul`
 
   width: 100%;
 
-  ${isMobile} {
+  /* NOTE: Media and container queries come before data-overflow attribute styles to allow
+   * the latter to take precedence */
+  @media screen and ${isWidthBelow('SM')} {
     width: max-content;
+  }
+
+  @container ${isWidthBelow('SM')} {
+    width: max-content;
+  }
+
+  /* NOTE: This container query will override the default media query behaviour above if there's
+   * an ancestor is a container. If there's no ancestral container, the media query will behave
+   * as defined above. */
+  @container ${isWidthAtOrAbove('SM')} {
+    width: 100%;
   }
 
   [data-overflow='truncate'] > & {

--- a/src/core/page-header/leading-element/styles.ts
+++ b/src/core/page-header/leading-element/styles.ts
@@ -1,4 +1,4 @@
-import { isTablet } from '#src/styles/deprecated-media'
+import { isWidthAtOrAbove, isWidthBelow } from '#src/utils/breakpoints'
 import { styled } from '@linaria/react'
 
 interface PageHeaderLeadingElementProps {
@@ -19,24 +19,25 @@ export const ElPageHeaderLeadingElement = styled.div<PageHeaderLeadingElementPro
     height: var(--size-6);
     width: var(--size-6);
 
-    ${isTablet} {
+    @media screen and ${isWidthAtOrAbove('SM')} {
       padding-block-start: var(--spacing-1);
       height: var(--size-10);
       width: var(--size-10);
     }
 
-    @supports (container-type: inline-size) {
-      @container (width < 768px) {
-        padding-block-start: var(--spacing-2);
-        height: var(--size-6);
-        width: var(--size-6);
-      }
+    @container ${isWidthAtOrAbove('SM')} {
+      padding-block-start: var(--spacing-1);
+      height: var(--size-10);
+      width: var(--size-10);
+    }
 
-      @container (width >= 768px) {
-        padding-block-start: var(--spacing-1);
-        height: var(--size-10);
-        width: var(--size-10);
-      }
+    /* NOTE: This container query will override the default media query behaviour above if there's
+     * an ancestor is a container. If there's no ancestral container, the media query will behave
+     * as defined above. */
+    @container ${isWidthBelow('SM')} {
+      padding-block-start: var(--spacing-2);
+      height: var(--size-6);
+      width: var(--size-6);
     }
   }
 
@@ -47,18 +48,19 @@ export const ElPageHeaderLeadingElement = styled.div<PageHeaderLeadingElementPro
     padding-block-start: var(--spacing-1);
     width: var(--size-16);
 
-    ${isTablet} {
+    @media screen and ${isWidthAtOrAbove('SM')} {
       width: var(--size-24);
     }
 
-    @supports (container-type: inline-size) {
-      @container (width < 768px) {
-        width: var(--size-16);
-      }
+    @container ${isWidthAtOrAbove('SM')} {
+      width: var(--size-24);
+    }
 
-      @container (width >= 768px) {
-        width: var(--size-24);
-      }
+    /* NOTE: This container query will override the default media query behaviour above if there's
+     * an ancestor is a container. If there's no ancestral container, the media query will behave
+     * as defined above. */
+    @container ${isWidthBelow('SM')} {
+      width: var(--size-16);
     }
   }
 `

--- a/src/core/page-header/styles.ts
+++ b/src/core/page-header/styles.ts
@@ -1,4 +1,4 @@
-import { isDesktop, isTablet } from '#src/styles/deprecated-media'
+import { isWidthAtOrAbove, isWidthBelow } from '#src/utils/breakpoints'
 import { styled } from '@linaria/react'
 
 import type { CSSProperties } from 'react'
@@ -24,12 +24,12 @@ export const ElPageHeader = styled.header<PageHeaderProps>`
 
   /* NOTE: Media queries are use by default, but if the browser supports container queries, they will override the
    * media query styles defined here. */
-  ${isTablet} {
+  @media screen and ${isWidthAtOrAbove('SM')} {
     padding-block: var(--spacing-8);
     padding-inline: var(--spacing-8);
   }
 
-  ${isDesktop} {
+  @media screen and ${isWidthAtOrAbove('MD')} {
     padding-block: var(--spacing-10);
     padding-inline: var(--spacing-10);
   }
@@ -37,21 +37,19 @@ export const ElPageHeader = styled.header<PageHeaderProps>`
   /* NOTE: These container query styles come _after_ the media query styles, so they will override them (if the browser
    * supports container queries). These container query styles are also dependent on a parent element being a size or
    * inline-size container. */
-  @supports (container-type: inline-size) {
-    @container (width < 768px) {
-      padding-block: var(--spacing-3);
-      padding-inline: var(--spacing-5) var(--spacing-3);
-    }
+  @container ${isWidthBelow('SM')} {
+    padding-block: var(--spacing-3);
+    padding-inline: var(--spacing-5) var(--spacing-3);
+  }
 
-    @container (width >= 768px) {
-      padding-block: var(--spacing-8);
-      padding-inline: var(--spacing-8);
-    }
+  @container ${isWidthBelow('MD')} {
+    padding-block: var(--spacing-8);
+    padding-inline: var(--spacing-8);
+  }
 
-    @container (width >= 1024px) {
-      padding-block: var(--spacing-8);
-      padding-inline: var(--spacing-10);
-    }
+  @container ${isWidthBelow('MD')} {
+    padding-block: var(--spacing-8);
+    padding-inline: var(--spacing-10);
   }
 `
 
@@ -61,21 +59,19 @@ export const ElPageHeaderBreadcrumbsContainer = styled.div`
 
   /* NOTE: Media queries are use by default, but if the browser supports container queries, they will override the
    * media query styles defined here. */
-  ${isTablet} {
+  @media screen and ${isWidthAtOrAbove('SM')} {
+    padding-block-end: var(--spacing-4);
+  }
+
+  @container ${isWidthAtOrAbove('SM')} {
     padding-block-end: var(--spacing-4);
   }
 
   /* NOTE: These container query styles come _after_ the media query styles, so they will override them (if the browser
-  * supports container queries). These container query styles are also dependent on a parent element being a size or
-  * inline-size container. */
-  @supports (container-type: inline-size) {
-    @container (width < 768px) {
-      padding-block-end: var(--spacing-2);
-    }
-
-    @container (width >= 768px) {
-      padding-block-end: var(--spacing-4);
-    }
+   * supports container queries). These container query styles are also dependent on a parent element being a size or
+   * inline-size container. */
+  @container ${isWidthBelow('SM')} {
+    padding-block-end: var(--spacing-2);
   }
 `
 
@@ -85,21 +81,19 @@ export const ElPageHeaderLeadingElementContainer = styled.div`
 
   /* NOTE: Media queries are use by default, but if the browser supports container queries, they will override the
    * media query styles defined here. */
-  ${isTablet} {
+  @media screen and ${isWidthAtOrAbove('SM')} {
+    padding-inline-end: var(--spacing-4);
+  }
+
+  @container ${isWidthAtOrAbove('SM')} {
     padding-inline-end: var(--spacing-4);
   }
 
   /* NOTE: These container query styles come _after_ the media query styles, so they will override them (if the browser
-  * supports container queries). These container query styles are also dependent on a parent element being a size or
-  * inline-size container. */
-  @supports (container-type: inline-size) {
-    @container (width < 768px) {
-      padding-inline-end: var(--spacing-3);
-    }
-
-    @container (width >= 768px) {
-      padding-inline-end: var(--spacing-4);
-    }
+   * supports container queries). These container query styles are also dependent on a parent element being a size or
+   * inline-size container. */
+  @container ${isWidthBelow('SM')} {
+    padding-inline-end: var(--spacing-3);
   }
 `
 

--- a/src/core/top-bar/constants.ts
+++ b/src/core/top-bar/constants.ts
@@ -1,0 +1,1 @@
+export const TOP_BAR_CONTAINER_NAME = '--top-bar-container'

--- a/src/core/top-bar/nav-search/styles.ts
+++ b/src/core/top-bar/nav-search/styles.ts
@@ -1,4 +1,3 @@
-import { isTablet } from '#src/styles/deprecated-media'
 import { styled } from '@linaria/react'
 
 export const ElTopBarNavSearch = styled.div`
@@ -9,29 +8,15 @@ export const ElTopBarNavSearch = styled.div`
 export const ElTopBarNavSearchButtonContainer = styled.div`
   display: none;
 
-  @supports not (container-type: inline-size) {
-    ${isTablet} {
-      display: block;
-    }
-  }
-  @supports (container-type: inline-size) {
-    @container nav-search (width >= 150px) {
-      display: block;
-    }
+  @container nav-search (width >= 150px) {
+    display: block;
   }
 `
 
 export const ElTopBarNavSearchIconItemContainer = styled.div`
   display: block;
 
-  @supports not (container-type: inline-size) {
-    ${isTablet} {
-      display: none;
-    }
-  }
-  @supports (container-type: inline-size) {
-    @container nav-search (width >= 150px) {
-      display: none;
-    }
+  @container nav-search (width >= 150px) {
+    display: none;
   }
 `

--- a/src/core/top-bar/styles.ts
+++ b/src/core/top-bar/styles.ts
@@ -1,29 +1,35 @@
-import { styled } from '@linaria/react'
-import { isTablet, isDesktop, isWideScreen } from '../../styles/deprecated-media'
 import { css } from '@linaria/core'
+import { isWidthAtOrAbove } from '#src/utils/breakpoints'
+import { styled } from '@linaria/react'
+import { TOP_BAR_CONTAINER_NAME } from './constants'
 
 export const ElTopBar = styled.header`
+  height: var(--size-14);
+  width: 100%;
+
+  container-name: ${TOP_BAR_CONTAINER_NAME};
+  container-type: inline-size;
+
+  border-bottom: var(--comp-navigation-border-width-top_bar) solid var(--comp-navigation-colour-border-top_bar);
+  background: var(--comp-navigation-colour-fill-top_bar);
+`
+
+export const ElTopBarContentContainer = styled.div`
   display: grid;
   align-items: center;
   grid-template-areas: 'app-switcher logo main-nav search secondary-nav mobile-nav profile';
   grid-template-columns: min-content min-content 1fr auto auto auto auto;
-  height: var(--size-14);
-  width: 100%;
-
-  container-name: top-bar;
-  container-type: inline-size;
 
   padding-block: var(--spacing-2);
   padding-inline: var(--spacing-4) var(--spacing-2);
-  ${isTablet} {
+
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('SM')} {
     padding-inline: var(--spacing-4);
   }
-  ${isWideScreen} {
+
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('LG')} {
     padding-inline: var(--spacing-5);
   }
-
-  border-bottom: var(--comp-navigation-border-width-top_bar) solid var(--comp-navigation-colour-border-top_bar);
-  background: var(--comp-navigation-colour-fill-top_bar);
 `
 
 export const ElTopBarAppSwitcherContainer = styled.div`
@@ -31,24 +37,13 @@ export const ElTopBarAppSwitcherContainer = styled.div`
 
   display: none;
   padding-inline-end: var(--spacing-4);
-  @supports not (container: inline-size) {
-    ${isTablet} {
-      display: block;
-    }
-    ${isWideScreen} {
-      padding-inline-end: var(--spacing-5);
-    }
+
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('SM')} {
+    display: block;
   }
 
-  @supports (container: inline-size) {
-    /* isTablet equivalent inline size; i.e. 768px - 2 * var(--spacing-4) */
-    @container top-bar (width >= 736px) {
-      display: block;
-    }
-    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
-    @container top-bar (width >= 1400px) {
-      padding-inline-end: var(--spacing-5);
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('LG')} {
+    padding-inline-end: var(--spacing-5);
   }
 `
 
@@ -67,17 +62,8 @@ export const ElTopBarAvatarContainer = styled.div`
 
   display: none;
 
-  @supports not (container: inline-size) {
-    ${isDesktop} {
-      display: flex;
-    }
-  }
-
-  @supports (container: inline-size) {
-    /* isDesktop equivalent inline size; i.e. 1024px - 2 * var(--spacing-4) */
-    @container top-bar (width >= 992px) {
-      display: flex;
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('MD')} {
+    display: flex;
   }
 `
 
@@ -92,17 +78,8 @@ export const ElTopBarMainNavContainer = styled.div`
 
   display: none;
 
-  @supports not (container: inline-size) {
-    ${isWideScreen} {
-      display: block;
-    }
-  }
-
-  @supports (container: inline-size) {
-    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
-    @container top-bar (width >= 1400px) {
-      display: block;
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('LG')} {
+    display: block;
   }
 `
 
@@ -112,17 +89,8 @@ export const ElTopBarSecondaryNavContainer = styled.div`
 
   display: none;
 
-  @supports not (container: inline-size) {
-    ${isWideScreen} {
-      display: block;
-    }
-  }
-
-  @supports (container: inline-size) {
-    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
-    @container top-bar (width >= 1400px) {
-      display: block;
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('SM')} {
+    display: block;
   }
 `
 
@@ -133,21 +101,10 @@ export const ElTopBarSearchContainer = styled.div`
   padding-block: var(--spacing-none);
   padding-inline-end: var(--spacing-2);
 
-  @supports not (container: inline-size) {
-    ${isTablet} {
-      width: 216px;
-      padding-block: var(--spacing-1);
-      padding-inline-end: var(--spacing-4);
-    }
-  }
-
-  @supports (container: inline-size) {
-    /* isTablet equivalent inline size; i.e. 768px - 2 * var(--spacing-4) */
-    @container top-bar (width >= 736px) {
-      width: 216px;
-      padding-block: var(--spacing-1);
-      padding-inline-end: var(--spacing-4);
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('SM')} {
+    width: 216px;
+    padding-block: var(--spacing-1);
+    padding-inline-end: var(--spacing-4);
   }
 `
 
@@ -157,24 +114,12 @@ export const ElTopBarMenuContainer = styled.div`
   display: block;
   padding-inline-end: 0;
 
-  @supports not (container: inline-size) {
-    ${isDesktop} {
-      padding-inline-end: var(--spacing-2);
-    }
-    ${isWideScreen} {
-      display: none;
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('MD')} {
+    padding-inline-end: var(--spacing-2);
   }
 
-  @supports (container: inline-size) {
-    /* isDesktop equivalent inline size; i.e. 1024px - 2 * var(--spacing-4) */
-    @container top-bar (width >= 992px) {
-      padding-inline-end: var(--spacing-2);
-    }
-    /* isWideScreen equivalent inline size; i.e. 1440px - 2 * var(--spacing-5) */
-    @container top-bar (width >= 1400px) {
-      display: none;
-    }
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('LG')} {
+    display: none;
   }
 `
 

--- a/src/core/top-bar/top-bar.stories.tsx
+++ b/src/core/top-bar/top-bar.stories.tsx
@@ -213,7 +213,7 @@ export const Example: Story = {
   },
   decorators: [
     (Story) => (
-      <div style={{ height: '400px' }}>
+      <div style={{ height: '200px' }}>
         <Story />
       </div>
     ),
@@ -227,7 +227,7 @@ export const Example: Story = {
  * For viewports under 768px, very few of the Top Bar's sections will be visible. Most will have collapsed
  * into the overflow menu, except for the product's "global" search entry point, if one is available.
  */
-export const Mobile: Story = {
+export const XS: Story = {
   args: {
     ...Example.args,
   },
@@ -239,7 +239,7 @@ export const Mobile: Story = {
  * and the "global" search entry point have more space available to itself. The main navigation, secondary
  * navigation, and user profile menu will still be collapsed into the overflow menu.
  */
-export const Tablet: Story = {
+export const SM: Story = {
   args: {
     ...Example.args,
   },
@@ -249,9 +249,9 @@ export const Tablet: Story = {
 /**
  * For viewports between 1024px and 1440px, the user's profile menu will become available directly in the Top Bar.
  */
-export const Desktop: Story = {
+export const MD: Story = {
   args: {
-    ...Tablet.args,
+    ...SM.args,
   },
   decorators: [useConstrainedWidthDecorator('1024px')],
 }
@@ -259,9 +259,10 @@ export const Desktop: Story = {
 /**
  * For viewports 1440px and wider, the Top Bar will display all of its regions.
  */
-export const WideScreen: Story = {
+export const LG_2XL: Story = {
+  name: 'LG–2XL',
   args: {
-    ...Tablet.args,
+    ...MD.args,
   },
   decorators: [useConstrainedWidthDecorator('1440px')],
 }

--- a/src/core/top-bar/top-bar.tsx
+++ b/src/core/top-bar/top-bar.tsx
@@ -2,10 +2,11 @@ import { BrandLogo } from './brand-logo'
 import {
   ElTopBar,
   ElTopBarAppSwitcherContainer,
+  ElTopBarAvatarContainer,
+  ElTopBarContentContainer,
   ElTopBarLogoContainer,
   ElTopBarMainNavContainer,
   ElTopBarMenuContainer,
-  ElTopBarAvatarContainer,
   ElTopBarSearchContainer,
   ElTopBarSecondaryNavContainer,
 } from './styles'
@@ -72,15 +73,17 @@ interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> 
 export function TopBar({ appSwitcher, avatar, logo, mainNav, menu, search, secondaryNav, ...rest }: TopBarProps) {
   return (
     <ElTopBar {...rest}>
-      {/* NOTE: The order here defines the "source order" of the DOM content. For a11y, it's important this
-       * matches the visual order defined by ElTopBar's CSS grid layout. */}
-      {appSwitcher && <ElTopBarAppSwitcherContainer>{appSwitcher}</ElTopBarAppSwitcherContainer>}
-      <ElTopBarLogoContainer>{logo}</ElTopBarLogoContainer>
-      {mainNav && <ElTopBarMainNavContainer>{mainNav}</ElTopBarMainNavContainer>}
-      {search && <ElTopBarSearchContainer>{search}</ElTopBarSearchContainer>}
-      {secondaryNav && <ElTopBarSecondaryNavContainer>{secondaryNav}</ElTopBarSecondaryNavContainer>}
-      {menu && <ElTopBarMenuContainer>{menu}</ElTopBarMenuContainer>}
-      <ElTopBarAvatarContainer>{avatar}</ElTopBarAvatarContainer>
+      <ElTopBarContentContainer>
+        {/* NOTE: The order here defines the "source order" of the DOM content. For a11y, it's important this
+         * matches the visual order defined by ElTopBar's CSS grid layout. */}
+        {appSwitcher && <ElTopBarAppSwitcherContainer>{appSwitcher}</ElTopBarAppSwitcherContainer>}
+        <ElTopBarLogoContainer>{logo}</ElTopBarLogoContainer>
+        {mainNav && <ElTopBarMainNavContainer>{mainNav}</ElTopBarMainNavContainer>}
+        {search && <ElTopBarSearchContainer>{search}</ElTopBarSearchContainer>}
+        {secondaryNav && <ElTopBarSecondaryNavContainer>{secondaryNav}</ElTopBarSecondaryNavContainer>}
+        {menu && <ElTopBarMenuContainer>{menu}</ElTopBarMenuContainer>}
+        <ElTopBarAvatarContainer>{avatar}</ElTopBarAvatarContainer>
+      </ElTopBarContentContainer>
     </ElTopBar>
   )
 }

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -25,6 +25,8 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **chore:** Updated all core components to use the `font` helper instead of duplicated font styles.
 - **chore!:** Moved Table components from `@reapit/elements/core/table` to `@reapit/elements/lab/table` and the related CSS classes are all prefixed with `el-experimental-*` now. Importantly, they are no longer available via the main `@reapit/elements` entry point. The deprecated v4 Table components are still available via `@reapit/elements/deprecated/table`.
 - **feat:** Added `FolderTabs`. See [FolderTabs](?path=/docs/core-foldertabs--docs) for details.
+- **chore:** Use new breakpoints and related conditions in core components.
+- **fix:** Bug with `isWidthBelow` condition where it was inclusive of the upper bound rather than being strictly less than the upper bound.
 
 ### **5.0.0-beta.43 - 12/08/25**
 

--- a/src/utils/breakpoints/__tests__/conditions.test.ts
+++ b/src/utils/breakpoints/__tests__/conditions.test.ts
@@ -6,9 +6,9 @@ import type { Breakpoint } from '../breakpoints'
 const breakpoints = Object.keys(BreakpointMinimumDimensions).sort() as Breakpoint[]
 
 test.each(breakpoints)('isWidthAtOrAbove("%s")', (bp) => {
-  expect(isWidthAtOrAbove(bp)).toBe(`(min-width: ${BreakpointMinimumDimensions[bp]})`)
+  expect(isWidthAtOrAbove(bp)).toBe(`(width >= ${BreakpointMinimumDimensions[bp]})`)
 })
 
 test.each(breakpoints)('isWidthBelow("%s")', (bp) => {
-  expect(isWidthBelow(bp)).toBe(`(max-width: ${BreakpointMinimumDimensions[bp]})`)
+  expect(isWidthBelow(bp)).toBe(`(width < ${BreakpointMinimumDimensions[bp]})`)
 })

--- a/src/utils/breakpoints/conditions.ts
+++ b/src/utils/breakpoints/conditions.ts
@@ -10,7 +10,7 @@ import type { Breakpoint } from './breakpoints'
  * @returns A condition that can be used with media or container queries.
  */
 export function isWidthAtOrAbove(breakpoint: Breakpoint) {
-  return `(min-width: ${BreakpointMinimumDimensions[breakpoint]})`
+  return `(width >= ${BreakpointMinimumDimensions[breakpoint]})`
 }
 
 /**
@@ -21,5 +21,5 @@ export function isWidthAtOrAbove(breakpoint: Breakpoint) {
  * @returns A condition that can be used with media or container queries.
  */
 export function isWidthBelow(breakpoint: Breakpoint) {
-  return `(max-width: ${BreakpointMinimumDimensions[breakpoint]})`
+  return `(width < ${BreakpointMinimumDimensions[breakpoint]})`
 }


### PR DESCRIPTION
### Context

- We recently introduced new breakpoint and breakpoint condition helpers to Elements.
- These replace the old media query-only helpers like `isTablet` etc.
- We want our core components to use the new helpers rather than the old, deprecated ones.
- Further, some components use conditionally fallback to media queries if CSS container queries are unsupported; this is not necessary as CSS container queries are [now baselined](chore: use new breakpoint helpers in core components) in all major browsers.

### This PR

- Updates all core components still relying on the deprecated media query helpers to use the new breakpoint condition helpers.
- Removes unnecessary media query fallbacks from some components. Some media queries have been left, particularly when the CSS container queries are dependent on ancestral containers that may or may not be defined. In these cases, we still use the media queries to ensure the correct behaviour of the component.
- Scouts a small fix for the `isWidthBelow` condition.