### PR TITLE
fix: `PageHeader` no longer accepts `children` in its interface

### DIFF
--- a/src/core/page-header/page-header.tsx
+++ b/src/core/page-header/page-header.tsx
@@ -13,8 +13,10 @@ import { PageHeaderTitle } from './title'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-// NOTE: We omit the `title` attribute because we want to use that prop name for the page header title.
-type AttributesToOmit = 'title'
+// NOTE: We omit...
+// - `children`, because the page title's "children" are spread across multiple props.
+// - `title`, because we want to use that prop name for the page header title.
+type AttributesToOmit = 'children' | 'title'
 
 interface PageHeaderProps extends Omit<HTMLAttributes<HTMLElement>, AttributesToOmit> {
   /**

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -21,6 +21,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **fix:** Regression in `DeprecatedNav` styles.
 - **fix:** `AppAvatar` displays app avatars using data URL to avoid `id` collisions from their linear gradients when multiple app avatars for the same product are present on the page.
 - **fix:** `FolderTabs` documentation links.
+- **fix:** `PageHeader` no longer accepts `children` in its interface.
 
 ### **5.0.0-beta.45 - 18/09/25**
 


### PR DESCRIPTION
What it says on the tin.

`PageHeader` was incorrectly accepting `children` when it shouldn't.