### PR TITLE
feat: Add new `TableHead`

### DIFF
--- a/src/core/table/__story__/table-wrapper.tsx
+++ b/src/core/table/__story__/table-wrapper.tsx
@@ -1,5 +1,6 @@
 import { TableBody } from '../body'
 import { TableBodyRow } from '../body-row'
+import { TableHead } from '../head'
 import { TableHeaderRow } from '../header-row'
 
 import type { CSSProperties, FC, ReactNode } from 'react'
@@ -16,12 +17,6 @@ export function buildTableWrapper(placement: ChildPlacement): FC<{ children: Rea
       gridTemplateColumns: '1fr 1fr 1fr min-content',
       justifyContent: 'start',
       width: '100%',
-    }
-
-    const subgridStyles: CSSProperties = {
-      display: 'grid',
-      gridColumn: '1 / -1',
-      gridTemplateColumns: 'subgrid',
     }
 
     switch (placement) {
@@ -46,15 +41,15 @@ export function buildTableWrapper(placement: ChildPlacement): FC<{ children: Rea
       case 'header-cell':
         return (
           <table style={tableStyle}>
-            <thead style={subgridStyles}>
+            <TableHead>
               <TableHeaderRow style={{ border: 'none' }}>{children}</TableHeaderRow>
-            </thead>
+            </TableHead>
           </table>
         )
       case 'header-row':
         return (
           <table style={tableStyle}>
-            <thead style={subgridStyles}>{children}</thead>
+            <TableHead>{children}</TableHead>
           </table>
         )
     }

--- a/src/core/table/head/__tests__/head.test.tsx
+++ b/src/core/table/head/__tests__/head.test.tsx
@@ -1,0 +1,51 @@
+import { buildTableWrapper } from '../../__story__/table-wrapper'
+import { render, screen } from '@testing-library/react'
+import { TableHead } from '../head'
+
+const wrapper = buildTableWrapper('head')
+
+test('renders as a rowgroup element by default', () => {
+  render(
+    <TableHead>
+      <tr />
+    </TableHead>,
+    { wrapper },
+  )
+  expect(screen.getByRole('rowgroup')).toBeVisible()
+})
+
+test('can render as a div with no implicit role', () => {
+  const { container } = render(<TableHead as="div">Foo</TableHead>)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+  expect(screen.queryByRole('rowgroup')).not.toBeInTheDocument()
+})
+
+test('has .el-table-head class', () => {
+  render(
+    <TableHead>
+      <tr />
+    </TableHead>,
+    { wrapper },
+  )
+  expect(screen.getByRole('rowgroup')).toHaveClass('el-table-head')
+})
+
+test('accepts other classes', () => {
+  render(
+    <TableHead className="custom-class">
+      <tr />
+    </TableHead>,
+    { wrapper },
+  )
+  expect(screen.getByRole('rowgroup')).toHaveClass('el-table-head custom-class')
+})
+
+test('forwards additional props to the row', () => {
+  render(
+    <TableHead data-testid="test-id">
+      <tr />
+    </TableHead>,
+    { wrapper },
+  )
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('rowgroup'))
+})

