### PR TITLE
feat: Add new `TableHeaderRow`

### DIFF
--- a/src/core/table/__story__/table-wrapper.tsx
+++ b/src/core/table/__story__/table-wrapper.tsx
@@ -1,5 +1,6 @@
 import { TableBody } from '../body'
 import { TableBodyRow } from '../body-row'
+import { TableHeaderRow } from '../header-row'
 
 import type { CSSProperties, FC, ReactNode } from 'react'
 
@@ -46,7 +47,7 @@ export function buildTableWrapper(placement: ChildPlacement): FC<{ children: Rea
         return (
           <table style={tableStyle}>
             <thead style={subgridStyles}>
-              <tr style={subgridStyles}>{children}</tr>
+              <TableHeaderRow style={{ border: 'none' }}>{children}</TableHeaderRow>
             </thead>
           </table>
         )

--- a/src/core/table/header-row/__tests__/header-row.test.tsx
+++ b/src/core/table/header-row/__tests__/header-row.test.tsx
@@ -1,0 +1,51 @@
+import { buildTableWrapper } from '../../__story__/table-wrapper'
+import { render, screen } from '@testing-library/react'
+import { TableHeaderRow } from '../header-row'
+
+const wrapper = buildTableWrapper('header-row')
+
+test('renders as a cell element by default', () => {
+  render(
+    <TableHeaderRow>
+      <td />
+    </TableHeaderRow>,
+    { wrapper },
+  )
+  expect(screen.getByRole('row')).toBeVisible()
+})
+
+test('can render as a div with no implicit role', () => {
+  const { container } = render(<TableHeaderRow as="div">Foo</TableHeaderRow>)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+  expect(screen.queryByRole('row')).not.toBeInTheDocument()
+})
+
+test('has .el-table-header-row class', () => {
+  render(
+    <TableHeaderRow>
+      <td />
+    </TableHeaderRow>,
+    { wrapper },
+  )
+  expect(screen.getByRole('row')).toHaveClass('el-table-header-row')
+})
+
+test('accepts other classes', () => {
+  render(
+    <TableHeaderRow className="custom-class">
+      <td />
+    </TableHeaderRow>,
+    { wrapper },
+  )
+  expect(screen.getByRole('row')).toHaveClass('el-table-header-row custom-class')
+})
+
+test('forwards additional props to the row', () => {
+  render(
+    <TableHeaderRow data-testid="test-id">
+      <td />
+    </TableHeaderRow>,
+    { wrapper },
+  )
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('row'))
+})

