### PR TITLE
feat: `Text` supports new `overflow='truncate'` prop

### DIFF
--- a/src/core/text/__tests__/text.test.tsx
+++ b/src/core/text/__tests__/text.test.tsx
@@ -14,9 +14,9 @@ test('renders as the specified HTML element', () => {
   expect(el.tagName).toBe('STRONG')
 })
 
-test('applies data attributes for colour, size, and weight', () => {
+test('applies data attributes for colour, overflow, size, and weight', () => {
   render(
-    <Text as="em" colour="secondary" size="xl" weight="bold">
+    <Text as="em" colour="secondary" overflow="truncate" size="xl" weight="bold">
       Styled text
     </Text>,
   )
@@ -24,6 +24,7 @@ test('applies data attributes for colour, size, and weight', () => {
   expect(el).toHaveAttribute('data-colour', 'secondary')
   expect(el).toHaveAttribute('data-font-size', 'xl')
   expect(el).toHaveAttribute('data-font-weight', 'bold')
+  expect(el).toHaveAttribute('data-overflow', 'truncate')
 })
 
 test('forwards additional props to the rendered element', () => {

--- a/src/core/text/styles.ts
+++ b/src/core/text/styles.ts
@@ -1,17 +1,16 @@
+import { css } from '@linaria/core'
 import { font } from './font'
 import { fontSizes, fontWeights, textColours } from './types'
-import { styled } from '@linaria/react'
 
-import type { FontSize, FontWeight } from './types'
-
-interface ElTextProps {
-  'data-font-size': FontSize
-  'data-font-weight': FontWeight
-}
-
-export const ElText = styled.span<ElTextProps>`
+export const elText = css`
   ${generateElTextFontStyles()}
   ${generateElTextColourStyles()}
+
+  &[data-overflow='truncate'] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 `
 
 function generateElTextFontStyles() {

--- a/src/core/text/text.stories.tsx
+++ b/src/core/text/text.stories.tsx
@@ -16,19 +16,29 @@ const meta = {
     },
     children: {
       control: 'text',
+      description: 'The text content.',
       table: {
         type: { summary: 'ReactNode' },
       },
     },
     colour: {
       control: 'select',
+      description: 'The text colour.',
       options: textColours,
       table: {
         type: { summary: 'union' },
       },
     },
+    overflow: {
+      control: false,
+      description: 'Determines what happens when text overflows its parent.',
+      table: {
+        type: { summary: "'truncate'" },
+      },
+    },
     size: {
       control: 'select',
+      description: 'The font size of the text.',
       options: fontSizes,
       table: {
         type: { summary: 'union' },
@@ -36,6 +46,7 @@ const meta = {
     },
     weight: {
       control: 'select',
+      description: 'The font weight of the text.',
       options: fontWeights,
       table: {
         type: { summary: 'union' },
@@ -51,7 +62,7 @@ type Story = StoryObj<typeof Text>
 export const Example: Story = {
   args: {
     as: 'span',
-    children: 'A semantically meaningful portion of text',
+    children: 'A styled span of text',
     colour: 'primary',
     size: 'base',
     weight: 'regular',
@@ -113,7 +124,35 @@ export const Nesting: Story = {
   render: (args) => (
     <Text {...args}>
       This is a span of text that includes a{' '}
-      <Text as="strong" colour="action">
+      <Text as="strong" colour="error" weight="medium">
+        nested span of text.
+      </Text>
+    </Text>
+  ),
+}
+
+/**
+ * The `overflow` prop controls whether the text should be truncated with an ellipsis or remain
+ * visible when it overflows. This behaviour is dependent on the layout mode of the parent. In this
+ * example, the parent is a flex container, which ensures the text is sized to fit within the grid.
+ * This means the text will overflow and truncate.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    overflow: 'truncate',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', display: 'flex', width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <Text {...args}>
+      This is a span of text that includes a{' '}
+      <Text as="strong" colour="error" weight="medium">
         nested span of text.
       </Text>
     </Text>

--- a/src/core/text/text.tsx
+++ b/src/core/text/text.tsx
@@ -1,10 +1,12 @@
-import { ElText } from './styles'
+import { cx } from '@linaria/core'
+import { elText } from './styles'
 
 import type { FontSize, FontWeight, TextColour } from './types'
 import type { HTMLAttributes, QuoteHTMLAttributes, TimeHTMLAttributes } from 'react'
 
 interface BaseTextProps {
   colour?: TextColour
+  overflow?: 'truncate'
   size?: FontSize
   weight?: FontWeight
 }
@@ -64,6 +66,23 @@ type TextProps =
  * elements focused on inline text semantics. This is because we want this component to be minimally
  * useful.
  */
-export function Text({ as = 'span', colour = 'inherit', size = 'base', weight = 'regular', ...props }: TextProps) {
-  return <ElText as={as} data-colour={colour} data-font-size={size} data-font-weight={weight} {...props} />
+export function Text({
+  as: Element = 'span',
+  className,
+  colour = 'inherit',
+  overflow,
+  size = 'base',
+  weight = 'regular',
+  ...rest
+}: TextProps) {
+  return (
+    <Element
+      className={cx(elText, className)}
+      data-colour={colour}
+      data-overflow={overflow}
+      data-font-size={size}
+      data-font-weight={weight}
+      {...(rest as HTMLAttributes<HTMLElement>)}
+    />
+  )
 }

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -24,6 +24,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **fix:** `PageHeader` no longer accepts `children` in its interface.
 - **chore!:** Refactored `EmptyData`. `EmptyData.SecondaryDescription` removed; the secondary text can now be supplied as a prop on `EmptyData.Description`. Added `EmptyData.Action` for `<a>`-based actions. Both `EmptyData.Action` and `EmptyData.ActionButton` are now based on `Button`.
 - **chore:** Update design tokens to match latest updates in Figma.
+- **feat:** `Text` now supports an `overflow="truncate"` prop that assists with text truncation.
 
 ### **5.0.0-beta.45 - 18/09/25**
 


### PR DESCRIPTION
What it says on the tin.