--- a/src/core/table/head/head.stories.tsx
+++ b/src/core/table/head/head.stories.tsx
@@ -1,0 +1,106 @@
+import { TableCellSortButton } from '../sort-button'
+import { TableHead } from './head'
+import { TableHeaderCell } from '../header-cell'
+import { TableHeaderRow } from '../header-row'
+import { useTableDecorator } from '../__story__/use-table-decorator'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/Head',
+  component: TableHead,
+  argTypes: {
+    as: {
+      control: false,
+      description: 'The element this table row will render as.',
+      table: {
+        type: {
+          summary: "'tbody' | 'div'",
+        },
+      },
+    },
+    children: {
+      control: 'select',
+      description: 'The table rows.',
+      options: ['Static text', 'Sortable columns'],
+      mapping: {
+        'Static text': buildRows('non-sortable'),
+        'Sortable columns': buildRows('sortable'),
+      },
+      table: {
+        type: {
+          summary: 'ReactNode',
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof TableHead>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    as: 'thead',
+    children: 'Static text',
+  },
+  decorators: [useTableDecorator('head')],
+}
+
+/**
+ * Sometimes it may be necessary to render the table row as a plain `<div>`. Providing
+ * `as="div"` will achieve this outcome. When doing so, it's important to consider whether an
+ * [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+ * should also be specified.
+ *
+ * Care must also be taken to ensure the descendant cells are also rendered as `<div>` elements,
+ * possibly with explicit ARIA roles as well.
+ */
+export const Divs: Story = {
+  args: {
+    as: 'div',
+    children: (
+      <TableHeaderRow as="div">
+        <TableHeaderCell as="div">I&apos;m all divs and no a11y 😬</TableHeaderCell>
+      </TableHeaderRow>
+    ),
+  },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
+}
+
+function buildRows(type: 'non-sortable' | 'sortable') {
+  switch (type) {
+    case 'non-sortable': {
+      return (
+        <TableHeaderRow>
+          <TableHeaderCell>Property</TableHeaderCell>
+          <TableHeaderCell>Ownership</TableHeaderCell>
+          <TableHeaderCell>Tenancy</TableHeaderCell>
+          <TableHeaderCell aria-label="Actions">{null}</TableHeaderCell>
+        </TableHeaderRow>
+      )
+    }
+    case 'sortable': {
+      return (
+        <TableHeaderRow>
+          <TableHeaderCell>Property</TableHeaderCell>
+          <TableHeaderCell>
+            <TableCellSortButton name="total" value="none">
+              Amount
+            </TableCellSortButton>
+          </TableHeaderCell>
+          <TableHeaderCell aria-sort="descending">
+            <TableCellSortButton name="dueDate" value="descending">
+              Due
+            </TableCellSortButton>
+          </TableHeaderCell>
+          <TableHeaderCell aria-label="Actions">{null}</TableHeaderCell>
+        </TableHeaderRow>
+      )
+    }
+  }
+}

--- a/src/core/table/head/head.tsx
+++ b/src/core/table/head/head.tsx
@@ -1,0 +1,32 @@
+import { cx } from '@linaria/core'
+import { elTableHead } from './styles'
+
+import type { HTMLAttributes, ReactNode } from 'react'
+
+interface TableHeadAsTheadProps extends HTMLAttributes<HTMLTableSectionElement> {
+  as?: 'thead'
+  /** The table's rows. */
+  children: ReactNode
+}
+
+interface TableHeadAsDivProps extends HTMLAttributes<HTMLDivElement> {
+  as: 'div'
+  /** The table's rows. */
+  children: ReactNode
+}
+
+type TableHeadProps = TableHeadAsTheadProps | TableHeadAsDivProps
+
+/**
+ * A table's head. Does little more than render its children in a `<thead>` or `<div>` element.
+ * Descendants will flow to new rows while columns will align to the table's grid using
+ * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
+ * Typically used via `Table.Head`.
+ */
+export function TableHead({ as: Element = 'thead', children, className, ...rest }: TableHeadProps) {
+  return (
+    <Element {...rest} className={cx(elTableHead, className)}>
+      {children}
+    </Element>
+  )
+}

--- a/src/core/table/head/index.ts
+++ b/src/core/table/head/index.ts
@@ -1,0 +1,2 @@
+export * from './head'
+export * from './styles'

--- a/src/core/table/head/styles.ts
+++ b/src/core/table/head/styles.ts
@@ -1,0 +1,13 @@
+import { css } from '@linaria/core'
+
+export const elTableHead = css`
+  position: sticky;
+  top: 0;
+
+  display: grid;
+  grid-column: 1 / -1;
+  grid-auto-flow: row;
+  grid-auto-rows: auto;
+  grid-template-columns: subgrid;
+  justify-content: inherit;
+`


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work focused on atoms involved in the table's body and was completed over a number of PRs: #715, #716, #717, #718, #719, #720 and #721.
- The next chunk of work will be focused on the atoms involved in the table's head:
  - Part 1: #725 
  - Part 2: #726 
  - Part 3: #727 
  - Part 4: Table head (this PR)

### This PR

- Adds `TableHead`.

<img width="816" height="615" alt="Screenshot 2025-08-29 at 9 17 22 am" src="https://github.com/user-attachments/assets/fa113cf5-4dbd-4e51-9f19-60ee4d15dbb5" />
<img width="821" height="236" alt="Screenshot 2025-08-29 at 9 17 29 am" src="https://github.com/user-attachments/assets/3052590a-fd69-4cfd-afa6-96b95196feac" />