--- a/src/core/table/header-row/header-row.stories.tsx
+++ b/src/core/table/header-row/header-row.stories.tsx
@@ -1,0 +1,106 @@
+import { TableCellSortButton } from '../sort-button'
+import { TableHeaderCell } from '../header-cell'
+import { TableHeaderRow } from './header-row'
+import { useTableDecorator } from '../__story__/use-table-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/HeaderRow',
+  component: TableHeaderRow,
+  argTypes: {
+    as: {
+      control: false,
+      description: 'The element this table row will render as.',
+      table: {
+        type: {
+          summary: "'tr' | 'div'",
+        },
+      },
+    },
+    children: {
+      control: 'select',
+      description: 'The row content.',
+      options: ['Static text', 'Sortable columns'],
+      mapping: {
+        'Static text': (
+          <>
+            <TableHeaderCell>Property</TableHeaderCell>
+            <TableHeaderCell>Ownership</TableHeaderCell>
+            <TableHeaderCell>Tenancy</TableHeaderCell>
+            <TableHeaderCell aria-label="Actions">{null}</TableHeaderCell>
+          </>
+        ),
+        'Sortable columns': (
+          <>
+            <TableHeaderCell>Property</TableHeaderCell>
+            <TableHeaderCell>
+              <TableCellSortButton name="total" value="none">
+                Amount
+              </TableCellSortButton>
+            </TableHeaderCell>
+            <TableHeaderCell aria-sort="descending">
+              <TableCellSortButton name="dueDate" value="descending">
+                Due
+              </TableCellSortButton>
+            </TableHeaderCell>
+            <TableHeaderCell aria-label="Actions">{null}</TableHeaderCell>
+          </>
+        ),
+      },
+      table: {
+        type: {
+          summary: 'ReactNode',
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof TableHeaderRow>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * By default, rows do not exhibit any cursor-based interactivity, such has hover styles. This is because
+ * rows themselves are never interactive.
+ */
+export const Example: Story = {
+  args: {
+    as: 'tr',
+    children: 'Static text',
+  },
+  decorators: [useTableDecorator('header-row')],
+}
+
+/**
+ * Any number of columns in the table can be sortable. In this example, two columns have sort buttons
+ * that would allow users to sort the table's data.
+ */
+export const SortableColumns: Story = {
+  args: {
+    as: 'tr',
+    children: 'Sortable columns',
+  },
+  decorators: [useTableDecorator('header-row')],
+}
+
+/**
+ * Sometimes it may be necessary to render the table row as a plain `<div>`. Providing
+ * `as="div"` will achieve this outcome. When doing so, it's important to consider whether an
+ * [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+ * should also be specified.
+ *
+ * Care must also be taken to ensure the descendant cells are also rendered as `<div>` elements,
+ * possibly with explicit ARIA roles as well.
+ */
+export const Divs: Story = {
+  args: {
+    as: 'div',
+    children: <TableHeaderCell as="div">I&apos;m all divs and no a11y 😬</TableHeaderCell>,
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+}

--- a/src/core/table/header-row/header-row.tsx
+++ b/src/core/table/header-row/header-row.tsx
@@ -1,0 +1,33 @@
+import { cx } from '@linaria/core'
+import { elTableHeaderRow } from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface TableHeaderRowAsTrProps extends HTMLAttributes<HTMLTableRowElement> {
+  as?: 'tr'
+  /** The row content. */
+  children: ReactNode
+}
+
+interface TableHeaderRowAsDivProps extends HTMLAttributes<HTMLDivElement> {
+  as: 'div'
+  /** The row content. */
+  children: ReactNode
+}
+
+type TableHeaderRowProps = TableHeaderRowAsTrProps | TableHeaderRowAsDivProps
+
+/**
+ * A basic row for a table's head. Does little more than render it's children in a `<tr>` or `<div>`.
+ * Cells within a row may contain static text or buttons that sort the table column. Cells are
+ * aligned to the table's CSS grid layout via
+ * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid). Typically
+ * used via `Table.HeadingRow`.
+ */
+export function TableHeaderRow({ as: Element = 'tr', children, className, ...rest }: TableHeaderRowProps) {
+  return (
+    <Element {...rest} className={cx(elTableHeaderRow, className)}>
+      {children}
+    </Element>
+  )
+}

--- a/src/core/table/header-row/index.ts
+++ b/src/core/table/header-row/index.ts
@@ -1,0 +1,2 @@
+export * from './header-row'
+export * from './styles'

--- a/src/core/table/header-row/styles.ts
+++ b/src/core/table/header-row/styles.ts
@@ -1,0 +1,27 @@
+import { css } from '@linaria/core'
+
+// NOTE: This is a plain class so that we have an exportable class name
+// available for consumers that want table row styling on an element not
+// supported by the TableHeaderRow component.
+export const elTableHeaderRow = css`
+  /* Relative positioning is critical for the row's primary action to work correctly.
+   * The TableRowPrimaryAction component relies on this relative positioning to position
+   * its ::after pseudo-element over the entire row so that clicks on the row are captured
+   * by the action rather than the row. */
+  position: relative;
+
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  grid-template-rows: auto;
+  align-items: center;
+  justify-content: inherit;
+  width: 100%;
+
+  background: var(--colour-fill-white);
+  border-block-end: var(--border-width-default) solid var(--colour-border-light_default);
+  padding: 0;
+
+  min-height: var(--size-10);
+  max-height: var(--size-12);
+`


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work focused on atoms involved in the table's body and was completed over a number of PRs: #715, #716, #717, #718, #719, #720 and #721.
- The next chunk of work will be focused on the atoms involved in the table's head:
  - Part 1: #725 
  - Part 2: #726 
  - Part 3: Header row (this PR)
  - Part 4: Table head

### This PR

- Adds `TableHeaderRow`.

<img width="820" height="651" alt="Screenshot 2025-08-29 at 9 10 15 am" src="https://github.com/user-attachments/assets/591b490d-54b3-4751-aed8-3b13931a2f6f" />
<img width="822" height="449" alt="Screenshot 2025-08-29 at 9 10 20 am" src="https://github.com/user-attachments/assets/685ecf45-5862-4f5c-93f5-dc0883d41a55" />
