### PR TITLE
feat: Add new `TableBodyRow`

### DIFF
--- a/src/core/table/__story__/use-table-decorator.tsx
+++ b/src/core/table/__story__/use-table-decorator.tsx
@@ -1,14 +1,33 @@
+import type { CSSProperties } from 'react'
 import type { Decorator } from '@storybook/react-vite'
-import { CSSProperties } from 'react'
 
 type StoryPlacement = 'body' | 'body-cell' | 'body-row' | 'head' | 'header-cell' | 'header-row'
 
 /** Simple story decorator that renders the story in a valid table DOM hierarchy */
 export function useTableDecorator(placement: StoryPlacement): Decorator {
-  return (Story, { parameters: { tableWidth = 'auto' } }) => {
-    const tableStyle: CSSProperties = { borderCollapse: 'collapse', width: tableWidth }
-    const rowGroupStyle: CSSProperties = { display: 'grid' }
-    const rowStyle: CSSProperties = { display: 'grid', gridAutoFlow: 'column' }
+  return (Story, { parameters: { tableWidth = 'auto', tableColumns = 3 } }) => {
+    const tableStyle: CSSProperties = {
+      display: 'grid',
+      gridAutoFlow: 'row',
+      gridAutoRows: 'auto',
+      gridTemplateColumns: `repeat(${tableColumns}, 1fr)`,
+      justifyContent: 'start',
+      width: tableWidth,
+    }
+    const rowGroupStyle: CSSProperties = {
+      display: 'grid',
+      gridColumn: '1 / -1',
+      gridAutoFlow: 'row',
+      gridAutoRows: 'auto',
+      gridTemplateColumns: 'subgrid',
+      justifyContent: 'inherit',
+    }
+    const rowStyle: CSSProperties = {
+      display: 'grid',
+      gridColumn: '1 / -1',
+      gridTemplateColumns: 'subgrid',
+      justifyContent: 'inherit',
+    }
 
     switch (placement) {
       case 'body':
@@ -22,7 +41,7 @@ export function useTableDecorator(placement: StoryPlacement): Decorator {
         return (
           <table style={tableStyle}>
             <thead />
-            <tbody>
+            <tbody style={rowGroupStyle}>
               <tr style={rowStyle}>
                 <Story />
               </tr>

--- a/src/core/table/body-cell/body-cell.stories.tsx
+++ b/src/core/table/body-cell/body-cell.stories.tsx
@@ -239,9 +239,6 @@ export const Alignment: Story = {
     ),
     useTableDecorator('body-cell'),
   ],
-  parameters: {
-    tableWidth: 'var(--size-80)',
-  },
 }
 
 /**

--- a/src/core/table/body-cell/styles.ts
+++ b/src/core/table/body-cell/styles.ts
@@ -6,6 +6,8 @@ import { font } from '#src/core/text'
 // supported by the TableBodyCell component.
 export const elTableBodyCell = css`
   display: grid;
+  align-items: center;
+  justify-content: inherit;
 
   ${font('sm', 'regular')}
 
@@ -14,7 +16,6 @@ export const elTableBodyCell = css`
 
   overflow: hidden;
 
-  &,
   &[data-justify-content='start'] {
     justify-content: start;
   }

--- a/src/core/table/body-row/__tests__/body-row.test.tsx
+++ b/src/core/table/body-row/__tests__/body-row.test.tsx
@@ -1,0 +1,31 @@
+import { composeStories } from '@storybook/react-vite'
+import { render, screen } from '@testing-library/react'
+import * as tableBodyRowStories from '../body-row.stories'
+
+const TableBodyRowStories = composeStories(tableBodyRowStories)
+
+test('renders as a cell element by default', () => {
+  render(<TableBodyRowStories.Example />)
+  expect(screen.getByRole('row')).toBeVisible()
+})
+
+test('can render as a div with no implicit role', () => {
+  const { container } = render(<TableBodyRowStories.Divs />)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+  expect(screen.queryByRole('row')).not.toBeInTheDocument()
+})
+
+test('has .el-table-body-row class', () => {
+  render(<TableBodyRowStories.Example />)
+  expect(screen.getByRole('row')).toHaveClass('el-table-body-row')
+})
+
+test('accepts other classes', () => {
+  render(<TableBodyRowStories.Example className="custom-class" />)
+  expect(screen.getByRole('row')).toHaveClass('el-table-body-row custom-class')
+})
+
+test('forwards additional props to the row', () => {
+  render(<TableBodyRowStories.Example data-testid="test-id" />)
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('row'))
+})

--- a/src/core/table/body-row/body-row.stories.tsx
+++ b/src/core/table/body-row/body-row.stories.tsx
@@ -1,0 +1,144 @@
+import { Avatar } from '#src/core/avatar'
+import { TableBodyCell } from '../body-cell'
+import { TableBodyRow } from './body-row'
+import { TableCellDoubleLineLayout } from '../double-line-layout'
+import { TableRowPrimaryAction } from '../primary-action'
+import { useTableDecorator } from '../__story__/use-table-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const href = globalThis.top?.location.href!
+
+const meta = {
+  title: 'Core/Table/BodyRow',
+  component: TableBodyRow,
+  argTypes: {
+    as: {
+      control: false,
+      description: 'The element this table row will render as.',
+      table: {
+        type: {
+          summary: "'tr' | 'div'",
+        },
+      },
+    },
+    children: {
+      control: 'select',
+      description: 'The row content.',
+      options: ['Plain text', 'Primary action', 'Double-line'],
+      mapping: {
+        'Plain text': (
+          <>
+            <TableBodyCell>10 Hay St, Melbourne 3100</TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+          </>
+        ),
+        'Primary action': (
+          <>
+            <TableBodyCell as="th" scope="row">
+              <TableRowPrimaryAction href={href}>10 Hay St, Melbourne 3100</TableRowPrimaryAction>
+            </TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+          </>
+        ),
+        'Double-line': (
+          <>
+            <TableBodyCell>
+              <TableCellDoubleLineLayout mediaItem={<Avatar>MJ</Avatar>} supplementaryData="Engineer">
+                <TableRowPrimaryAction href={href}>Mary Jane</TableRowPrimaryAction>
+              </TableCellDoubleLineLayout>
+            </TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+          </>
+        ),
+      },
+      table: {
+        type: {
+          summary: 'ReactNode',
+        },
+      },
+    },
+  },
+  parameters: {
+    tableWidth: '100%',
+  },
+} satisfies Meta<typeof TableBodyRow>
+
+export default meta
+type Story = StoryObj<typeof TableBodyRow>
+
+/**
+ * By default, rows do not exhibit any cursor-based interactivity, such has hover styles. This is because
+ * rows themselves are never interactive.
+ */
+export const Example: Story = {
+  args: {
+    as: 'tr',
+    children: 'Plain text',
+  },
+  decorators: [useTableDecorator('body-row')],
+}
+
+/**
+ * Rows within a table's body will often provide a number of actions to users. When there is a single
+ * action, such as viewing more details about the entity represented by a row, that action should appear
+ * to users as being invoked by clicking the row. However, rows themselves must not be interactive, so
+ * [Table.PrimaryAction](./?path=/docs/core-table-primaryaction--docs) is provided to achieve this visual
+ * outcome while maintaining accessiblity and DOM structure. The presence of a `Table.PrimaryAction`
+ * descendant in a row will result in the row exhibiting cursor interactivity such as hover styles.
+ *
+ * Other actions such as a row selection checkbox or a "more actions" menu can be provided. When providing
+ * these secondary actions, care must be taken to ensure they sit above the primary action's hit area.
+ * This is handled automatically by table-specific component, but if custom actions are provided, it will
+ * be up to the consumer to ensure they are click accessible.
+ */
+export const RowActions: Story = {
+  args: {
+    ...Example.args,
+    children: 'Primary action',
+  },
+  decorators: [useTableDecorator('body-row')],
+}
+
+/**
+ * Rows have minimum and maximum height constraints, but within this range, they may grow to accommodate
+ * their content. For example, a row that contains
+ * [Table.DoubleLineLayout](./?path=/docs/core-table-doublelinelayout--docs) cell content will be taller
+ * than a row with a single line of cell content.
+ */
+export const DoubleLineContent: Story = {
+  name: 'Double-line content',
+  args: {
+    ...Example.args,
+    children: 'Double-line',
+  },
+  decorators: [useTableDecorator('body-row')],
+}
+
+/**
+ * Sometimes it may be necessary to render the table row as a plain `<div>`. Providing
+ * `as="div"` will achieve this outcome. When doing so, it's important to consider whether an
+ * [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+ * should also be specified.
+ *
+ * Care must also be taken to ensure the descendant cells are also rendered as `<div>` elements,
+ * possibly with explicit ARIA roles as well.
+ */
+export const Divs: Story = {
+  args: {
+    as: 'div',
+    children: (
+      <TableBodyCell as="div">
+        <TableRowPrimaryAction href={href}>I&apos;m all divs and no a11y 😬</TableRowPrimaryAction>
+      </TableBodyCell>
+    ),
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+}

--- a/src/core/table/body-row/body-row.tsx
+++ b/src/core/table/body-row/body-row.tsx
@@ -1,0 +1,37 @@
+import { cx } from '@linaria/core'
+import { elTableBodyRow } from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface TableBodyRowAsTrProps extends HTMLAttributes<HTMLTableRowElement> {
+  as?: 'tr'
+  /** The cell content. */
+  children: ReactNode
+}
+
+interface TableBodyRowAsDivProps extends HTMLAttributes<HTMLDivElement> {
+  as: 'div'
+  /** The row content. */
+  children: ReactNode
+}
+
+type TableBodyRowProps = TableBodyRowAsTrProps | TableBodyRowAsDivProps
+
+/**
+ * A basic row for a table's body. Does little more than render it's children in a `<tr>` or `<div>`.
+ * Cells within a row may contain interactive elements such as buttons, links or menus.
+ *
+ * The row itself should never be interactive. When a row must *appear* to be clickable to users,
+ * [Table.PrimaryAction](./?path=/docs/core-table-primaryaction--docs) should be used in the row's header
+ * cell; it's "hit area" will cover the entire row to give users the experience of being interactive
+ * without violating accessibility guidelines or producing an invalid DOM hierarchy.
+ *
+ * Typically used via `Table.BodyRow`.
+ */
+export function TableBodyRow({ as: Element = 'tr', children, className, ...rest }: TableBodyRowProps) {
+  return (
+    <Element {...rest} className={cx(elTableBodyRow, className)}>
+      {children}
+    </Element>
+  )
+}

--- a/src/core/table/body-row/index.ts
+++ b/src/core/table/body-row/index.ts
@@ -1,0 +1,2 @@
+export * from './body-row'
+export * from './styles'

--- a/src/core/table/body-row/styles.ts
+++ b/src/core/table/body-row/styles.ts
@@ -1,0 +1,32 @@
+import { css } from '@linaria/core'
+import { elTableRowPrimaryAction } from '../primary-action/styles'
+
+// NOTE: This is a plain class so that we have an exportable class name
+// available for consumers that want table row styling on an element not
+// supported by the TableBodyRow component.
+export const elTableBodyRow = css`
+  /* Relative positioning is critical for the row's primary action to work correctly.
+   * The TableRowPrimaryAction component relies on this relative positioning to position
+   * its ::after pseudo-element over the entire row so that clicks on the row are captured
+   * by the action rather than the row. */
+  position: relative;
+
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  grid-template-rows: auto;
+  align-items: center;
+  justify-content: inherit;
+  width: 100%;
+
+  background: var(--colour-white);
+  padding-block: var(--spacing-2);
+  border-block-end: var(--border-width-default) solid var(--colour-border-light_default);
+
+  min-height: var(--size-10);
+  max-height: var(--size-18);
+
+  &:has(.${elTableRowPrimaryAction}):hover {
+    background: var(--colour-fill-neutral-lightest);
+  }
+`

--- a/src/core/table/primary-action/styles.ts
+++ b/src/core/table/primary-action/styles.ts
@@ -23,8 +23,14 @@ export const elTableRowPrimaryAction = css`
     inset: 0 0 0 0;
   }
 
-  &:focus-visible::after {
-    outline: var(--border-width-double) solid var(--colour-border-focus);
-    outline-offset: var(--border-width-default);
+  &:focus-visible {
+    /* We increase the z-index to ensure the focus outline is above subsequent sibling table
+     * row hover styles */
+    z-index: 1;
+
+    &::after {
+      outline: var(--border-width-double) solid var(--colour-border-focus);
+      outline-offset: var(--border-width-default);
+    }
   }
 `


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work will be done over a number of PRs and be focused on atoms involved in the table's body:
  - Part 1: #715 
  - Part 2: #716 
  - Part 3: #717 
  - Part 4: #718 
  - Part 5: Body row (this PR)
  - Part 6: Table body

### This PR

- Adds `TableBodyRow`. This component handles the layout requirements of a row within the table's body (classically, the `<tr>` element).
- Updates `TableBodyCell` to ensure its content is vertically centred.
- Updates `TableRowPrimaryAction` to ensure its focus outline is layered above subsequent sibling rows.

<img width="819" height="517" alt="Screenshot 2025-08-27 at 10 20 15 pm" src="https://github.com/user-attachments/assets/8fc79ddf-c448-42e0-b656-92af52fcee17" />
<img width="815" height="542" alt="Screenshot 2025-08-27 at 10 20 22 pm" src="https://github.com/user-attachments/assets/bc4e04c0-1c64-4fb7-b25c-abc245437f2b" />
<img width="815" height="482" alt="Screenshot 2025-08-27 at 10 20 27 pm" src="https://github.com/user-attachments/assets/5d5bf11e-be2b-47f8-ba70-01f1fae67c25" />
