### PR TITLE
chore: ensure valid DOM in table unit tests

### DIFF
--- a/src/core/table/__story__/table-wrapper.tsx
+++ b/src/core/table/__story__/table-wrapper.tsx
@@ -1,0 +1,55 @@
+import { TableBody } from '../body'
+import { TableBodyRow } from '../body-row'
+
+import type { CSSProperties, FC, ReactNode } from 'react'
+
+export type ChildPlacement = 'body' | 'body-cell' | 'body-row' | 'head' | 'header-cell' | 'header-row'
+
+/** Simple factory that returns a component that renders valid table DOM hierarchy around its children */
+export function buildTableWrapper(placement: ChildPlacement): FC<{ children: ReactNode }> {
+  return ({ children }) => {
+    const tableStyle: CSSProperties = {
+      display: 'grid',
+      gridAutoFlow: 'row',
+      gridAutoRows: 'auto',
+      gridTemplateColumns: '1fr 1fr 1fr min-content',
+      justifyContent: 'start',
+      width: '100%',
+    }
+
+    switch (placement) {
+      case 'body':
+        return <table style={tableStyle}>{children}</table>
+      case 'body-cell':
+        return (
+          <table style={tableStyle}>
+            <TableBody>
+              <TableBodyRow style={{ border: 'none' }}>{children}</TableBodyRow>
+            </TableBody>
+          </table>
+        )
+      case 'body-row':
+        return (
+          <table style={tableStyle}>
+            <TableBody>{children}</TableBody>
+          </table>
+        )
+      case 'head':
+        return <table style={tableStyle}>{children}</table>
+      case 'header-cell':
+        return (
+          <table style={tableStyle}>
+            <thead>
+              <tr>{children}</tr>
+            </thead>
+          </table>
+        )
+      case 'header-row':
+        return (
+          <table style={tableStyle}>
+            <thead>{children}</thead>
+          </table>
+        )
+    }
+  }
+}

--- a/src/core/table/__story__/use-table-decorator.tsx
+++ b/src/core/table/__story__/use-table-decorator.tsx
@@ -1,78 +1,18 @@
-import { TableBody } from '../body'
-import { TableBodyRow } from '../body-row'
+import { buildTableWrapper } from './table-wrapper'
 
-import type { CSSProperties } from 'react'
+import type { ChildPlacement } from './table-wrapper'
 import type { Decorator } from '@storybook/react-vite'
 
-type StoryPlacement = 'body' | 'body-cell' | 'body-row' | 'head' | 'header-cell' | 'header-row'
+type StoryPlacement = ChildPlacement
 
 /** Simple story decorator that renders the story in a valid table DOM hierarchy */
 export function useTableDecorator(placement: StoryPlacement): Decorator {
+  const TableWrapper = buildTableWrapper(placement)
   return (Story) => {
-    const tableStyle: CSSProperties = {
-      display: 'grid',
-      gridAutoFlow: 'row',
-      gridAutoRows: 'auto',
-      gridTemplateColumns: '1fr 1fr 1fr min-content',
-      justifyContent: 'start',
-      width: '100%',
-    }
-
-    switch (placement) {
-      case 'body':
-        return (
-          <table style={tableStyle}>
-            <thead />
-            <Story />
-          </table>
-        )
-      case 'body-cell':
-        return (
-          <table style={tableStyle}>
-            <thead />
-            <TableBody>
-              <TableBodyRow style={{ border: 'none' }}>
-                <Story />
-              </TableBodyRow>
-            </TableBody>
-          </table>
-        )
-      case 'body-row':
-        return (
-          <table style={tableStyle}>
-            <thead />
-            <TableBody>
-              <Story />
-            </TableBody>
-          </table>
-        )
-      case 'head':
-        return (
-          <table style={tableStyle}>
-            <Story />
-            <tbody />
-          </table>
-        )
-      case 'header-cell':
-        return (
-          <table style={tableStyle}>
-            <thead>
-              <tr>
-                <Story />
-              </tr>
-            </thead>
-            <tbody />
-          </table>
-        )
-      case 'header-row':
-        return (
-          <table style={tableStyle}>
-            <thead>
-              <Story />
-            </thead>
-            <tbody />
-          </table>
-        )
-    }
+    return (
+      <TableWrapper>
+        <Story />
+      </TableWrapper>
+    )
   }
 }

