### PR TITLE
feat: Add new `TableCellSortButton`

### DIFF
--- a/src/core/table/sort-button/__tests__/sort-button.test.tsx
+++ b/src/core/table/sort-button/__tests__/sort-button.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { TableCellSortButton } from '../sort-button'
+
+test('renders as a button element', () => {
+  render(
+    <TableCellSortButton name="address" value="none">
+      Property
+    </TableCellSortButton>,
+  )
+  expect(screen.getByRole('button', { name: 'Property' })).toBeVisible()
+})
+
+test('renders an ARIA hidden icon', () => {
+  const { container } = render(
+    <TableCellSortButton name="address" value="none">
+      Property
+    </TableCellSortButton>,
+  )
+  expect(container.querySelector('svg')).toBeInTheDocument()
+})
+
+test('has .el-table-cell-sort-button class', () => {
+  render(
+    <TableCellSortButton name="address" value="none">
+      Property
+    </TableCellSortButton>,
+  )
+  expect(screen.getByRole('button')).toHaveClass('el-table-cell-sort-button')
+})
+
+test('accepts other classes', () => {
+  render(
+    <TableCellSortButton className="custom-class" name="address" value="none">
+      Property
+    </TableCellSortButton>,
+  )
+  expect(screen.getByRole('button')).toHaveClass('el-table-cell-sort-button custom-class')
+})
+
+test('forwards additional props to the button', () => {
+  render(
+    <TableCellSortButton data-testid="test-id" name="address" value="none">
+      Property
+    </TableCellSortButton>,
+  )
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('button'))
+})

--- a/src/core/table/sort-button/__tests__/sort-direction.test.tsx
+++ b/src/core/table/sort-button/__tests__/sort-direction.test.tsx
@@ -1,0 +1,41 @@
+import { parseSortDirection, getNextSortDirection } from '../sort-direction'
+
+describe('parseSortDirection', () => {
+  test('returns "ascending" when value is "ascending"', () => {
+    expect(parseSortDirection('ascending')).toBe('ascending')
+  })
+
+  test('returns "descending" when value is "ascending"', () => {
+    expect(parseSortDirection('descending')).toBe('descending')
+  })
+
+  test('returns "none" for all other values', () => {
+    expect(parseSortDirection('none')).toBe('none')
+
+    // invalid sort directions
+    expect(parseSortDirection(0)).toBe('none')
+    expect(parseSortDirection(null)).toBe('none')
+    expect(parseSortDirection(undefined)).toBe('none')
+    expect(parseSortDirection('invalid')).toBe('none')
+  })
+})
+
+describe('getNextSortDirection', () => {
+  test('returns "ascending" when current value is "descending"', () => {
+    expect(getNextSortDirection('descending')).toBe('ascending')
+  })
+
+  test('returns "descending" when current value is "ascending"', () => {
+    expect(getNextSortDirection('ascending')).toBe('descending')
+  })
+
+  test('returns "descending" for all other current values', () => {
+    expect(getNextSortDirection('none')).toBe('descending')
+
+    // invalid sort directions
+    expect(getNextSortDirection(0)).toBe('descending')
+    expect(getNextSortDirection(null)).toBe('descending')
+    expect(getNextSortDirection(undefined)).toBe('descending')
+    expect(getNextSortDirection('invalid')).toBe('descending')
+  })
+})

--- a/src/core/table/sort-button/index.ts
+++ b/src/core/table/sort-button/index.ts
@@ -1,0 +1,2 @@
+export * from './sort-button'
+export * from './styles'

