### PR TITLE
feat: Add new `TableBodyCell`

### DIFF
--- a/src/core/table/__story__/use-table-decorator.tsx
+++ b/src/core/table/__story__/use-table-decorator.tsx
@@ -1,0 +1,70 @@
+import type { Decorator } from '@storybook/react-vite'
+import { CSSProperties } from 'react'
+
+type StoryPlacement = 'body' | 'body-cell' | 'body-row' | 'head' | 'header-cell' | 'header-row'
+
+/** Simple story decorator that renders the story in a valid table DOM hierarchy */
+export function useTableDecorator(placement: StoryPlacement): Decorator {
+  return (Story, { parameters: { tableWidth = 'auto' } }) => {
+    const tableStyle: CSSProperties = { borderCollapse: 'collapse', width: tableWidth }
+    const rowGroupStyle: CSSProperties = { display: 'grid' }
+    const rowStyle: CSSProperties = { display: 'grid', gridAutoFlow: 'column' }
+
+    switch (placement) {
+      case 'body':
+        return (
+          <table style={tableStyle}>
+            <thead />
+            <Story />
+          </table>
+        )
+      case 'body-cell':
+        return (
+          <table style={tableStyle}>
+            <thead />
+            <tbody>
+              <tr style={rowStyle}>
+                <Story />
+              </tr>
+            </tbody>
+          </table>
+        )
+      case 'body-row':
+        return (
+          <table style={tableStyle}>
+            <thead />
+            <tbody style={rowGroupStyle}>
+              <Story />
+            </tbody>
+          </table>
+        )
+      case 'head':
+        return (
+          <table style={tableStyle}>
+            <Story />
+            <tbody />
+          </table>
+        )
+      case 'header-cell':
+        return (
+          <table style={tableStyle}>
+            <thead>
+              <tr style={rowStyle}>
+                <Story />
+              </tr>
+            </thead>
+            <tbody />
+          </table>
+        )
+      case 'header-row':
+        return (
+          <table style={tableStyle}>
+            <thead style={rowGroupStyle}>
+              <Story />
+            </thead>
+            <tbody />
+          </table>
+        )
+    }
+  }
+}

--- a/src/core/table/body-cell/__test__/body-cell.test.tsx
+++ b/src/core/table/body-cell/__test__/body-cell.test.tsx
@@ -1,0 +1,41 @@
+import { composeStories } from '@storybook/react-vite'
+import { render, screen } from '@testing-library/react'
+import * as tableBodyCellStories from '../body-cell.stories'
+
+const TableBodyCellStories = composeStories(tableBodyCellStories)
+
+test('renders as a cell element by default', () => {
+  render(<TableBodyCellStories.Example />)
+  expect(screen.getByRole('cell')).toBeVisible()
+})
+
+test('can render as a row header cell', () => {
+  render(<TableBodyCellStories.RowHeader scope="row" data-testid="table-cell" />)
+  expect(screen.getByRole('rowheader')).toBeVisible()
+})
+
+test('can render as a div with no implicit role', () => {
+  const { container } = render(<TableBodyCellStories.Divs />)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+  expect(screen.queryByRole('cell')).not.toBeInTheDocument()
+})
+
+test('applies `data-justify-content` when `justifyContent` is provided', () => {
+  render(<TableBodyCellStories.Alignment />)
+  expect(screen.getByRole('cell')).toHaveAttribute('data-justify-content', 'end')
+})
+
+test('has .el-table-body-cell class', () => {
+  render(<TableBodyCellStories.Example />)
+  expect(screen.getByRole('cell')).toHaveClass('el-table-body-cell')
+})
+
+test('accepts other classes', () => {
+  render(<TableBodyCellStories.Example className="custom-class" />)
+  expect(screen.getByRole('cell')).toHaveClass('el-table-body-cell custom-class')
+})
+
+test('forwards additional props to the cell', () => {
+  render(<TableBodyCellStories.Example data-testid="test-id" />)
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('cell'))
+})

