### PR TITLE
fix: #679 `DeprecatedNav` styles regression

### DIFF
--- a/src/deprecated/nav/__styles__/index.ts
+++ b/src/deprecated/nav/__styles__/index.ts
@@ -91,6 +91,11 @@ export const ElDeprecatedNavItem = styled.a`
   border-left: 3px solid var(--white);
   text-decoration: none;
 
+  &:hover {
+    color: var(--neutral-500);
+    background-color: var(--neutral-050);
+  }
+
   &:first-child {
     opacity: 1;
     background-color: var(--white);
@@ -103,11 +108,6 @@ export const ElDeprecatedNavItem = styled.a`
   &:not(:first-child) {
     height: 0;
     overflow: hidden;
-  }
-
-  &:hover {
-    color: var(--neutral-500);
-    background-color: var(--neutral-050);
   }
 
   &:hover:not(:first-child) {

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.46 - ??/??/25**
 
-- TBC
+- **fix:** Regression in `DeprecatedNav` styles.
 
 ### **5.0.0-beta.45 - 18/09/25**
 


### PR DESCRIPTION
What it says on the tin.

Fixes #679.

### Before

![deprecated nav - bug](https://github.com/user-attachments/assets/331431de-f143-44a3-b27f-b0eaf2fe68ea)

### After

![deprecated nav](https://github.com/user-attachments/assets/4b9225d5-f084-41a7-9a1e-e4c542d72fcb)
