### PR TITLE
feat: Add new `TableHeaderCell`

### DIFF
--- a/src/core/table/__story__/table-wrapper.tsx
+++ b/src/core/table/__story__/table-wrapper.tsx
@@ -17,6 +17,12 @@ export function buildTableWrapper(placement: ChildPlacement): FC<{ children: Rea
       width: '100%',
     }
 
+    const subgridStyles: CSSProperties = {
+      display: 'grid',
+      gridColumn: '1 / -1',
+      gridTemplateColumns: 'subgrid',
+    }
+
     switch (placement) {
       case 'body':
         return <table style={tableStyle}>{children}</table>
@@ -39,15 +45,15 @@ export function buildTableWrapper(placement: ChildPlacement): FC<{ children: Rea
       case 'header-cell':
         return (
           <table style={tableStyle}>
-            <thead>
-              <tr>{children}</tr>
+            <thead style={subgridStyles}>
+              <tr style={subgridStyles}>{children}</tr>
             </thead>
           </table>
         )
       case 'header-row':
         return (
           <table style={tableStyle}>
-            <thead>{children}</thead>
+            <thead style={subgridStyles}>{children}</thead>
           </table>
         )
     }

--- a/src/core/table/header-cell/__tests__/header-cell.test.tsx
+++ b/src/core/table/header-cell/__tests__/header-cell.test.tsx
@@ -1,0 +1,41 @@
+import { buildTableWrapper } from '../../__story__/table-wrapper'
+import { TableHeaderCell } from '../header-cell'
+import { render, screen } from '@testing-library/react'
+
+const wrapper = buildTableWrapper('header-cell')
+
+test('can render as a header cell by default', () => {
+  render(<TableHeaderCell as="th">Content</TableHeaderCell>, { wrapper })
+  expect(screen.getByRole('columnheader')).toBeVisible()
+})
+
+test('can render as a div with no implicit role', () => {
+  const { container } = render(<TableHeaderCell as="div">Content</TableHeaderCell>)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+  expect(screen.queryByRole('columnheader')).not.toBeInTheDocument()
+})
+
+test('applies scope="col" when rendered as a header cell', () => {
+  render(<TableHeaderCell as="th">Content</TableHeaderCell>, { wrapper })
+  expect(screen.getByRole('columnheader')).toHaveAttribute('scope', 'col')
+})
+
+test('applies `data-justify-self` when `justifySelf` is provided', () => {
+  render(<TableHeaderCell justifySelf="end">Content</TableHeaderCell>, { wrapper })
+  expect(screen.getByRole('columnheader')).toHaveAttribute('data-justify-self', 'end')
+})
+
+test('has .el-table-header-cell class', () => {
+  render(<TableHeaderCell>Content</TableHeaderCell>, { wrapper })
+  expect(screen.getByRole('columnheader')).toHaveClass('el-table-header-cell')
+})
+
+test('accepts other classes', () => {
+  render(<TableHeaderCell className="custom-class">Content</TableHeaderCell>, { wrapper })
+  expect(screen.getByRole('columnheader')).toHaveClass('el-table-header-cell custom-class')
+})
+
+test('forwards additional props to the cell', () => {
+  render(<TableHeaderCell data-testid="test-id">Content</TableHeaderCell>, { wrapper })
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('columnheader'))
+})