--- a/src/core/table/body-cell/__tests__/body-cell.test.tsx
+++ b/src/core/table/body-cell/__tests__/body-cell.test.tsx
@@ -1,13 +1,16 @@
-import { TableBodyCell } from '../body-cell'
+import { buildTableWrapper } from '../../__story__/table-wrapper'
 import { render, screen } from '@testing-library/react'
+import { TableBodyCell } from '../body-cell'
+
+const wrapper = buildTableWrapper('body-cell')
 
 test('renders as a cell element by default', () => {
-  render(<TableBodyCell>Content</TableBodyCell>)
+  render(<TableBodyCell>Content</TableBodyCell>, { wrapper })
   expect(screen.getByRole('cell')).toBeVisible()
 })
 
 test('can render as a header cell', () => {
-  render(<TableBodyCell as="th">Content</TableBodyCell>)
+  render(<TableBodyCell as="th">Content</TableBodyCell>, { wrapper })
   expect(screen.getByRole('rowheader')).toBeVisible()
 })
 
@@ -18,26 +21,26 @@ test('can render as a div with no implicit role', () => {
 })
 
 test('applies scope="row" when rendered as a header cell', () => {
-  render(<TableBodyCell as="th">Content</TableBodyCell>)
+  render(<TableBodyCell as="th">Content</TableBodyCell>, { wrapper })
   expect(screen.getByRole('rowheader')).toHaveAttribute('scope', 'row')
 })
 
 test('applies `data-justify-content` when `justifyContent` is provided', () => {
-  render(<TableBodyCell justifyContent="end">Content</TableBodyCell>)
+  render(<TableBodyCell justifyContent="end">Content</TableBodyCell>, { wrapper })
   expect(screen.getByRole('cell')).toHaveAttribute('data-justify-content', 'end')
 })
 
 test('has .el-table-body-cell class', () => {
-  render(<TableBodyCell>Content</TableBodyCell>)
+  render(<TableBodyCell>Content</TableBodyCell>, { wrapper })
   expect(screen.getByRole('cell')).toHaveClass('el-table-body-cell')
 })
 
 test('accepts other classes', () => {
-  render(<TableBodyCell className="custom-class">Content</TableBodyCell>)
+  render(<TableBodyCell className="custom-class">Content</TableBodyCell>, { wrapper })
   expect(screen.getByRole('cell')).toHaveClass('el-table-body-cell custom-class')
 })
 
 test('forwards additional props to the cell', () => {
-  render(<TableBodyCell data-testid="test-id">Content</TableBodyCell>)
+  render(<TableBodyCell data-testid="test-id">Content</TableBodyCell>, { wrapper })
   expect(screen.getByTestId('test-id')).toBe(screen.getByRole('cell'))
 })

--- a/src/core/table/body-row/__tests__/body-row.test.tsx
+++ b/src/core/table/body-row/__tests__/body-row.test.tsx
@@ -1,31 +1,51 @@
-import { composeStories } from '@storybook/react-vite'
+import { buildTableWrapper } from '../../__story__/table-wrapper'
 import { render, screen } from '@testing-library/react'
-import * as tableBodyRowStories from '../body-row.stories'
+import { TableBodyRow } from '../body-row'
 
