### PR TITLE
feat: Add new `TableCellDoubleLineLayout`

### DIFF
--- a/src/core/table/double-line-layout/__tests__/double-line-layout.test.tsx
+++ b/src/core/table/double-line-layout/__tests__/double-line-layout.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { TableCellDoubleLineLayout } from '../double-line-layout'
+
+test('renders as a div element', () => {
+  const { container } = render(<TableCellDoubleLineLayout>Data</TableCellDoubleLineLayout>)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+})
+
+test('displays provided content', () => {
+  render(<TableCellDoubleLineLayout>Data</TableCellDoubleLineLayout>)
+  expect(screen.getByText('Data')).toBeVisible()
+})
+
+test('can display supplementary data', () => {
+  render(<TableCellDoubleLineLayout supplementaryData="Supplementary data">Data</TableCellDoubleLineLayout>)
+  expect(screen.getByText('Supplementary data')).toBeVisible()
+})
+
+test('can display a media item', () => {
+  render(<TableCellDoubleLineLayout mediaItem="Media item">Data</TableCellDoubleLineLayout>)
+  expect(screen.getByText('Media item')).toBeVisible()
+})
+
+test('forwards additional props to the div element', () => {
+  const { container } = render(<TableCellDoubleLineLayout data-testid="test-id">Data</TableCellDoubleLineLayout>)
+  expect(screen.getByTestId('test-id')).toBe(container.firstElementChild)
+})

