### PR TITLE
feat: Add new `TableCellPrimaryData`

### DIFF
--- a/src/core/table/primary-data/__tests__/primary-data.test.tsx
+++ b/src/core/table/primary-data/__tests__/primary-data.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { TableCellPrimaryData } from '../primary-data'
+
+test('renders as a div element', () => {
+  const { container } = render(<TableCellPrimaryData>Data</TableCellPrimaryData>)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+})
+
+test('displays provided content', () => {
+  render(<TableCellPrimaryData>Data</TableCellPrimaryData>)
+  expect(screen.getByText('Data')).toBeVisible()
+})
+
+test('can display a leading icon', () => {
+  render(<TableCellPrimaryData iconLeft="Left icon">Data</TableCellPrimaryData>)
+  const leftIcon = screen.getByText('Left icon')
+  expect(leftIcon).toBeVisible()
+  expect(leftIcon).toHaveAttribute('data-placement', 'left')
+  expect(leftIcon).toHaveRole('presentation')
+})
+
+test('can display a trailing icon', () => {
+  render(<TableCellPrimaryData iconRight="Right icon">Data</TableCellPrimaryData>)
+  const rightIcon = screen.getByText('Right icon')
+  expect(rightIcon).toBeVisible()
+  expect(rightIcon).toHaveAttribute('data-placement', 'right')
+  expect(rightIcon).toHaveRole('presentation')
+})
+
+test('can display a leading and trailing icon', () => {
+  render(
+    <TableCellPrimaryData iconLeft="Left icon" iconRight="Right icon">
+      Data
+    </TableCellPrimaryData>,
+  )
+  expect(screen.getByText('Left icon')).toBeVisible()
+  expect(screen.getByText('Right icon')).toBeVisible()
+})
+
+test('forwards additional props to the div element', () => {
+  const { container } = render(<TableCellPrimaryData data-testid="test-id">Data</TableCellPrimaryData>)
+  expect(screen.getByTestId('test-id')).toBe(container.firstElementChild)
+})

--- a/src/core/table/primary-data/index.ts
+++ b/src/core/table/primary-data/index.ts
@@ -1,0 +1,2 @@
+export * from './primary-data'
+export * from './styles'

