### PR TITLE
chore: align `TagGroup` and `ChipGroup`

### DIFF
--- a/src/core/chip-group/__tests__/chip-group.test.tsx
+++ b/src/core/chip-group/__tests__/chip-group.test.tsx
@@ -10,12 +10,28 @@ test('renders its children in a list', () => {
   expect(list).toHaveTextContent('Fake child')
 })
 
-test('chip group list has `data-overflow="wrap"` attribute, by default', () => {
+test('chip group list has `data-flow="wrap"` attribute, by default', () => {
   render(<ChipGroup>Fake child</ChipGroup>)
-  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'wrap')
+  expect(screen.getByRole('list')).toHaveAttribute('data-flow', 'wrap')
 })
 
-test('chip group list has `data-overflow="scroll"` attribute when specified', () => {
-  render(<ChipGroup overflow="scroll">Fake child</ChipGroup>)
-  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'scroll')
+test('chip group list has `data-overflow="visible"` attribute, by default', () => {
+  render(<ChipGroup>Fake child</ChipGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'visible')
+})
+
+test('chip group list has `data-flow="nowrap"` attribute when specified', () => {
+  render(<ChipGroup flow="nowrap">Fake child</ChipGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-flow', 'nowrap')
+})
+
+test('chip group list has `data-overflow="auto"` attribute when specified', () => {
+  render(<ChipGroup overflow="auto">Fake child</ChipGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'auto')
+})
+
+test('forwards additional props to the list element', () => {
+  render(<ChipGroup data-testid="test-id">Test Tag</ChipGroup>)
+  expect(screen.getByTestId('test-id')).toBeVisible()
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('list'))
 })

--- a/src/core/chip-group/chip-group.stories.tsx
+++ b/src/core/chip-group/chip-group.stories.tsx
@@ -56,7 +56,6 @@ const meta = {
     },
     overflow: {
       control: 'radio',
-      options: ['scroll', 'wrap'],
     },
   },
 } satisfies Meta<typeof ChipGroup>
