### PR TITLE
chore: update `TableBodyCell` to auto apply `scope="row"`

### DIFF
--- a/src/core/table/body-cell/__test__/body-cell.test.tsx
+++ b/src/core/table/body-cell/__test__/body-cell.test.tsx
@@ -1,41 +1,43 @@
-import { composeStories } from '@storybook/react-vite'
+import { TableBodyCell } from '../body-cell'
 import { render, screen } from '@testing-library/react'
-import * as tableBodyCellStories from '../body-cell.stories'
-
-const TableBodyCellStories = composeStories(tableBodyCellStories)
 
 test('renders as a cell element by default', () => {
-  render(<TableBodyCellStories.Example />)
+  render(<TableBodyCell>Content</TableBodyCell>)
   expect(screen.getByRole('cell')).toBeVisible()
 })
 
-test('can render as a row header cell', () => {
-  render(<TableBodyCellStories.RowHeader scope="row" data-testid="table-cell" />)
+test('can render as a header cell', () => {
+  render(<TableBodyCell as="th">Content</TableBodyCell>)
   expect(screen.getByRole('rowheader')).toBeVisible()
 })
 
 test('can render as a div with no implicit role', () => {
-  const { container } = render(<TableBodyCellStories.Divs />)
+  const { container } = render(<TableBodyCell as="div">Content</TableBodyCell>)
   expect(container.firstElementChild?.tagName).toBe('DIV')
   expect(screen.queryByRole('cell')).not.toBeInTheDocument()
 })
 
+test('applies scope="row" when rendered as a header cell', () => {
+  render(<TableBodyCell as="th">Content</TableBodyCell>)
+  expect(screen.getByRole('rowheader')).toHaveAttribute('scope', 'row')
+})
+
 test('applies `data-justify-content` when `justifyContent` is provided', () => {
-  render(<TableBodyCellStories.Alignment />)
+  render(<TableBodyCell justifyContent="end">Content</TableBodyCell>)
   expect(screen.getByRole('cell')).toHaveAttribute('data-justify-content', 'end')
 })
 
 test('has .el-table-body-cell class', () => {
-  render(<TableBodyCellStories.Example />)
+  render(<TableBodyCell>Content</TableBodyCell>)
   expect(screen.getByRole('cell')).toHaveClass('el-table-body-cell')
 })
 
 test('accepts other classes', () => {
-  render(<TableBodyCellStories.Example className="custom-class" />)
+  render(<TableBodyCell className="custom-class">Content</TableBodyCell>)
   expect(screen.getByRole('cell')).toHaveClass('el-table-body-cell custom-class')
 })
 
 test('forwards additional props to the cell', () => {
-  render(<TableBodyCellStories.Example data-testid="test-id" />)
+  render(<TableBodyCell data-testid="test-id">Content</TableBodyCell>)
   expect(screen.getByTestId('test-id')).toBe(screen.getByRole('cell'))
 })

--- a/src/core/table/body-cell/body-cell.stories.tsx
+++ b/src/core/table/body-cell/body-cell.stories.tsx
@@ -89,7 +89,7 @@ const meta = {
 } satisfies Meta<typeof TableBodyCell>
 
 export default meta
-type Story = StoryObj<typeof TableBodyCell>
+type Story = StoryObj<typeof meta>
 
 /**
  * At their simplest, body cell's will contain a single line of plain text. However, it's important
@@ -132,14 +132,13 @@ export const DoubleLineLayout: Story = {
 /**
  * Often it will be necessary to render a table cell as a row header, `<th>`. When you
  * do use `th`, it's [scope](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope)
- * should also be specified as `row`. Further, the text should typically have a medium font weight.
- * If you need a cell to act as a column header, you should use `Table.HeadingCell` instead.
+ * will automatically be set as `row`. Care should be taken to use a medium font weight for the cell's
+ * primary content. If you need a cell to act as a column header, use `Table.HeadingCell` instead.
  */
 export const RowHeader: Story = {
   args: {
     ...Example.args,
     as: 'th',
-    scope: 'row',
     children: <Text weight="medium">I&apos;m in a &lt;th&gt;</Text>,
   },
   decorators: [useTableDecorator('body-cell')],

--- a/src/core/table/body-cell/body-cell.tsx
+++ b/src/core/table/body-cell/body-cell.tsx
@@ -4,6 +4,7 @@ import { elTableBodyCell } from './styles'
 import type { HTMLAttributes, ReactNode, TdHTMLAttributes, ThHTMLAttributes } from 'react'
 
 interface TableBodyCellCommonProps {
+  /** The alignment of the cell's content. */
   justifyContent?: 'start' | 'center' | 'end'
 }
 
@@ -13,7 +14,10 @@ interface TableBodyCellAsTdProps extends TableBodyCellCommonProps, TdHTMLAttribu
   children: ReactNode
 }
 
-interface TableBodyCellAsThProps extends TableBodyCellCommonProps, ThHTMLAttributes<HTMLTableCellElement> {
+interface TableBodyCellAsThProps
+  extends TableBodyCellCommonProps,
+    // NOTE: we omit scope because it should always be "row"
+    Omit<ThHTMLAttributes<HTMLTableCellElement>, 'scope'> {
   as: 'th'
   /** The cell content. */
   children: ReactNode
@@ -38,8 +42,14 @@ export function TableBodyCell({
   justifyContent,
   ...rest
 }: TableBodyCellProps) {
+  const thElementScope = Element === 'th' ? { scope: 'row' } : undefined
   return (
-    <Element {...rest} className={cx(elTableBodyCell, className)} data-justify-content={justifyContent}>
+    <Element
+      {...rest}
+      {...thElementScope}
+      className={cx(elTableBodyCell, className)}
+      data-justify-content={justifyContent}
+    >
       {children}
     </Element>
   )

--- a/src/core/table/body-row/body-row.stories.tsx
+++ b/src/core/table/body-row/body-row.stories.tsx
@@ -85,7 +85,7 @@ const meta = {
 } satisfies Meta<typeof TableBodyRow>
 
 export default meta
-type Story = StoryObj<typeof TableBodyRow>
+type Story = StoryObj<typeof meta>
 
 /**
  * By default, rows do not exhibit any cursor-based interactivity, such has hover styles. This is because

--- a/src/core/table/body-row/styles.ts
+++ b/src/core/table/body-row/styles.ts
@@ -19,7 +19,7 @@ export const elTableBodyRow = css`
   justify-content: inherit;
   width: 100%;
 
-  background: var(--colour-white);
+  background: var(--colour-fill-white);
   border-block-end: var(--border-width-default) solid var(--colour-border-light_default);
   padding: 0;
 


### PR DESCRIPTION
### Context

- #718 added a new `TableBodyCell`.
- It required consumers to manually supply `scope="row"` when using `as="th"`.
- But, this should be handled automatically for consumers.

### This PR

- Updates `TableBodyCell` to auto apply `scope="row"` when `as="th"`
- Updates tests to no longer rely on stories, because `composeStories` wasn't decorating the stories correctly leading to DOM nesting errors under test.