--- a/src/core/table/double-line-layout/double-line-layout.stories.tsx
+++ b/src/core/table/double-line-layout/double-line-layout.stories.tsx
@@ -1,0 +1,157 @@
+import { Avatar } from '#src/core/avatar'
+import { AvatarRectangle } from '#src/core/avatar-rectangle'
+import { Skeleton } from '#src/core/skeleton'
+import { StarIcon } from '#src/icons/star'
+import { SupplementaryInfo } from '#src/core/supplementary-info'
+import { TableCellDoubleLineLayout } from './double-line-layout'
+import { TableCellPrimaryData } from '../primary-data'
+import { Text } from '#src/core/text'
+import { Tooltip } from '#src/core/tooltip'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/DoubleLineLayout',
+  component: TableCellDoubleLineLayout,
+  argTypes: {
+    children: {
+      control: 'select',
+      options: ['Address Line 1', 'Text + icon', 'Skeleton'],
+      mapping: {
+        'Address Line 1': '10 Elizabeth St',
+        'Contact name': 'Mary Jane',
+        'Text + icon': <TableCellPrimaryData iconRight={<StarIcon />}>Alphanumeric value</TableCellPrimaryData>,
+        Skeleton: <Skeleton />,
+      },
+    },
+    mediaItem: {
+      control: 'radio',
+      options: ['None', 'Avatar', 'Image', 'Skeleton'],
+      mapping: {
+        None: null,
+        Avatar: <Avatar>MJ</Avatar>,
+        Image: <AvatarRectangle size="small" variant="residential" />,
+        Skeleton: <Skeleton borderRadius="100%" height="40px" width="40px" />,
+      },
+    },
+    supplementaryData: {
+      control: 'radio',
+      options: ['None', 'Address Line 2', 'Supplementary info', 'Skeleton'],
+      mapping: {
+        None: null,
+        'Address Line 2': 'Brisbane City 4000',
+        'Supplementary info': (
+          <SupplementaryInfo size="xs">
+            <SupplementaryInfo.Item>Value 1</SupplementaryInfo.Item>
+            <SupplementaryInfo.Item>Value 2</SupplementaryInfo.Item>
+            <SupplementaryInfo.Item>Value 3</SupplementaryInfo.Item>
+          </SupplementaryInfo>
+        ),
+        Skeleton: <Skeleton />,
+      },
+    },
+  },
+} satisfies Meta<typeof TableCellDoubleLineLayout>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * [Table.PrimaryData](./?path=/docs/core-table-primarydata--docs) will often be used to display
+ * the primary data in the double-line layout, though any appropriate content can be provided.
+ */
+export const Example: Story = {
+  args: {
+    children: 'Text + icon',
+    mediaItem: 'None',
+    supplementaryData: 'Supplementary info',
+  },
+}
+
+/**
+ * Media items like avatars and images can also be displayed.
+ */
+export const MediaItems: Story = {
+  args: {
+    ...Example.args,
+    children: 'Contact name',
+    mediaItem: 'Avatar',
+    supplementaryData: 'Supplementary info',
+  },
+}
+
+/**
+ * In cases where the content has insufficient space, content will be clipped while the icons remain
+ * visible. Notice that the primary data text in this example is not truncating; this is because its
+ * not configured to do so, and thus is simply being clipped.
+ */
+export const Clipping: Story = {
+  args: {
+    ...Example.args,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', display: 'flex', width: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Where possible, content should be truncated, with a tooltip used to display the unabridged content
+ * when hovered. Again, the icons will remain visible and only the content will be truncated.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Example.args,
+    children: (
+      <>
+        <Text id="primary-text" overflow="truncate" size="sm">
+          10 Queen Elizabeth St
+        </Text>
+        <Tooltip id="primary-tooltip" placement="top" triggerId="primary-text" truncationTargetId="primary-text">
+          10 Queen Elizabeth St
+        </Tooltip>
+      </>
+    ),
+    mediaItem: 'Image',
+    supplementaryData: (
+      <>
+        <Text id="supplementary-text" overflow="truncate" size="xs">
+          Melbourne 3100
+        </Text>
+        <Tooltip
+          id="supplementary-tooltip"
+          placement="top"
+          triggerId="supplementary-text"
+          truncationTargetId="supplementary-text"
+        >
+          Melbourne 3100
+        </Tooltip>
+      </>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', display: 'flex', width: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Skeletons can used for the content and the icons to communicate a loading state. The fidelity of
+ * the loading state can be low; there is no need to perfectly represent the content being loaded.
+ * That is, it would be sufficient in many cases to only display a skeleton for the content, even
+ * if an icon may be present once loading is complete.
+ */
+export const Loading: Story = {
+  args: {
+    ...Example.args,
+    children: 'Skeleton',
+    mediaItem: 'Skeleton',
+    supplementaryData: 'Skeleton',
+  },
+}

--- a/src/core/table/double-line-layout/double-line-layout.tsx
+++ b/src/core/table/double-line-layout/double-line-layout.tsx
@@ -1,0 +1,41 @@
+import {
+  ElTableCellDoubleLineLayout,
+  ElTableCellDoubleLineLayoutMediaItem,
+  ElTableCellDoubleLineLayoutPrimaryData,
+  ElTableCellDoubleLineLayoutSupplementaryData,
+} from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface TableCellDoubleLineLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The primary data being displayed in the table cell. Typically used with alphanumeric
+   * information like addresses, dates, times, and names.
+   */
+  children: ReactNode
+  /** The media item to display. Typically an image or avatar. */
+  mediaItem?: ReactNode
+  /** The trailing icon displayed after the content. */
+  supplementaryData?: ReactNode
+}
+
+/**
+ * A simple layout component for displaying two lines of content within a cell, plus an optional
+ * media item (e.g., an avatar or image). Typically used via `Table.DoubleLineLayout`.
+ */
+export function TableCellDoubleLineLayout({
+  children,
+  mediaItem,
+  supplementaryData,
+  ...rest
+}: TableCellDoubleLineLayoutProps) {
+  return (
+    <ElTableCellDoubleLineLayout {...rest}>
+      {mediaItem && <ElTableCellDoubleLineLayoutMediaItem>{mediaItem}</ElTableCellDoubleLineLayoutMediaItem>}
+      <ElTableCellDoubleLineLayoutPrimaryData>{children}</ElTableCellDoubleLineLayoutPrimaryData>
+      {supplementaryData && (
+        <ElTableCellDoubleLineLayoutSupplementaryData>{supplementaryData}</ElTableCellDoubleLineLayoutSupplementaryData>
+      )}
+    </ElTableCellDoubleLineLayout>
+  )
+}

--- a/src/core/table/double-line-layout/index.ts
+++ b/src/core/table/double-line-layout/index.ts
@@ -1,0 +1,2 @@
+export * from './double-line-layout'
+export * from './styles'

--- a/src/core/table/double-line-layout/styles.ts
+++ b/src/core/table/double-line-layout/styles.ts
@@ -1,0 +1,51 @@
+import { font } from '#src/core/text'
+import { styled } from '@linaria/react'
+
+export const ElTableCellDoubleLineLayout = styled.div`
+  display: inline-grid;
+  grid-template: 'media-item primary-data' auto 'media-item supplementary-data' auto / auto 1fr;
+  align-items: center;
+  justify-content: inherit;
+  justify-self: inherit;
+
+  padding-block: var(--spacing-2);
+`
+
+export const ElTableCellDoubleLineLayoutPrimaryData = styled.div`
+  grid-area: primary-data;
+  display: inline-grid;
+  justify-content: inherit;
+  justify-self: inherit;
+
+  /* NOTE: We want to avoid any overflow AND prevent text from wrapping. The nowrap
+   * behaviour here is important because some components may be design to wrap by default.
+   * However, when used in a table cell, we don't want them to. */
+  overflow: hidden;
+  white-space: nowrap;
+
+  ${font('sm', 'regular')}
+`
+
+export const ElTableCellDoubleLineLayoutSupplementaryData = styled.span`
+  grid-area: supplementary-data;
+  display: inline-grid;
+  color: var(--colour-text-secondary);
+  justify-content: inherit;
+  justify-self: inherit;
+
+  /* NOTE: We want to avoid any overflow AND prevent text from wrapping. The nowrap
+   * behaviour here is important because some components may be design to wrap by default.
+   * However, when used in a table cell, we don't want them to. */
+  overflow: hidden;
+  white-space: nowrap;
+
+  ${font('xs', 'regular')}
+
+  margin-block-start: var(--spacing-1);
+`
+
+export const ElTableCellDoubleLineLayoutMediaItem = styled.div`
+  grid-area: media-item;
+  max-height: var(--size-10);
+  margin-inline-end: var(--spacing-4);
+`


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work will be done over a number of PRs and be focused on atoms involved in the table's body:
  - Part 1: #715 
  - Part 2: #716 
  - Part 3: Double-line layout for cells (this PR)
  - Part 4: Body cell
  - Part 5: Body row
  - Part 6: Table body

### This PR

- Adds `TableRowDoubleLineLayout`. This component handles the layout requirements of double-line cells.

<img width="820" height="611" alt="Screenshot 2025-08-27 at 10 27 23 am" src="https://github.com/user-attachments/assets/0709c914-1d6e-411d-a605-5bf1cd707b90" />
<img width="814" height="676" alt="Screenshot 2025-08-27 at 10 27 29 am" src="https://github.com/user-attachments/assets/457b3990-980c-46f0-ad5d-b915f51ec28f" />
<img width="816" height="470" alt="Screenshot 2025-08-27 at 10 27 34 am" src="https://github.com/user-attachments/assets/74c62b93-0d7e-4ce0-a825-7050cbb44e34" />