--- a/src/core/table/body-cell/body-cell.stories.tsx
+++ b/src/core/table/body-cell/body-cell.stories.tsx
@@ -1,0 +1,257 @@
+import { Badge } from '#src/core/badge'
+import { Features } from '#src/core/features'
+import { Skeleton } from '#src/core/skeleton'
+import { StarIcon } from '#src/icons/star'
+import { StatusIndicator } from '#src/core/status-indicator'
+import { SupplementaryInfo } from '../../supplementary-info'
+import { TableBodyCell } from './body-cell'
+import { TableCellDoubleLineLayout } from '../double-line-layout/double-line-layout'
+import { TableCellPrimaryData } from '../primary-data'
+import { TagGroup } from '#src/core/tag-group'
+import { Text } from '#src/core/text'
+import { Tooltip } from '#src/core/tooltip'
+import { WarningIcon } from '#src/icons/warning'
+import { useTableDecorator } from '../__story__/use-table-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/BodyCell',
+  component: TableBodyCell,
+  argTypes: {
+    as: {
+      control: false,
+      description: 'The element this table cell will render as.',
+      table: {
+        type: {
+          summary: "'td' | 'th' | 'div'",
+        },
+      },
+    },
+    children: {
+      control: 'select',
+      description: 'The cell content.',
+      options: [
+        'Plain text',
+        'Text + icons',
+        'Double-line layout',
+        'Badge',
+        'Icon',
+        'Features',
+        'Status indicator',
+        'Tag group',
+        'Skeleton',
+      ],
+      mapping: {
+        'Plain text': '10 Hay St, Melbourne 3100',
+        'Text + icons': <TableCellPrimaryData iconRight={<StarIcon />}>10 Hay St, Melbourne 3100</TableCellPrimaryData>,
+        'Double-line layout': (
+          <TableCellDoubleLineLayout
+            supplementaryData={
+              <SupplementaryInfo size="xs">
+                <SupplementaryInfo.Item>Value 1</SupplementaryInfo.Item>
+                <SupplementaryInfo.Item>Value 2</SupplementaryInfo.Item>
+                <SupplementaryInfo.Item>Value 3</SupplementaryInfo.Item>
+              </SupplementaryInfo>
+            }
+          >
+            <TableCellPrimaryData iconRight={<StarIcon />}>
+              <time dateTime="2025-08-22T09:21:00">22 August 2025, 9:21am</time>
+            </TableCellPrimaryData>
+          </TableCellDoubleLineLayout>
+        ),
+        Badge: <Badge colour="neutral">Label</Badge>,
+        Icon: <StarIcon color="primary" size="sm" />,
+        Features: (
+          <Features size="2xs" wrap="nowrap">
+            <Features.Bedrooms value={4} />
+            <Features.Bathrooms value={2} />
+            <Features.CarSpaces value={2} />
+          </Features>
+        ),
+        'Status indicator': <StatusIndicator variant="neutral">Status indicator</StatusIndicator>,
+        'Tag group': (
+          <TagGroup flow="nowrap">
+            <TagGroup.Item>Tag 1</TagGroup.Item>
+            <TagGroup.Item>Tag 2</TagGroup.Item>
+            <TagGroup.Item>Tag 3</TagGroup.Item>
+          </TagGroup>
+        ),
+        Skeleton: <Skeleton />,
+      },
+      table: {
+        type: {
+          summary: 'ReactNode',
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof TableBodyCell>
+
+export default meta
+type Story = StoryObj<typeof TableBodyCell>
+
+/**
+ * At their simplest, body cell's will contain a single line of plain text. However, it's important
+ * to understand that, without additional styles for the plain text, it will flow to additional lines
+ * rather than overflow or truncate when there is insufficient space.
+ */
+export const Example: Story = {
+  args: {
+    as: 'td',
+    children: 'Plain text',
+  },
+  decorators: [useTableDecorator('body-cell')],
+}
+
+/**
+ * Often, the cell content will include some text paired with an icon. To achieve this,
+ * [Table.PrimaryData](./?path=/docs/core-table-primarydata--docs) can be used.
+ */
+export const Icons: Story = {
+  args: {
+    ...Example.args,
+    children: 'Text + icons',
+  },
+  decorators: [useTableDecorator('body-cell')],
+}
+
+/**
+ * For cells that need to communicate more information than can fit on a single line,
+ * [Table.DoubleLineLayout](./?path=/docs/core-table-doublelinelayout--docs) can be used.
+ */
+export const DoubleLineLayout: Story = {
+  name: 'Double-line layout',
+  args: {
+    ...Example.args,
+    children: 'Double-line layout',
+  },
+  decorators: [useTableDecorator('body-cell')],
+}
+
+/**
+ * Often it will be necessary to render a table cell as a row header, `<th>`. When you
+ * do use `th`, it's [scope](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope)
+ * should also be specified as `row`. Further, the text should typically have a medium font weight.
+ * If you need a cell to act as a column header, you should use `Table.HeadingCell` instead.
+ */
+export const RowHeader: Story = {
+  args: {
+    ...Example.args,
+    as: 'th',
+    scope: 'row',
+    children: <Text weight="medium">I&apos;m in a &lt;th&gt;</Text>,
+  },
+  decorators: [useTableDecorator('body-cell')],
+}
+
+/**
+ * Sometimes it may be necessary to render the table cell as a plain `<div>`. Providing
+ * `as="div"` will achieve this outcome. When doing so, it's important to consider whether an
+ * [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+ * should also be specified.
+ */
+export const Divs: Story = {
+  args: {
+    ...Example.args,
+    as: 'div',
+    children: "I'm in a <div>",
+  },
+}
+
+/**
+ * In cases where the content can’t fit inside the cell due to the columns width, it will be clipped
+ * to avoid overflow into the next column.
+ */
+export const Overflow: Story = {
+  args: {
+    ...Example.args,
+    children: (
+      <Badge id="badge" colour="warning" iconLeft={<WarningIcon />}>
+        A very very long badge label
+      </Badge>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', display: 'flex', width: '150px' }}>
+        <Story />
+      </div>
+    ),
+    useTableDecorator('body-cell'),
+  ],
+}
+
+/**
+ * When possible, truncation should be preferred over clipping, with a tooltip displayed when
+ * the truncated content is hovered. The tooltip should display the unabridged content. Achieving
+ * this will typically require the truncated text to be inside a container sized to the width of
+ * the cell.
+ *
+ * This is what the single- or double-line content components assist with.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Example.args,
+    children: (
+      <>
+        <Text id="text" overflow="truncate" size="sm">
+          10 Queen Elizabeth St, Melbourne 3100
+        </Text>
+        <Tooltip id="tooltip" placement="top" triggerId="text" truncationTargetId="text">
+          10 Queen Elizabeth St, Melbourne 3100
+        </Tooltip>
+      </>
+    ),
+  },
+  decorators: Overflow.decorators,
+}
+
+/**
+ * When the cell has no data to display, it can either be blank or it can display a placeholder message.
+ */
+export const EmptyCells: Story = {
+  args: {
+    ...Example.args,
+    children: (
+      <Text colour="placeholder" size="sm">
+        Not available
+      </Text>
+    ),
+  },
+  decorators: [useTableDecorator('body-cell')],
+}
+
+/**
+ * The justification of the cell's content within the cell's bounding box can be specified using
+ * `justifyContent`. There are three options: `start` (default), `center`, and `end`.
+ */
+export const Alignment: Story = {
+  args: {
+    ...DoubleLineLayout.args,
+    justifyContent: 'end',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'grid', boxSizing: 'content-box', border: '1px solid #FA00FF' }}>
+        <Story />
+      </div>
+    ),
+    useTableDecorator('body-cell'),
+  ],
+  parameters: {
+    tableWidth: 'var(--size-80)',
+  },
+}
+
+/**
+ * A simple loading state can be achieved by providing a [Skeleton](?path=/docs/core-skeleton--docs)
+ * as the content of the cell.
+ */
+export const Loading: Story = {
+  args: {
+    ...Example.args,
+    children: 'Skeleton',
+  },
+  decorators: [useTableDecorator('body-cell')],
+}

--- a/src/core/table/body-cell/body-cell.tsx
+++ b/src/core/table/body-cell/body-cell.tsx
@@ -1,0 +1,46 @@
+import { cx } from '@linaria/core'
+import { elTableBodyCell } from './styles'
+
+import type { HTMLAttributes, ReactNode, TdHTMLAttributes, ThHTMLAttributes } from 'react'
+
+interface TableBodyCellCommonProps {
+  justifyContent?: 'start' | 'center' | 'end'
+}
+
+interface TableBodyCellAsTdProps extends TableBodyCellCommonProps, TdHTMLAttributes<HTMLTableCellElement> {
+  as?: 'td'
+  /** The cell content. */
+  children: ReactNode
+}
+
+interface TableBodyCellAsThProps extends TableBodyCellCommonProps, ThHTMLAttributes<HTMLTableCellElement> {
+  as: 'th'
+  /** The cell content. */
+  children: ReactNode
+}
+
+interface TableBodyCellAsDivProps extends TableBodyCellCommonProps, HTMLAttributes<HTMLDivElement> {
+  as: 'div'
+  /** The cell content. */
+  children: ReactNode
+}
+
+type TableBodyCellProps = TableBodyCellAsTdProps | TableBodyCellAsThProps | TableBodyCellAsDivProps
+
+/**
+ * A basic cell for a table's body. Does little more than render its children in a `<td>`,
+ * `<th>`, or `<div>` element. Typically used via `Table.BodyCell`.
+ */
+export function TableBodyCell({
+  as: Element = 'td',
+  children,
+  className,
+  justifyContent,
+  ...rest
+}: TableBodyCellProps) {
+  return (
+    <Element {...rest} className={cx(elTableBodyCell, className)} data-justify-content={justifyContent}>
+      {children}
+    </Element>
+  )
+}

--- a/src/core/table/body-cell/index.ts
+++ b/src/core/table/body-cell/index.ts
@@ -1,0 +1,2 @@
+export * from './body-cell'
+export * from './styles'

--- a/src/core/table/body-cell/styles.ts
+++ b/src/core/table/body-cell/styles.ts
@@ -1,0 +1,27 @@
+import { css } from '@linaria/core'
+import { font } from '#src/core/text'
+
+// NOTE: This is a plain class so that we have an exportable class name
+// available for consumers that want table cell styling on an element not
+// supported by the TableBodyCell component.
+export const elTableBodyCell = css`
+  display: grid;
+
+  ${font('sm', 'regular')}
+
+  border: none;
+  padding: 0 var(--spacing-2);
+
+  overflow: hidden;
+
+  &,
+  &[data-justify-content='start'] {
+    justify-content: start;
+  }
+  &[data-justify-content='center'] {
+    justify-content: center;
+  }
+  &[data-justify-content='end'] {
+    justify-content: end;
+  }
+`


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work will be done over a number of PRs and be focused on atoms involved in the table's body:
  - Part 1: #715 
  - Part 2: #716 
  - Part 3: #717 
  - Part 4: Body cell (this PR)
  - Part 5: Body row
  - Part 6: Table body

### This PR

- Adds `TableBodyCell`. This component handles the layout requirements of the actual cell within the table's body (classically, the `<td>` and `<th>` elements).

<img width="816" height="558" alt="Screenshot 2025-08-27 at 12 57 43 pm" src="https://github.com/user-attachments/assets/2e388194-9256-4a07-b088-0aaed6058fb3" />
<img width="816" height="594" alt="Screenshot 2025-08-27 at 12 57 49 pm" src="https://github.com/user-attachments/assets/a4ed8918-1cda-409d-8a93-e21813b20d6f" />
<img width="816" height="613" alt="Screenshot 2025-08-27 at 12 57 57 pm" src="https://github.com/user-attachments/assets/7d508715-169a-4753-b416-539d2f401666" />
<img width="818" height="586" alt="Screenshot 2025-08-27 at 12 58 02 pm" src="https://github.com/user-attachments/assets/fe303441-798f-4d90-8b64-80233afc733f" />
