### PR TITLE
feat: Add new `TableRowPrimaryAction`

### DIFF
--- a/src/core/table/primary-action/__tests__/primary-action.test.tsx
+++ b/src/core/table/primary-action/__tests__/primary-action.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { TableRowPrimaryAction } from '../primary-action'
+
+const href = 'https://fake.url'
+
+test('renders as a link element', () => {
+  render(<TableRowPrimaryAction href={href}>Action</TableRowPrimaryAction>)
+  expect(screen.getByRole('link', { name: 'Action' })).toBeVisible()
+})
+
+test('has .el-table-row-primary-action class', () => {
+  render(<TableRowPrimaryAction href={href}>Action</TableRowPrimaryAction>)
+  expect(screen.getByRole('link')).toHaveClass('el-table-row-primary-action')
+})
+
+test('accepts other classes', () => {
+  render(
+    <TableRowPrimaryAction className="custom-class" href={href}>
+      Action
+    </TableRowPrimaryAction>,
+  )
+  expect(screen.getByRole('link')).toHaveClass('el-table-row-primary-action custom-class')
+})
+
+test('forwards additional props to the link', () => {
+  render(
+    <TableRowPrimaryAction data-testid="test-id" href={href}>
+      Action
+    </TableRowPrimaryAction>,
+  )
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('link'))
+})

--- a/src/core/table/primary-action/__tests__/primary-button.test.tsx
+++ b/src/core/table/primary-action/__tests__/primary-button.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { TableRowPrimaryActionButton } from '../primary-action-button'
+
+test('renders as a button element', () => {
+  render(<TableRowPrimaryActionButton>Action</TableRowPrimaryActionButton>)
+  expect(screen.getByRole('button', { name: 'Action' })).toBeVisible()
+})
+
+test('has .el-table-row-primary-action class', () => {
+  render(<TableRowPrimaryActionButton>Action</TableRowPrimaryActionButton>)
+  expect(screen.getByRole('button')).toHaveClass('el-table-row-primary-action')
+})
+
+test('accepts other classes', () => {
+  render(<TableRowPrimaryActionButton className="custom-class">Action</TableRowPrimaryActionButton>)
+  expect(screen.getByRole('button')).toHaveClass('el-table-row-primary-action custom-class')
+})
+
+test('forwards additional props to the button', () => {
+  render(<TableRowPrimaryActionButton data-testid="test-id">Action</TableRowPrimaryActionButton>)
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('button'))
+})

--- a/src/core/table/primary-action/index.ts
+++ b/src/core/table/primary-action/index.ts
@@ -1,0 +1,2 @@
+export * from './primary-action'
+export * from './styles'

--- a/src/core/table/primary-action/primary-action-button.tsx
+++ b/src/core/table/primary-action/primary-action-button.tsx
@@ -1,0 +1,22 @@
+import { cx } from '@linaria/core'
+import { elTableRowPrimaryAction } from './styles'
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+// NOTE: We omit...
+// - disabled, because the row's primary action should never be disabled.
+type AttributesToOmit = 'disabled'
+
+export interface TableRowPrimaryActionButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+  /** The content of the primary action */
+  children: ReactNode
+}
+
+/**
+ * A simple primary action component for table rows. Comes in two varieties: `Table.PrimaryActionButton`,
+ * which renders as a button, and `Table.PrimaryAction`, which renders as an anchor.
+ */
+export function TableRowPrimaryActionButton({ className, ...rest }: TableRowPrimaryActionButtonProps) {
+  return <button {...rest} className={cx(elTableRowPrimaryAction, className)} />
+}

