### PR TITLE
fix: `TopBar` secondary nav regression introduced by #687

### DIFF
--- a/src/core/top-bar/styles.ts
+++ b/src/core/top-bar/styles.ts
@@ -89,7 +89,7 @@ export const ElTopBarSecondaryNavContainer = styled.div`
 
   display: none;
 
-  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('SM')} {
+  @container ${TOP_BAR_CONTAINER_NAME} ${isWidthAtOrAbove('LG')} {
     display: block;
   }
 `

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,9 +16,9 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
-### **5.0.0-beta.45 - ??/??/25**
+### **5.0.0-beta.45 - 18/09/25**
 
-- TBC
+- **fix:** TopBar displays the secondary nav at the correct breakpoints again.
 
 ### **5.0.0-beta.44 - 18/09/25**
 


### PR DESCRIPTION
What it says on the tin.

#687 introduced a regression w.r.t. the top bar's secondary nav responsive styles. This PR fixes that regression.