--- a/src/core/table/sort-button/sort-button.stories.tsx
+++ b/src/core/table/sort-button/sort-button.stories.tsx
@@ -1,0 +1,132 @@
+import { getNextSortDirection } from './sort-direction'
+import { TableCellSortButton } from './sort-button'
+import { useArgs } from 'storybook/preview-api'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { MouseEventHandler } from 'react'
+import type { SortDirection } from './sort-direction'
+import { Text } from '../../text'
+import { Tooltip } from '../../tooltip'
+
+const meta = {
+  title: 'Core/Table/SortButton',
+  component: TableCellSortButton,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    value: {
+      control: 'select',
+      options: ['ascending', 'descending', 'none'] satisfies SortDirection[],
+    },
+  },
+} satisfies Meta<typeof TableCellSortButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * To indicate that no sort is active for the column, use a value of "none". To change the sort
+ * direction when the button is clicked, the consumer must handle click events and update the state
+ * that determines what value is provided to the button's `value` prop.
+ *
+ * Since the button's value represents the _current_ sort direction, the click event handler must
+ * calculate what the _next_ sort direction will be. This can be acheived using the
+ * `getNextSortDirection` function available from `@reapit/elements/core/table`.
+ */
+export const Example: Story = {
+  args: {
+    children: 'Property',
+    name: 'address',
+    value: 'none',
+  },
+  render: (args) => {
+    const [, setArgs] = useArgs()
+    const updateSortDirection: MouseEventHandler<HTMLButtonElement> = (event) => {
+      setArgs({ value: getNextSortDirection(event.currentTarget.value) })
+    }
+    return <TableCellSortButton {...args} onClick={updateSortDirection} />
+  },
+}
+
+/**
+ * To indicate an ascending sort order for the column, use a value of "ascending".
+ */
+export const Ascending: Story = {
+  args: {
+    ...Example.args,
+    value: 'ascending',
+  },
+}
+
+/**
+ * To indicate a descending sort order for the column, use a value of "descending".
+ */
+export const Descending: Story = {
+  args: {
+    ...Example.args,
+    value: 'descending',
+  },
+}
+
+/**
+ * The sort button inherits `justify-content` from its parent. This allows it to match the alignment
+ * specified for the table header cell in which it resides.
+ */
+export const Alignment: Story = {
+  args: {
+    ...Example.args,
+    value: 'descending',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+          width: '300px',
+          justifyContent: 'end',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Column headers should rarely be permitted to truncate, but when it is unavoidable, it's possible
+ * to allow truncation to occur and to display a tooltip with the unabridged text. When this is
+ * necessary, the tooltip should label the sort button and be displayed when the sort button is
+ * hovered or focused.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Descending.args,
+    'aria-labelledby': 'tooltip',
+    children: (
+      <>
+        <Text id="text" size="2xs" overflow="truncate" weight="bold">
+          Long column header
+        </Text>
+        <Tooltip id="tooltip" triggerId="sort-button" truncationTargetId="text">
+          Long column header
+        </Tooltip>
+      </>
+    ),
+    id: 'sort-button',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          boxSizing: 'content-box',
+          border: '1px solid #FA00FF',
+          width: '100px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/core/table/sort-button/sort-button.tsx
+++ b/src/core/table/sort-button/sort-button.tsx
@@ -1,0 +1,32 @@
+import { cx } from '@linaria/core'
+import { elTableCellSortButton, elTableCellSortButtonIcon } from './styles'
+import { SortDescendIcon } from '#src/icons/sort-descend'
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { SortDirection } from './sort-direction'
+
+// NOTE: we omit...
+// - disabled, because the sort button should never be disabled
+type AttributesToOmit = 'disabled'
+
+interface TableCellSortButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+  /** The sort button's label. */
+  children: ReactNode
+  /** The name of the "field" in the table's data sorted by this button. */
+  name: string
+  /** The current sort direction for this column, if any. */
+  value: SortDirection
+}
+
+/**
+ * A simple button for table column headers that allows users to sort the column in ascending
+ * or descending order. Typically used via `Table.SortButton`.
+ */
+export function TableCellSortButton({ children, className, name, value, ...rest }: TableCellSortButtonProps) {
+  return (
+    <button {...rest} className={cx(elTableCellSortButton, className)} name={name} value={value}>
+      {children}
+      <SortDescendIcon aria-hidden className={elTableCellSortButtonIcon} />
+    </button>
+  )
+}

--- a/src/core/table/sort-button/sort-direction.ts
+++ b/src/core/table/sort-button/sort-direction.ts
@@ -1,0 +1,41 @@
+export type SortDirection = 'ascending' | 'descending' | 'none'
+
+/**
+ * Parses an unknown value into a valid sort direction. Values that are not valid sort directions
+ * will return the default of "none", meaning no sort direction is specified.
+ */
+export function parseSortDirection(value: unknown): SortDirection {
+  switch (value) {
+    case 'ascending':
+    case 'descending':
+      return value
+    default:
+      return 'none'
+  }
+}
+
+/**
+ * Given the current sort direction, if any, determines what the next sort direction will be if the
+ * column sort is changed. The behaviour of column sort directions is described by the
+ * following simple state machine:
+ *
+ * ```
+ * No sort ──► Descending sort ◄─────┐
+ *             └──────► Ascending sort
+ * ```
+ *
+ * If the current sort direction is not valid, it will be treated as "none", which means the next
+ * sort direction will be "descending".
+ */
+export function getNextSortDirection(value: unknown): SortDirection {
+  const currentDirection = parseSortDirection(value)
+
+  switch (currentDirection) {
+    case 'ascending':
+      return 'descending'
+    case 'descending':
+      return 'ascending'
+    case 'none':
+      return 'descending'
+  }
+}

--- a/src/core/table/sort-button/styles.ts
+++ b/src/core/table/sort-button/styles.ts
@@ -1,0 +1,54 @@
+import { css } from '@linaria/core'
+import { font } from '#src/core/text'
+
+export const elTableCellSortButton = css`
+  display: inline-grid;
+  grid-template-columns: minmax(auto, min-content) min-content;
+  grid-template-rows: auto;
+  align-items: center;
+  justify-content: inherit;
+  gap: var(--spacing-1);
+  width: 100%;
+
+  border: none;
+  border-radius: var(--border-radius-m);
+  padding: var(--spacing-2);
+
+  background: transparent;
+  color: var(--colour-text-secondary);
+
+  cursor: pointer;
+
+  ${font('2xs', 'bold')}
+  text-align: center;
+  text-transform: uppercase;
+
+  &:focus-visible {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+
+  &:hover {
+    background: var(--colour-fill-neutral-lightest);
+  }
+`
+
+export const elTableCellSortButtonIcon = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: var(--icon_size-s);
+  height: var(--icon_size-s);
+
+  color: var(--colour-icon-disabled);
+
+  [value='ascending'] & {
+    color: var(--colour-icon-secondary);
+    transform: rotate(180deg);
+  }
+
+  [value='descending'] & {
+    color: var(--colour-icon-secondary);
+  }
+`

--- a/src/icons/make-icon/styles.ts
+++ b/src/icons/make-icon/styles.ts
@@ -6,66 +6,71 @@ export const elIcon = css`
   /* NOTE: necessary when used in an inline or inline-block layout */
   vertical-align: middle;
 
-  &,
-  &[color='primary'] {
-    color: var(--colour-icon-primary);
-  }
-  &[color='secondary'] {
-    color: var(--colour-icon-secondary);
-  }
-  &[color='disabled'] {
-    color: var(--colour-icon-disabled);
-  }
-  &[color='white'] {
-    color: var(--colour-icon-white);
-  }
-  &[color='action'] {
-    color: var(--colour-icon-action);
-  }
-  &[color='pending'] {
-    color: var(--colour-icon-pending);
-  }
-  &[color='warning'] {
-    color: var(--colour-icon-warning);
-  }
-  &[color='error'] {
-    color: var(--colour-icon-error);
-  }
-  &[color='success'] {
-    color: var(--colour-icon-success);
-  }
-  &[color='info'] {
-    color: var(--colour-icon-info);
-  }
-  &[color='accent_1'] {
-    color: var(--colour-icon-accent_1);
-  }
-  &[color='accent_2'] {
-    color: var(--colour-icon-accent_2);
-  }
-  &[color='inherit'] {
-    color: inherit;
-  }
+  /* NOTE: we place these styles inside a layer to allow them to be easily overridden
+   * by a consumer-supplied class that would otherwise have a lower specificity and
+   * therefore have no effect, or require the use of !important */
+  @layer {
+    &,
+    &[color='primary'] {
+      color: var(--colour-icon-primary);
+    }
+    &[color='secondary'] {
+      color: var(--colour-icon-secondary);
+    }
+    &[color='disabled'] {
+      color: var(--colour-icon-disabled);
+    }
+    &[color='white'] {
+      color: var(--colour-icon-white);
+    }
+    &[color='action'] {
+      color: var(--colour-icon-action);
+    }
+    &[color='pending'] {
+      color: var(--colour-icon-pending);
+    }
+    &[color='warning'] {
+      color: var(--colour-icon-warning);
+    }
+    &[color='error'] {
+      color: var(--colour-icon-error);
+    }
+    &[color='success'] {
+      color: var(--colour-icon-success);
+    }
+    &[color='info'] {
+      color: var(--colour-icon-info);
+    }
+    &[color='accent_1'] {
+      color: var(--colour-icon-accent_1);
+    }
+    &[color='accent_2'] {
+      color: var(--colour-icon-accent_2);
+    }
+    &[color='inherit'] {
+      color: inherit;
+    }
 
-  &,
-  &[data-size='100%'] {
-    width: 100%;
-    height: 100%;
-  }
-  &[data-size='xs'] {
-    width: var(--icon_size-xs);
-    height: var(--icon_size-xs);
-  }
-  &[data-size='sm'] {
-    width: var(--icon_size-s);
-    height: var(--icon_size-s);
-  }
-  &[data-size='md'] {
-    width: var(--icon_size-m);
-    height: var(--icon_size-m);
-  }
-  &[data-size='lg'] {
-    width: var(--icon_size-l);
-    height: var(--icon_size-l);
+    &,
+    &[data-size='100%'] {
+      width: 100%;
+      height: 100%;
+    }
+    &[data-size='xs'] {
+      width: var(--icon_size-xs);
+      height: var(--icon_size-xs);
+    }
+    &[data-size='sm'] {
+      width: var(--icon_size-s);
+      height: var(--icon_size-s);
+    }
+    &[data-size='md'] {
+      width: var(--icon_size-m);
+      height: var(--icon_size-m);
+    }
+    &[data-size='lg'] {
+      width: var(--icon_size-l);
+      height: var(--icon_size-l);
+    }
   }
 `


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work focused on atoms involved in the table's body and was completed over a number of PRs: #715, #716, #717, #718, #719 and #720.
- The next chunk of work will be focused on the atoms involved in the table's head:
  - Part 1: Sort button (this PR)
  - Part 2: Header cell
  - Part 3: Header row
  - Part 4: Table head

### This PR

- Adds `TableCellSortButton`.

<img width="824" height="460" alt="Screenshot 2025-08-28 at 10 59 23 pm" src="https://github.com/user-attachments/assets/8c87c607-9532-49d4-94fe-3bef9e8d1b78" />
<img width="819" height="671" alt="Screenshot 2025-08-28 at 10 59 30 pm" src="https://github.com/user-attachments/assets/21571abe-d8db-4a78-b7ab-dbab2c988062" />
<img width="818" height="397" alt="Screenshot 2025-08-28 at 10 59 36 pm" src="https://github.com/user-attachments/assets/3048e08c-9f33-4b00-9d6e-8a435db4a5b7" />
