### PR TITLE
fix: `StatusIndicator` text no longer wraps

### DIFF
--- a/src/core/status-indicator/status-indicator.stories.tsx
+++ b/src/core/status-indicator/status-indicator.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 const variants = ['neutral', 'success', 'pending', 'warning', 'danger', 'inactive', 'accent1', 'accent2'] as const
 
 const meta = {
-  title: 'Core/Status Indicator',
+  title: 'Core/StatusIndicator',
   component: StatusIndicator,
   argTypes: {
     children: {

--- a/src/core/status-indicator/styles.ts
+++ b/src/core/status-indicator/styles.ts
@@ -9,6 +9,8 @@ export const ElStatusIndicator = styled.strong`
   color: var(--comp-status-colour-text-neutral);
   ${font('sm', 'regular')}
 
+  white-space: nowrap;
+
   &::before {
     content: '';
     width: var(--size-2);

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -27,6 +27,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** `Text` now supports an `overflow="truncate"` prop that assists with text truncation.
 - **fix:** `Badge` label no longer wraps when it has insufficient space.
 - **feat!:** `SupplementaryInfo` now supports a `colour` prop that allows the colour of all items to be set. A new default of `inherit` is also used for both `SupplementaryInfo` and `SupplementaryInfo.Item`.
+- **fix:** `StatusIndicator` text no longer wraps when it has insufficient space.
 
 ### **5.0.0-beta.45 - 18/09/25**
 


### PR DESCRIPTION
What it says on the tin.