--- a/src/core/table/primary-action/primary-action.stories.tsx
+++ b/src/core/table/primary-action/primary-action.stories.tsx
@@ -1,0 +1,116 @@
+import { Pattern } from '#src/core/drawer/__story__/Pattern'
+import { StarIcon } from '#src/icons/star'
+import { Story } from '@storybook/addon-docs/blocks'
+import { TableCellPrimaryData } from '../primary-data'
+import { TableRowPrimaryAction } from './primary-action'
+import { TableRowPrimaryActionButton } from './primary-action-button'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Core/Table/PrimaryAction',
+  component: TableRowPrimaryAction,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    href: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      // NOTE: This relatively-positioned div is used to simulate a table row. It is this element's
+      // bounding box that the primary action's pseudo-element will be positioned in relation to.
+      <div style={{ position: 'relative' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    tableWidth: '100%',
+  },
+} satisfies Meta<typeof TableRowPrimaryAction>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * The default font styling of the action has a heavier weight as the primary action should always
+ * be used for the primary data of a row's header cell.
+ */
+export const Example: Story = {
+  args: {
+    children: '1 Brisbane St, Brisbane 4300',
+    href,
+  },
+}
+
+/**
+ * When using [Table.PrimaryData](./?path=/docs/core-table-tablecellprimarydata--docs), it is
+ * important to consider whether the leading or trailing icons should form part of the primary action's
+ * content or not. In this example, the primary action is a child of `Table.PrimaryData` rather
+ * than its parent. This means the accessible name of the icon is not part of the primary action's
+ * accessible name. If the icon were wanted as part of the primary action's accessible name, then the
+ * hierarchy can simply be inverted by using `Table.PrimaryData` as the content of `Table.PrimaryAction`.
+ */
+export const PrimaryData: Story = {
+  args: {
+    'aria-label': 'View Mary Jane',
+    children: 'Mary Jane',
+    href,
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+  render: (args) => (
+    <TableCellPrimaryData iconRight={<StarIcon aria-label="Preferred creditor" />}>
+      <TableRowPrimaryAction {...args} />
+    </TableCellPrimaryData>
+  ),
+}
+
+/**
+ * The key feature of the primary action is that its "hit area" will expand to fill the bounding box of
+ * the closest, relative-positioned ancestor. By default, this will be the table row. The example below
+ * demonstrates this by placing a sibling element—the pattern—next to the primary action. Hovering
+ * the patterned area shows the cursor is actually hovering the primary action. Likewise, focusing the
+ * action shows the focus outline surrounding both siblings.
+ */
+export const HitArea: Story = {
+  args: {
+    children: '1 Brisbane St, Brisbane 4300',
+    href,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'grid',
+          border: '1px solid #FA00FF',
+          gridTemplateColumns: 'auto 1fr',
+        }}
+      >
+        <Story />
+        <Pattern height="var(--font-small-regular-font-size)" />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * `Table.PrimaryActionButton` is identical to `Table.PrimaryAction`, except it renders as a
+ * `<button>` element, which allows button semantics to be used for a table row's primary action.
+ * That said, typically a row's primary action will involve navigation, such as opening a drawer
+ * or navigating to another page.
+ */
+export const Buttons: StoryObj<typeof TableRowPrimaryActionButton> = {
+  args: {
+    children: '1 Brisbane St, Brisbane 4300',
+  },
+  render: (args) => <TableRowPrimaryActionButton {...args} />,
+}

--- a/src/core/table/primary-action/primary-action.tsx
+++ b/src/core/table/primary-action/primary-action.tsx
@@ -1,0 +1,24 @@
+import { cx } from '@linaria/core'
+import { elTableRowPrimaryAction } from './styles'
+
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+
+export interface TableRowPrimaryActionProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** The content of the primary action */
+  children: ReactNode
+  /** The URL to which this primary action navigates */
+  href: string
+}
+
+/**
+ * A simple primary action component for table rows that allows an anchor or button, typically placed
+ * within a row's header cell, to act as the row's primary action. The key feature of the primary
+ * action is that its "hit area" will expand to fill the bounding box of the closest, relative-positioned
+ * ancestor. By default, this will be the table row.
+ *
+ * Comes in two varieties: `Table.PrimaryAction`, which renders as an anchor, and
+ * `Table.PrimaryActionButton`, which renders as a button.
+ */
+export function TableRowPrimaryAction({ className, ...rest }: TableRowPrimaryActionProps) {
+  return <a {...rest} className={cx(elTableRowPrimaryAction, className)} />
+}

--- a/src/core/table/primary-action/styles.ts
+++ b/src/core/table/primary-action/styles.ts
@@ -1,0 +1,30 @@
+import { css } from '@linaria/core'
+import { font } from '#src/core/text'
+
+export const elTableRowPrimaryAction = css`
+  display: inline-grid;
+  align-items: center;
+  border: none;
+  margin: 0;
+  padding: 0;
+
+  ${font('sm', 'medium')}
+
+  background: transparent;
+  color: var(--colour-text-primary);
+  text-decoration: none;
+
+  outline: none;
+
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0 0 0 0;
+  }
+
+  &:focus-visible::after {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+`


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work will be done over a number of PRs and be focused on atoms involved in the table's body:
  - Part 1: Primary action for table rows (this PR)
  - Part 2: Primary data for table body cells
  - Part 3: Double-line layout for cells
  - Part 4: Body cell
  - Part 5: Body row
  - Part 6: Table body

### This PR

- Adds `TableRowPrimaryAction` and `TableRowPrimaryActionButton`.

**note:** These components render as an anchor and button respectively, but ones whose "hit area" will expand to fill the bounding box of the closest, relatively-positioned ancestor, which, by default, will be the table row.

<img width="814" height="677" alt="Screenshot 2025-08-27 at 9 37 54 am" src="https://github.com/user-attachments/assets/4d8e0214-94f6-439a-92f6-4ac5d6135c4b" />
<img width="819" height="659" alt="Screenshot 2025-08-27 at 9 37 59 am" src="https://github.com/user-attachments/assets/02ed1b32-2868-4fab-92ea-65b3cf294c8a" />
