### PR TITLE
fix: #704 `Accordion` disclosure marker now hidden, custom icon now r…

### DIFF
--- a/src/core/accordion/summary/styles.ts
+++ b/src/core/accordion/summary/styles.ts
@@ -20,6 +20,11 @@ export const ElAccordionSummary = styled.summary`
     outline: var(--border-width-double) solid var(--colour-border-focus);
     outline-offset: var(--border-width-default);
   }
+
+  /* Ensure the user-agent disclosure marker is hidden */
+  &::marker {
+    display: none;
+  }
 `
 
 export const ElAccordionSummaryTitle = styled.div`
@@ -46,8 +51,9 @@ export const ElAccordionSummaryIcon = styled.div`
 
   color: var(--comp-accordion-colour-icon);
 
-  details:open &,
-  details[open] & {
+  /* We use :is because it accepts a forgiving selector list, and not all browsers
+   * support the :open selector for details elements. */
+  :is(details:open, details[open]) & {
     transform: rotate(180deg);
   }
 `

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -30,6 +30,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **fix:** `StatusIndicator` text no longer wraps when it has insufficient space.
 - **feat:** Experimental `SearchInput` now available via `@reapit/elements/lab/search-input`
 - **fix:** `AppSwitcher` was using the wrong product ID for the Lettings BDM product.
+- **fix:** `Accordion` user-agent disclosure marker is now forcefully hidden, and the custom disclosure icon now correctly rotates when the disclosure is open.
 
 ### **5.0.0-beta.45 - 18/09/25**
 


### PR DESCRIPTION
Fixes #704

- `:open` pseudo-class is not supported by Safari, so we need to use a forgiving selector like `:is`.
- `::marker` is styled with `display: none`. Typically, the marker is hidden automatically when the summary element has a non-list-item display mode, but this doesn't seem to be the case for older versions of Safari.