--- a/src/core/table/header-cell/header-cell.stories.tsx
+++ b/src/core/table/header-cell/header-cell.stories.tsx
@@ -1,0 +1,113 @@
+import { TableHeaderCell } from './header-cell'
+import { TableCellSortButton } from '../sort-button'
+import { useTableDecorator } from '../__story__/use-table-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/HeaderCell',
+  component: TableHeaderCell,
+  argTypes: {
+    'aria-sort': {
+      control: 'text',
+      description: 'The sort direction currently applied to the column.',
+      table: {
+        type: {
+          summary: "'ascending' | 'descending'",
+        },
+      },
+    },
+    as: {
+      control: false,
+      description: 'The element this table cell will render as.',
+      table: {
+        type: {
+          summary: "'th' | 'div'",
+        },
+      },
+    },
+    children: {
+      control: 'select',
+      description: 'The cell content.',
+      options: ['Plain text', 'Sort label'],
+      mapping: {
+        'Plain text': 'Property',
+        'Sort button': (
+          <TableCellSortButton name="totalAmount" value="descending">
+            Amount
+          </TableCellSortButton>
+        ),
+      },
+      table: {
+        type: {
+          summary: 'ReactNode',
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof TableHeaderCell>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * At their simplest, body cell's will contain a single line of plain text. However, it's important
+ * to understand that, without additional styles for the plain text, it will flow to additional lines
+ * rather than overflow or truncate when there is insufficient space.
+ */
+export const Example: Story = {
+  args: {
+    'aria-sort': undefined,
+    as: 'th',
+    children: 'Plain text',
+  },
+  decorators: [useTableDecorator('header-cell')],
+}
+
+/**
+ * Often, some columns in a table will be sortable. In this case,
+ * [Table.SortButton](./?path=/docs/core-table-sortbutton--docs) can be used as the header cell's content.
+ * Importantly, when the column has an active sort direction, the header cell must have an `aria-sort`
+ * attribute that communicates that sort direction to assistive technologies.
+ */
+export const Sortable: Story = {
+  args: {
+    ...Example.args,
+    'aria-sort': 'descending',
+    children: 'Sort button',
+  },
+  decorators: [useTableDecorator('header-cell')],
+}
+
+/**
+ * Sometimes it may be necessary to render the table cell as a plain `<div>`. Providing
+ * `as="div"` will achieve this outcome. When doing so, it's important to consider whether an
+ * [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+ * should also be specified.
+ */
+export const Divs: Story = {
+  args: {
+    ...Example.args,
+    as: 'div',
+    children: "I'm in a <div>",
+  },
+}
+
+/**
+ * The justification of the cell's content within the cell's bounding box can be specified using
+ * `justifySelf`. There are three options: `start` (default), `center`, and `end`.
+ */
+export const Alignment: Story = {
+  args: {
+    ...Example.args,
+    justifySelf: 'end',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'grid', boxSizing: 'content-box', border: '1px solid #FA00FF' }}>
+        <Story />
+      </div>
+    ),
+    useTableDecorator('header-cell'),
+  ],
+}

--- a/src/core/table/header-cell/header-cell.tsx
+++ b/src/core/table/header-cell/header-cell.tsx
@@ -1,0 +1,49 @@
+import { cx } from '@linaria/core'
+import { elTableHeaderCell } from './styles'
+
+import type { HTMLAttributes, ReactNode, ThHTMLAttributes } from 'react'
+
+interface TableHeaderCellCommonProps {
+  /** The alignment of the cell's content. */
+  justifySelf?: 'start' | 'center' | 'end'
+}
+
+interface TableHeaderCellAsThProps
+  extends TableHeaderCellCommonProps,
+    // NOTE: we omit scope because it should always be "col"
+    Omit<ThHTMLAttributes<HTMLTableCellElement>, 'scope'> {
+  /** The sort direction currently applied to the column. */
+  'aria-sort'?: 'ascending' | 'descending'
+  as?: 'th'
+  /** The cell content. */
+  children: ReactNode
+}
+
+interface TableHeaderCellAsDivProps extends TableHeaderCellCommonProps, HTMLAttributes<HTMLDivElement> {
+  /** The sort direction currently applied to the column. */
+  'aria-sort'?: 'ascending' | 'descending'
+  as: 'div'
+  /** The cell content. */
+  children: ReactNode
+}
+
+type TableHeaderCellProps = TableHeaderCellAsThProps | TableHeaderCellAsDivProps
+
+/**
+ * A basic header cell for a table's head. Does little more than render its children in a `<th>`, or
+ * `<div>` element. Typically used via `Table.HeaderCell`.
+ */
+export function TableHeaderCell({
+  as: Element = 'th',
+  children,
+  className,
+  justifySelf,
+  ...rest
+}: TableHeaderCellProps) {
+  const thElementScope = Element === 'th' ? { scope: 'col' } : undefined
+  return (
+    <Element {...rest} {...thElementScope} className={cx(elTableHeaderCell, className)} data-justify-self={justifySelf}>
+      {children}
+    </Element>
+  )
+}

--- a/src/core/table/header-cell/index.ts
+++ b/src/core/table/header-cell/index.ts
@@ -1,0 +1,2 @@
+export * from './header-cell'
+export * from './styles'

--- a/src/core/table/header-cell/styles.ts
+++ b/src/core/table/header-cell/styles.ts
@@ -1,0 +1,35 @@
+import { css } from '@linaria/core'
+import { elTableCellSortButton } from '../sort-button'
+import { font } from '#src/core/text'
+
+// NOTE: This is a plain class so that we have an exportable class name
+// available for consumers that want table cell styling on an element not
+// supported by the TableHeaderCell component.
+export const elTableHeaderCell = css`
+  display: grid;
+  align-items: center;
+
+  border: none;
+  padding: var(--spacing-2);
+
+  ${font('2xs', 'bold')}
+  color: var(--colour-text-secondary);
+  text-align: left;
+  text-transform: uppercase;
+
+  &[data-justify-self='start'] {
+    justify-self: start;
+  }
+  &[data-justify-self='center'] {
+    justify-self: center;
+  }
+  &[data-justify-self='end'] {
+    justify-self: end;
+  }
+
+  /* When the header cell contains a sort button, we need to remove the cell's inline padding
+   * because the sort button has its own. */
+  &:has(.${elTableCellSortButton}) {
+    padding-inline: 0;
+  }
+`

--- a/src/core/table/sort-button/index.ts
+++ b/src/core/table/sort-button/index.ts
@@ -1,2 +1,3 @@
 export * from './sort-button'
+export * from './sort-direction'
 export * from './styles'


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work focused on atoms involved in the table's body and was completed over a number of PRs: #715, #716, #717, #718, #719, #720 and #721.
- The next chunk of work will be focused on the atoms involved in the table's head:
  - Part 1: #725 
  - Part 2: Header cell (this PR)
  - Part 3: Header row
  - Part 4: Table head

### This PR

- Adds `TableHeaderCell`.

<img width="822" height="444" alt="Screenshot 2025-08-29 at 8 36 54 am" src="https://github.com/user-attachments/assets/c495ef66-e57b-423f-884b-8253116ce309" />
<img width="824" height="669" alt="Screenshot 2025-08-29 at 8 37 01 am" src="https://github.com/user-attachments/assets/95e8a65b-41d6-429d-9427-37e99f3f2d6e" />
<img width="822" height="203" alt="Screenshot 2025-08-29 at 8 37 05 am" src="https://github.com/user-attachments/assets/16e28062-51fb-4d50-9ab9-670493bb95ce" />