-const TableBodyRowStories = composeStories(tableBodyRowStories)
+const wrapper = buildTableWrapper('body-row')
 
 test('renders as a cell element by default', () => {
-  render(<TableBodyRowStories.Example />)
+  render(
+    <TableBodyRow>
+      <td />
+    </TableBodyRow>,
+    { wrapper },
+  )
   expect(screen.getByRole('row')).toBeVisible()
 })
 
 test('can render as a div with no implicit role', () => {
-  const { container } = render(<TableBodyRowStories.Divs />)
+  const { container } = render(<TableBodyRow as="div">Foo</TableBodyRow>)
   expect(container.firstElementChild?.tagName).toBe('DIV')
   expect(screen.queryByRole('row')).not.toBeInTheDocument()
 })
 
 test('has .el-table-body-row class', () => {
-  render(<TableBodyRowStories.Example />)
+  render(
+    <TableBodyRow>
+      <td />
+    </TableBodyRow>,
+    { wrapper },
+  )
   expect(screen.getByRole('row')).toHaveClass('el-table-body-row')
 })
 
 test('accepts other classes', () => {
-  render(<TableBodyRowStories.Example className="custom-class" />)
+  render(
+    <TableBodyRow className="custom-class">
+      <td />
+    </TableBodyRow>,
+    { wrapper },
+  )
   expect(screen.getByRole('row')).toHaveClass('el-table-body-row custom-class')
 })
 
 test('forwards additional props to the row', () => {
-  render(<TableBodyRowStories.Example data-testid="test-id" />)
+  render(
+    <TableBodyRow data-testid="test-id">
+      <td />
+    </TableBodyRow>,
+    { wrapper },
+  )
   expect(screen.getByTestId('test-id')).toBe(screen.getByRole('row'))
 })

--- a/src/core/table/body/__tests__/body.test.tsx
+++ b/src/core/table/body/__tests__/body.test.tsx
@@ -1,21 +1,21 @@
+import { buildTableWrapper } from '../../__story__/table-wrapper'
 import { render, screen } from '@testing-library/react'
 import { TableBody } from '../body'
+
+const wrapper = buildTableWrapper('body')
 
 test('renders as a rowgroup element by default', () => {
   render(
     <TableBody>
       <tr />
     </TableBody>,
+    { wrapper },
   )
   expect(screen.getByRole('rowgroup')).toBeVisible()
 })
 
 test('can render as a div with no implicit role', () => {
-  const { container } = render(
-    <TableBody as="div">
-      <div />
-    </TableBody>,
-  )
+  const { container } = render(<TableBody as="div">Foo</TableBody>)
   expect(container.firstElementChild?.tagName).toBe('DIV')
   expect(screen.queryByRole('rowgroup')).not.toBeInTheDocument()
 })
@@ -25,6 +25,7 @@ test('has .el-table-body class', () => {
     <TableBody>
       <tr />
     </TableBody>,
+    { wrapper },
   )
   expect(screen.getByRole('rowgroup')).toHaveClass('el-table-body')
 })
@@ -34,6 +35,7 @@ test('accepts other classes', () => {
     <TableBody className="custom-class">
       <tr />
     </TableBody>,
+    { wrapper },
   )
   expect(screen.getByRole('rowgroup')).toHaveClass('el-table-body custom-class')
 })
@@ -43,6 +45,7 @@ test('forwards additional props to the row', () => {
     <TableBody data-testid="test-id">
       <tr />
     </TableBody>,
+    { wrapper },
   )
   expect(screen.getByTestId('test-id')).toBe(screen.getByRole('rowgroup'))
 })

--- a/src/core/table/more-actions/styles.ts
+++ b/src/core/table/more-actions/styles.ts
@@ -18,6 +18,8 @@ export const elTableRowMoreActionsButton = css`
   background: transparent;
   color: var(--colour-icon-primary);
 
+  cursor: pointer;
+
   /* NOTE: This ensures the button is layered above the table row's primary action */
   z-index: ${TABLE_ROW_INTERACTIVE_ELEMENT_Z_INDEX};
 


### PR DESCRIPTION
Many of the unit tests for our table atoms, whether they're using `composeStories` or not, aren't rendering the subjects under test within a valid table DOM structure. This results in `validateDOMNesting` errors being present in the test output.

This PR extracts the table wrapper setup from `useTableDecorator` to a separate `buildTableWrapper` helper which is used directly by the unit tests.