--- a/src/core/table/primary-data/primary-data.stories.tsx
+++ b/src/core/table/primary-data/primary-data.stories.tsx
@@ -1,0 +1,156 @@
+import { Badge } from '#src/core/badge'
+import { Features } from '#src/core/features'
+import { Skeleton } from '#src/core/skeleton'
+import { StarIcon } from '#src/icons/star'
+import { StatusIndicator } from '#src/core/status-indicator'
+import { TableCellPrimaryData } from './primary-data'
+import { TagGroup } from '#src/core/tag-group'
+import { Text } from '#src/core/text'
+import { Tooltip } from '../../tooltip'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/PrimaryData',
+  component: TableCellPrimaryData,
+  argTypes: {
+    children: {
+      control: 'select',
+      options: ['Plain text', 'Badge', 'Features', 'Status indicator', 'Tag group', 'Skeleton'],
+      mapping: {
+        'Plain text': '10 Hay St, Melbourne 3100',
+        Badge: <Badge colour="neutral">Label</Badge>,
+        Features: (
+          <Features size="2xs" wrap="nowrap">
+            <Features.Bedrooms value={4} />
+            <Features.Bathrooms value={2} />
+            <Features.CarSpaces value={2} />
+          </Features>
+        ),
+        'Status indicator': <StatusIndicator variant="neutral">Status indicator</StatusIndicator>,
+        'Tag group': (
+          <TagGroup flow="nowrap">
+            <TagGroup.Item>Tag 1</TagGroup.Item>
+            <TagGroup.Item>Tag 2</TagGroup.Item>
+            <TagGroup.Item>Tag 3</TagGroup.Item>
+          </TagGroup>
+        ),
+        Skeleton: <Skeleton />,
+      },
+    },
+    iconLeft: {
+      control: 'radio',
+      options: ['None', 'Star', 'Skeleton'],
+      mapping: {
+        None: null,
+        Star: <StarIcon />,
+        Skeleton: <Skeleton />,
+      },
+    },
+    iconRight: {
+      control: 'radio',
+      options: ['None', 'Star', 'Skeleton'],
+      mapping: {
+        None: null,
+        Star: <StarIcon />,
+        Skeleton: <Skeleton />,
+      },
+    },
+  },
+} satisfies Meta<typeof TableCellPrimaryData>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    children: 'Plain text',
+    iconLeft: 'None',
+    iconRight: 'None',
+  },
+}
+
+/**
+ * Icons can be placed to the left or right of the content. When the content overflows the cell,
+ * the icons should remain visible.
+ */
+export const Icons: Story = {
+  args: {
+    ...Example.args,
+    iconLeft: 'Star',
+    iconRight: 'Star',
+  },
+}
+
+/**
+ * Any content can be displayed such as badges and tag groups. Typically, icons will be used
+ * with textual content, but they are available regardless of what content is provided.
+ */
+export const Content: Story = {
+  args: {
+    ...Example.args,
+    children: 'Badge',
+    iconLeft: 'Star',
+    iconRight: 'Star',
+  },
+}
+
+/**
+ * In cases where the content has insufficient space, content will be clipped while the icons remain
+ * visible.
+ */
+export const Clipping: Story = {
+  args: {
+    ...Icons.args,
+    children: 'Tag group',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', display: 'flex', width: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Where possible, content should be truncated, with a tooltip used to display the unabridged content
+ * when hovered. Again, the icons will remain visible.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Icons.args,
+    children: (
+      <>
+        <Text id="text" overflow="truncate">
+          10 Queen Elizabeth St, Melbourne 3100
+        </Text>
+        <Tooltip id="tooltip" placement="top" triggerId="text" truncationTargetId="text">
+          10 Queen Elizabeth St, Melbourne 3100
+        </Tooltip>
+      </>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', display: 'flex', width: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Skeletons can used for the content and the icons to communicate a loading state. The fidelity of
+ * the loading state can be low; there is no need to perfectly represent the content being loaded.
+ * That is, it would be sufficient in many cases to only display a skeleton for the content, even
+ * if an icon may be present once loading is complete.
+ */
+export const Loading: Story = {
+  args: {
+    ...Example.args,
+    children: 'Skeleton',
+    iconLeft: 'Skeleton',
+    iconRight: 'None',
+  },
+}

--- a/src/core/table/primary-data/primary-data.tsx
+++ b/src/core/table/primary-data/primary-data.tsx
@@ -1,0 +1,46 @@
+import {
+  ElTableCellPrimaryData,
+  ElTableCellPrimaryDataContentContainer,
+  ElTableCellPrimaryDataIconContainer,
+} from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface TableCellPrimaryDataProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The primary data being displayed in the table cell. Typically used with alphanumeric
+   * information like addresses, dates, times, and names.
+   */
+  children: ReactNode
+  /** The leading icon displayed before the content. */
+  iconLeft?: ReactNode
+  /** The trailing icon displayed after the content. */
+  iconRight?: ReactNode
+}
+
+/**
+ * A simple layout component for pairing a left or right icon with some other cell content.
+ * Typically used with alphanumeric information like addresses, dates, times, and names as a
+ * cell's primary data. It ensures the icons remain visible even when there is insufficient
+ * space for the content. Typically used via `Table.PrimaryData`.
+ */
+export function TableCellPrimaryData({ children, iconLeft, iconRight, ...rest }: TableCellPrimaryDataProps) {
+  return (
+    <ElTableCellPrimaryData {...rest}>
+      {iconLeft && (
+        // NOTE: the icon containers are not aria-hidden like other components do with their
+        // icon containers. This is because the icons displayed here may be semantically meaningful
+        // and therefore may need to be accessible to assistive technologies.
+        <ElTableCellPrimaryDataIconContainer data-placement="left" role="presentation">
+          {iconLeft}
+        </ElTableCellPrimaryDataIconContainer>
+      )}
+      <ElTableCellPrimaryDataContentContainer>{children}</ElTableCellPrimaryDataContentContainer>
+      {iconRight && (
+        <ElTableCellPrimaryDataIconContainer data-placement="right" role="presentation">
+          {iconRight}
+        </ElTableCellPrimaryDataIconContainer>
+      )}
+    </ElTableCellPrimaryData>
+  )
+}

--- a/src/core/table/primary-data/styles.ts
+++ b/src/core/table/primary-data/styles.ts
@@ -1,0 +1,42 @@
+import { font } from '#src/core/text'
+import { styled } from '@linaria/react'
+
+export const ElTableCellPrimaryData = styled.div`
+  display: inline-grid;
+  grid-template: 'icon-left data icon-right' auto / auto auto auto;
+  align-items: center;
+  justify-content: start;
+
+  ${font('sm', 'regular')}
+`
+
+export const ElTableCellPrimaryDataContentContainer = styled.div`
+  grid-area: data;
+  display: inline-grid;
+  overflow: hidden;
+  white-space: nowrap;
+`
+
+interface ElTableCellPrimaryDataIconContainerProps {
+  'data-placement': 'left' | 'right'
+}
+
+export const ElTableCellPrimaryDataIconContainer = styled.span<ElTableCellPrimaryDataIconContainerProps>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--icon_size-s);
+  height: var(--icon_size-s);
+
+  color: var(--colour-icon-primary);
+
+  &[data-placement='left'] {
+    grid-area: icon-left;
+    margin-inline-end: var(--spacing-2);
+  }
+
+  &[data-placement='right'] {
+    grid-area: icon-right;
+    margin-inline-start: var(--spacing-2);
+  }
+`


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work will be done over a number of PRs and be focused on atoms involved in the table's body:
  - Part 1: #715 
  - Part 2: Primary data for table body cells (this PR)
  - Part 3: Double-line layout for cells
  - Part 4: Body cell
  - Part 5: Body row
  - Part 6: Table body

### This PR

- Adds `TableRowPrimaryData`. This component assists with the layout concerns shared by single-line cells and the first row of double-line cells.

<img width="816" height="560" alt="Screenshot 2025-08-27 at 10 19 49 am" src="https://github.com/user-attachments/assets/d469d753-a8ce-4d48-a15e-7b3657d86c1c" />
<img width="818" height="556" alt="Screenshot 2025-08-27 at 10 19 55 am" src="https://github.com/user-attachments/assets/f4cd5f64-97ed-4717-b839-b843a6fa55d2" />
<img width="813" height="586" alt="Screenshot 2025-08-27 at 10 20 00 am" src="https://github.com/user-attachments/assets/999560c2-124b-4c8a-bb79-dd71396b8ee7" />