@@ -76,31 +75,43 @@ const useNarrowParentDecorator: Decorator = (Story) => {
 /**
  * By default, a chip group will grow to whatever width it's parent allows.
  */
-export const Default: Story = {
+export const Example: Story = {
   args: {
     children: 'Filter Chips',
-    overflow: 'wrap',
+    flow: 'wrap',
+    overflow: 'visible',
   },
 }
 
 /**
- * By default, chips will wrap to other lines if they would otherwise overflow the group's bounding box.
+ * By default, chips will wrap to other lines if there is insufficient space.
  */
-export const Overflow: Story = {
+export const Wrapping: Story = {
   args: {
-    ...Default.args,
-    overflow: 'wrap',
+    ...Example.args,
   },
   decorators: [useNarrowParentDecorator],
 }
 
 /**
- * In some instances (e.g. small breakpoints), horizontal scrolling can be facilitated.
+ * The default wrapping behaviour can be overridden using `flow="nowrap"`. This can be useful at
+ * small breakpoints where the chip group should not occupy too much vertical space.
  */
-export const Scrolling: Story = {
+export const NoWrapping: Story = {
   args: {
-    ...Overflow.args,
-    overflow: 'scroll',
+    ...Example.args,
+    flow: 'nowrap',
+  },
+  decorators: [useNarrowParentDecorator],
+}
+
+/**
+ * When wrapping is disabled, it will often be useful to allow the chip group to scroll horizontally.
+ */
+export const Overflow: Story = {
+  args: {
+    ...NoWrapping.args,
+    overflow: 'auto',
   },
   decorators: [useNarrowParentDecorator],
 }
@@ -138,12 +149,12 @@ export const ChipSizing: Story = {
       <ChipGroup.Item key="7" {...ChipStories.FilterChip.args}>
         Chip 6
       </ChipGroup.Item>,
-      <ChipGroup.Item key="8" {...ChipStories.Overflow.args}>
+      <ChipGroup.Item key="8" {...ChipStories.Wrapping.args}>
         Or, you can avoid truncation and allow a long chip label to wrap to multiple lines
       </ChipGroup.Item>,
       <ChipGroup.Item key="9" {...ChipStories.LongWords.args} />,
     ],
-    overflow: 'wrap',
+    flow: 'wrap',
   },
   decorators: [useNarrowParentDecorator],
 }

--- a/src/core/chip-group/chip-group.tsx
+++ b/src/core/chip-group/chip-group.tsx
@@ -1,22 +1,26 @@
-import { ElChipGroup, ElChipGroupList } from './styles'
 import { ChipGroupItem } from './chip-group-item'
+import { ElChipGroupList } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface ChipGroupProps extends HTMLAttributes<HTMLDivElement> {
+interface ChipGroupProps extends HTMLAttributes<HTMLUListElement> {
+  /** The chip group items. */
   children: ReactNode
-  overflow?: 'scroll' | 'wrap'
+  /** Whether the chip group should wrap or not. */
+  flow?: 'wrap' | 'nowrap'
+  /** What overflow behaviour the chip group should exhibit. */
+  overflow?: 'auto' | 'visible'
 }
 
 /**
  * Groups multiple chips together. Should only be used to group chips of the same variant. By default,
  * chips will wrap within the group, though horizontal scrolling can be permitted when required.
  */
-export function ChipGroup({ children, overflow = 'wrap', ...rest }: ChipGroupProps) {
+export function ChipGroup({ children, flow = 'wrap', overflow = 'visible', ...rest }: ChipGroupProps) {
   return (
-    <ElChipGroup {...rest}>
-      <ElChipGroupList data-overflow={overflow}>{children}</ElChipGroupList>
-    </ElChipGroup>
+    <ElChipGroupList {...rest} data-flow={flow} data-overflow={overflow}>
+      {children}
+    </ElChipGroupList>
   )
 }
 

--- a/src/core/chip-group/styles.ts
+++ b/src/core/chip-group/styles.ts
@@ -1,36 +1,41 @@
 import { styled } from '@linaria/react'
 
-export const ElChipGroup = styled.div`
-  display: block;
-
-  &:has(> [data-overflow='scroll']) {
-    overflow-x: auto;
-  }
-`
-
 interface ElChipGroupListProps {
-  'data-overflow': 'scroll' | 'wrap'
+  'data-flow': 'wrap' | 'nowrap'
+  'data-overflow': 'auto' | 'visible'
 }
 
 export const ElChipGroupList = styled.ul<ElChipGroupListProps>`
-  display: flex;
+  display: inline-flex;
   gap: var(--spacing-2);
 
   list-style: none;
-
   margin: 0;
   padding: 0;
+  width: 100%;
 
-  &[data-overflow='scroll'] {
-    flex-wrap: nowrap;
-    width: max-content;
+  &,
+  &[data-flow='wrap'] {
+    flex-flow: row wrap;
   }
 
-  &[data-overflow='wrap'] {
-    flex-wrap: wrap;
+  &[data-flow='nowrap'] {
+    flex-flow: row nowrap;
+  }
+
+  &,
+  &[data-overflow='visible'] {
+    overflow: visible;
+  }
+
+  &[data-overflow='auto'] {
+    overflow: auto;
   }
 `
 
 export const ElChipGroupListItem = styled.li`
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  max-width: 100%;
 `

--- a/src/core/chip/__tests__/chip.test.tsx
+++ b/src/core/chip/__tests__/chip.test.tsx
@@ -38,13 +38,13 @@ test('chip has no `aria-disabled` attribute when enabled', () => {
   expect(screen.getByRole('button', { name: 'Label' })).not.toHaveAttribute('aria-disabled')
 })
 
-test('chip label has `data-will-truncate="true"` attribute when `willTruncateLabel` is provided', () => {
+test('chip label has `data-overflow="truncate"` attribute when `overflow="truncate"` is provided', () => {
   render(
-    <Chip willTruncateLabel variant="selection">
+    <Chip overflow="truncate" variant="selection">
       Label
     </Chip>,
   )
-  expect(screen.getByText('Label')).toHaveAttribute('data-will-truncate', 'true')
+  expect(screen.getByText('Label')).toHaveAttribute('data-overflow', 'truncate')
 })
 
 test('ARIA disabled chip does not call `onClick`', () => {

--- a/src/core/chip/chip.stories.tsx
+++ b/src/core/chip/chip.stories.tsx
@@ -17,6 +17,9 @@ const meta = {
     disabled: {
       control: 'boolean',
     },
+    overflow: {
+      control: 'text',
+    },
     variant: {
       control: 'radio',
       options: ['filter', 'selection'],
@@ -33,7 +36,8 @@ export const Example: Story = {
     'aria-disabled': false,
     children: 'Label',
     disabled: false,
-    willTruncateLabel: false,
+    maxWidth: undefined,
+    overflow: undefined,
     variant: 'filter',
   },
 }
@@ -61,9 +65,11 @@ export const SelectionChip: Story = {
 }
 
 /**
- * Chips can be disabled using `aria-disabled` or `disabled`. In both cases, click events will be ignored, however,
- * `aria-disabled` allows the chip to still be focusable, which, for example, allows tooltips to still be displayed.
- * A `disabled` chip is also `aria-disabled`, regardless of the value of `aria-disabled`.
+ * Chips can be disabled using `aria-disabled` or `disabled`. In both cases,
+ * click events will be ignored, however, `aria-disabled` allows the chip to
+ * still be focusable, which, for example, allows tooltips to still be displayed.
+ * A `disabled` chip is also `aria-disabled`, regardless of the value of
+ * `aria-disabled`.
  */
 export const Disabled: Story = {
   args: {
@@ -86,22 +92,33 @@ export const Disabled: Story = {
   },
 }
 
-/** By default, long labels will wrap if there is not enough space is available. */
-export const Overflow: Story = {
+/**
+ * By default, long labels will wrap if there is not enough space is available.
+ */
+export const Wrapping: Story = {
   args: {
     ...FilterChip.args,
     children: "This very long label will wrap because it's parent is not wide enough",
-    maxWidth: '--size-80',
   },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
 }
 
-/** Line breaks within an otherwise unbreakable string are also permitted to prevent text from overflowing the chip. */
+/**
+ * Line breaks within an otherwise unbreakable string are also permitted to prevent text
+ * from overflowing the chip.
+ */
 export const LongWords: Story = {
   args: {
-    ...FilterChip.args,
+    ...Wrapping.args,
     children: 'Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu, NZ',
-    maxWidth: '--size-80',
   },
+  decorators: Wrapping.decorators,
 }
 
 /**
@@ -112,7 +129,19 @@ export const Truncation: Story = {
   args: {
     ...FilterChip.args,
     children: 'Truncation can be applied when necessary',
+    overflow: 'truncate',
+  },
+  decorators: Wrapping.decorators,
+}
+
+/**
+ * In some cases, it may be necessary to limit the width of a chip directly, rather than
+ * relying on its parent container.
+ */
+export const MaxWidth: Story = {
+  args: {
+    ...FilterChip.args,
+    children: 'This chip has its own maximum width constraint',
     maxWidth: '--size-80',
-    willTruncateLabel: true,
   },
 }

--- a/src/core/chip/chip.tsx
+++ b/src/core/chip/chip.tsx
@@ -28,10 +28,10 @@ interface ChipProps extends Omit<ElementAttributes, ElementAttributesToOmit> {
   disabled?: boolean
   /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
   maxWidth?: `--size-${string}`
+  /** Whether the label of the chip should be truncated if it is too long */
+  overflow?: 'truncate'
   /** The variant of the chip */
   variant: 'filter' | 'selection'
-  /** Whether the label of the chip should be truncated if it is too long */
-  willTruncateLabel?: boolean
 }
 
 /**
@@ -42,8 +42,8 @@ export function Chip({
   children,
   onClick,
   maxWidth,
+  overflow,
   variant,
-  willTruncateLabel,
   ...rest
 }: ChipProps) {
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
@@ -75,7 +75,7 @@ export function Chip({
       // attr() function syntax yet. Thus, we use a CSS variable instead.
       style={maxWidth ? { '--chip-max-width': `var(${maxWidth})` } : undefined}
     >
-      <ElChipLabel data-will-truncate={willTruncateLabel}>{children}</ElChipLabel>
+      <ElChipLabel data-overflow={overflow}>{children}</ElChipLabel>
       <ElChipClearIcon>
         <CloseIcon />
       </ElChipClearIcon>

--- a/src/core/chip/styles.ts
+++ b/src/core/chip/styles.ts
@@ -72,7 +72,7 @@ export const ElChip = styled.button<ElChipProps>`
 `
 
 interface ElChipLabelProps {
-  'data-will-truncate'?: boolean
+  'data-overflow': 'truncate' | undefined
 }
 
 export const ElChipLabel = styled.span<ElChipLabelProps>`
@@ -85,7 +85,7 @@ export const ElChipLabel = styled.span<ElChipLabelProps>`
 
   text-align: left;
 
-  &[data-will-truncate='true'] {
+  &[data-overflow='truncate'] {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/core/tag-group/__tests__/tag-group.test.tsx
+++ b/src/core/tag-group/__tests__/tag-group.test.tsx
@@ -6,7 +6,27 @@ test('renders as a list element', () => {
   expect(screen.getByRole('list')).toBeVisible()
 })
 
-test('passes through all props to the underlying list element', () => {
+test('chip group list has `data-flow="wrap"` attribute, by default', () => {
+  render(<TagGroup>Fake child</TagGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-flow', 'wrap')
+})
+
+test('chip group list has `data-overflow="visible"` attribute, by default', () => {
+  render(<TagGroup>Fake child</TagGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'visible')
+})
+
+test('chip group list has `data-flow="nowrap"` attribute when specified', () => {
+  render(<TagGroup flow="nowrap">Fake child</TagGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-flow', 'nowrap')
+})
+
+test('chip group list has `data-overflow="auto"` attribute when specified', () => {
+  render(<TagGroup overflow="auto">Fake child</TagGroup>)
+  expect(screen.getByRole('list')).toHaveAttribute('data-overflow', 'auto')
+})
+
+test('forwards additional props to the list element', () => {
   render(<TagGroup data-testid="test-id">Test Tag</TagGroup>)
   expect(screen.getByTestId('test-id')).toBeVisible()
   expect(screen.getByTestId('test-id')).toBe(screen.getByRole('list'))

--- a/src/core/tag-group/styles.ts
+++ b/src/core/tag-group/styles.ts
@@ -1,16 +1,52 @@
 import { styled } from '@linaria/react'
 
-export const ElTagGroupList = styled.ul`
+interface ElTagGroupListProps {
+  'data-flow': 'wrap' | 'nowrap'
+  'data-overflow': 'auto' | 'visible'
+}
+
+export const ElTagGroupList = styled.ul<ElTagGroupListProps>`
   display: inline-flex;
-  flex-flow: row wrap;
   gap: var(--spacing-1);
 
   list-style: none;
   margin: 0;
   padding: 0;
+  width: 100%;
 
   /* NOTE: necessary when used in an inline or inline-block layout */
   vertical-align: middle;
+
+  &,
+  &[data-flow='wrap'] {
+    flex-flow: row wrap;
+  }
+
+  &[data-flow='nowrap'] {
+    flex-flow: row nowrap;
+  }
+
+  &,
+  &[data-overflow='visible'] {
+    overflow: visible;
+  }
+
+  &[data-overflow='auto'] {
+    overflow: auto;
+  }
+
+  &[data-overflow='hidden'] {
+    overflow: hidden;
+  }
+
+  &[data-overflow='scroll'] {
+    overflow: scroll;
+  }
+
+  &[data-overflow='auto'],
+  &[data-overflow='scroll'] {
+    scrollbar-width: 0;
+  }
 `
 
 export const ElTagGroupListItem = styled.li`

--- a/src/core/tag-group/tag-group.stories.tsx
+++ b/src/core/tag-group/tag-group.stories.tsx
@@ -30,13 +30,15 @@ type Story = StoryObj<typeof TagGroup>
 export const Example: Story = {
   args: {
     children: 'Many',
+    flow: 'wrap',
+    overflow: 'visible',
   },
 }
 
 /**
  * By default, tags within the tag group will wrap to the next line if the container is too small.
  */
-export const Overflow: Story = {
+export const Wrapping: Story = {
   args: {
     children: 'Many',
   },
@@ -47,4 +49,31 @@ export const Overflow: Story = {
       </div>
     ),
   ],
+}
+
+/**
+ * The default wrapping behaviour can be overridden by setting `flow="nowrap"`. This is often
+ * useful when using a tag group within the context of an element that does not want its content
+ * wrapping, such as a single-line table cell.
+ */
+export const NoWrapping: Story = {
+  args: {
+    ...Wrapping.args,
+    flow: 'nowrap',
+  },
+  decorators: Wrapping.decorators,
+}
+
+/**
+ * When wrapping is disabled, the overflow behaviour can also be configured using `overflow`. By
+ * default, it will be `visible`, but `auto` can be used to allow scrolling if the content does
+ * overflow.
+ */
+export const Overflow: Story = {
+  args: {
+    ...NoWrapping.args,
+    flow: 'nowrap',
+    overflow: 'auto',
+  },
+  decorators: NoWrapping.decorators,
 }

--- a/src/core/tag-group/tag-group.tsx
+++ b/src/core/tag-group/tag-group.tsx
@@ -4,14 +4,23 @@ import { TagGroupItem } from './tag-group-item'
 import type { HTMLAttributes, ReactNode } from 'react'
 
 interface TagGroupProps extends HTMLAttributes<HTMLUListElement> {
+  /** The tag group items. */
   children: ReactNode
+  /** Whether the tag group should wrap or not. */
+  flow?: 'wrap' | 'nowrap'
+  /** What overflow behaviour the tag group should exhibit. */
+  overflow?: 'auto' | 'visible'
 }
 
 /**
  * Groups multiple tags together. A tag group should have at least one tag.
  */
-export function TagGroup({ children, ...rest }: TagGroupProps) {
-  return <ElTagGroupList {...rest}>{children}</ElTagGroupList>
+export function TagGroup({ children, flow = 'wrap', overflow = 'visible', ...rest }: TagGroupProps) {
+  return (
+    <ElTagGroupList {...rest} data-flow={flow} data-overflow={overflow}>
+      {children}
+    </ElTagGroupList>
+  )
 }
 
 TagGroup.Item = TagGroupItem

--- a/src/core/tag/styles.ts
+++ b/src/core/tag/styles.ts
@@ -8,4 +8,5 @@ export const ElTag = styled.span`
   background: var(--comp-tag-colour-fill);
 
   ${font('xs', 'medium')}
+  white-space: nowrap;
 `

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,11 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.47 - ??/??/25**
 
-- TBC
+- **chore!:** Align `TagGroup` and `ChipGroup` interfaces:
+  - `ChipGroup` no longer supports `overflow: 'scroll' | 'wrap'`. Instead, it now supports `flow: 'wrap' | 'nowrap'` and `overflow: 'auto' | 'hidden'`. To migrate, `overflow="scroll"` becomes `flow="nowrap"` and `overflow="auto"`, while `overflow="wrap"` becomes `flow="wrap"` (the default).
+  - `TagGroup` now supports `flow: 'wrap' | 'nowrap'` and `overflow: 'auto' | 'hidden'` as well.
+- **chore!:** Enhance the DOM structure of `ChipGroup` to match `TagGroup`. Specifically, `el-chip-group` has been removed, with chip group now rendering directly as a `<ul>` rather than a `<div>` with a `<ul>` child.
+- **chore:** Enhanced `ChipGroup` to ensure items are sized to the full-width of the container if their labels are too long for the available space.
 
 ### **5.0.0-beta.46 - 25/08/25**
 


### PR DESCRIPTION
### Context

- `ChipGroup` current supports an `overflow: 'scroll' | 'wrap'`. This allows consumes to either have items wrap to additional lines or to remain on a single line and overflow with scrolling.
- `TagGroup` items currently wrap to additional lines, but we need to support the ability to disable this wrapping behaviour and, optionally, overflow with scrolling. That is, we need more flexibility than we have with `ChipGroup`.
- A single `overflow` prop is insufficient; better, would be to split the concerns over two props: `flow: 'wrap' | 'nowrap'` and `overflow: 'auto' | 'hidden'`.

### This PR

- Aligns `TagGroup` and `ChipGroup` interfaces:
  - `ChipGroup` no longer supports `overflow: 'scroll' | 'wrap'`. Instead, it now supports `flow: 'wrap' | 'nowrap'` and `overflow: 'auto' | 'hidden'`. To migrate, `overflow="scroll"` becomes `flow="nowrap"` and `overflow="auto"`, while `overflow="wrap"` becomes `flow="wrap"` (the default).
  - `TagGroup` now supports `flow: 'wrap' | 'nowrap'` and `overflow: 'auto' | 'hidden'` as well.
- Simplifies the DOM structure of `ChipGroup` to match `TagGroup`. Specifically, `el-chip-group` has been removed, with chip group now rendering directly as a `<ul>` rather than a `<div>` with a `<ul>` child.
- Enhances `ChipGroup` to ensure items are sized to the full-width of the container if their labels are too long for the available space.

<img width="821" height="487" alt="Screenshot 2025-08-25 at 10 12 48 pm" src="https://github.com/user-attachments/assets/95e92646-6ced-4e3c-9278-0b4701b1965a" />
<img width="821" height="652" alt="Screenshot 2025-08-25 at 10 12 57 pm" src="https://github.com/user-attachments/assets/054ed83b-b9d9-489e-8f6a-ccbb9e944542" />
<img width="816" height="532" alt="Screenshot 2025-08-25 at 10 13 06 pm" src="https://github.com/user-attachments/assets/548ea54d-c12e-491c-9724-4cf9a58c8210" />
<img width="822" height="659" alt="Screenshot 2025-08-25 at 10 14 20 pm" src="https://github.com/user-attachments/assets/d3c168db-1528-489e-93e8-5fe745c80f99" />
<img width="821" height="613" alt="Screenshot 2025-08-25 at 10 14 28 pm" src="https://github.com/user-attachments/assets/08bcf9dc-58e0-4b26-80ab-632de07da6b3" />
