### PR TITLE
feat: add `font` prop to `Text`

### DIFF
--- a/src/core/table/body-cell/body-cell.stories.tsx
+++ b/src/core/table/body-cell/body-cell.stories.tsx
@@ -139,7 +139,7 @@ export const RowHeader: Story = {
   args: {
     ...Example.args,
     as: 'th',
-    children: <Text weight="medium">I&apos;m in a &lt;th&gt;</Text>,
+    children: <Text font="text-sm/medium">I&apos;m in a &lt;th&gt;</Text>,
   },
   decorators: [useTableDecorator('body-cell')],
 }
@@ -194,7 +194,7 @@ export const Truncation: Story = {
     ...Example.args,
     children: (
       <>
-        <Text id="text" overflow="truncate" size="sm">
+        <Text font="inherit" id="text" overflow="truncate">
           10 Queen Elizabeth St, Melbourne 3100
         </Text>
         <Tooltip id="tooltip" placement="top" triggerId="text" truncationTargetId="text">
@@ -213,7 +213,7 @@ export const EmptyCells: Story = {
   args: {
     ...Example.args,
     children: (
-      <Text colour="placeholder" size="sm">
+      <Text font="inherit" colour="placeholder">
         Not available
       </Text>
     ),

--- a/src/core/table/double-line-layout/double-line-layout.stories.tsx
+++ b/src/core/table/double-line-layout/double-line-layout.stories.tsx
@@ -107,7 +107,7 @@ export const Truncation: Story = {
     ...Example.args,
     children: (
       <>
-        <Text id="primary-text" overflow="truncate" size="sm">
+        <Text font="inherit" id="primary-text" overflow="truncate">
           10 Queen Elizabeth St
         </Text>
         <Tooltip id="primary-tooltip" placement="top" triggerId="primary-text" truncationTargetId="primary-text">
@@ -118,7 +118,7 @@ export const Truncation: Story = {
     mediaItem: 'Image',
     supplementaryData: (
       <>
-        <Text id="supplementary-text" overflow="truncate" size="xs">
+        <Text font="inherit" id="supplementary-text" overflow="truncate">
           Melbourne 3100
         </Text>
         <Tooltip

--- a/src/core/table/primary-data/primary-data.stories.tsx
+++ b/src/core/table/primary-data/primary-data.stories.tsx
@@ -122,7 +122,7 @@ export const Truncation: Story = {
     ...Icons.args,
     children: (
       <>
-        <Text id="text" overflow="truncate">
+        <Text font="inherit" id="text" overflow="truncate">
           10 Queen Elizabeth St, Melbourne 3100
         </Text>
         <Tooltip id="tooltip" placement="top" triggerId="text" truncationTargetId="text">

--- a/src/core/table/sort-button/sort-button.stories.tsx
+++ b/src/core/table/sort-button/sort-button.stories.tsx
@@ -106,7 +106,7 @@ export const Truncation: Story = {
     'aria-labelledby': 'tooltip',
     children: (
       <>
-        <Text id="text" size="2xs" overflow="truncate" weight="bold">
+        <Text font="inherit" id="text" overflow="truncate">
           Long column header
         </Text>
         <Tooltip id="tooltip" triggerId="sort-button" truncationTargetId="text">

--- a/src/core/text/__tests__/text.test.tsx
+++ b/src/core/text/__tests__/text.test.tsx
@@ -16,7 +16,7 @@ test('renders as the specified HTML element', () => {
 
 test('applies data attributes for colour, overflow, size, and weight', () => {
   render(
-    <Text as="em" colour="secondary" overflow="truncate" size="xl" weight="bold">
+    <Text as="em" colour="secondary" font="text-xl/bold" overflow="truncate">
       Styled text
     </Text>,
   )
@@ -25,6 +25,38 @@ test('applies data attributes for colour, overflow, size, and weight', () => {
   expect(el).toHaveAttribute('data-font-size', 'xl')
   expect(el).toHaveAttribute('data-font-weight', 'bold')
   expect(el).toHaveAttribute('data-overflow', 'truncate')
+})
+
+test('defaults to text-base/regular when no font, size or weight props are provided', () => {
+  render(<Text>Styled text</Text>)
+  const el = screen.getByText('Styled text')
+  expect(el).toHaveAttribute('data-font-size', 'base')
+  expect(el).toHaveAttribute('data-font-weight', 'regular')
+})
+
+test('uses deprecated size/weight props when at least one is specified and font is not', () => {
+  render(<Text size="md">Styled text</Text>)
+  const el = screen.getByText('Styled text')
+  expect(el).toHaveAttribute('data-font-size', 'md')
+  expect(el).toHaveAttribute('data-font-weight', 'regular')
+})
+
+test('uses font size/weight when specified when deprecated size/weight are also specified', () => {
+  render(
+    <Text font="text-3xl/bold" size="md" weight="medium">
+      Styled text
+    </Text>,
+  )
+  const el = screen.getByText('Styled text')
+  expect(el).toHaveAttribute('data-font-size', '3xl')
+  expect(el).toHaveAttribute('data-font-weight', 'bold')
+})
+
+test('uses font size/weight when specified and deprecated size/weight are not', () => {
+  render(<Text font="text-3xl/bold">Styled text</Text>)
+  const el = screen.getByText('Styled text')
+  expect(el).toHaveAttribute('data-font-size', '3xl')
+  expect(el).toHaveAttribute('data-font-weight', 'bold')
 })
 
 test('forwards additional props to the rendered element', () => {

--- a/src/core/text/styles.ts
+++ b/src/core/text/styles.ts
@@ -14,7 +14,12 @@ export const elText = css`
 `
 
 function generateElTextFontStyles() {
-  return fontSizes
+  return `
+  &[data-font-size='inherit'][data-font-weight='inherit'] {
+    font: inherit;
+  }
+
+  ${fontSizes
     .map((size) => {
       return fontWeights
         .map((weight) => {
@@ -26,7 +31,8 @@ function generateElTextFontStyles() {
         })
         .join('\n')
     })
-    .join('\n')
+    .join('\n')}
+  `
 }
 
 function generateElTextColourStyles() {

--- a/src/core/text/text.stories.tsx
+++ b/src/core/text/text.stories.tsx
@@ -91,40 +91,33 @@ export const Colour: Story = {
 }
 
 /**
- * The `size` prop controls the font size.
+ * The `font` prop controls the font size and weight.
  */
-export const Size: Story = {
+export const FontStyle: Story = {
   args: {
     ...Example.args,
-    size: 'xs',
+    font: 'text-2xl/bold',
   },
 }
 
 /**
- * The `weight` prop controls the font weight.
- */
-export const Weight: Story = {
-  args: {
-    ...Example.args,
-    as: 'strong',
-    weight: 'bold',
-  },
-}
-
-/**
- * Usage of Text can be nested within other Text components. This can be useful when you need to prototype spans
- * of differently coloured text within a larger block of text.
+ * Both `font` and `colour` accept "inherit" as values. This allows for nested Text usage, which is
+ * useful when you need a child span to be styled differently from its parent while inheriting the
+ * other properties. However, because our font styles are always size/weight pairs, it is not possible
+ * to inherit the font size separate to it's weight.
  *
- * **Important:** The size and weight of the nested text do **NOT** inherit from the parent.
+ * This example shows a smaller span of text inheriting the font size and weight of its parent while
+ * colouring itself differently.
  */
-export const Nesting: Story = {
+export const Inheritance: Story = {
   args: {
     ...Example.args,
+    font: 'text-xs/bold',
   },
   render: (args) => (
     <Text {...args}>
       This is a span of text that includes a{' '}
-      <Text as="strong" colour="error" weight="medium">
+      <Text as="strong" colour="error" font="inherit">
         nested span of text.
       </Text>
     </Text>
@@ -139,7 +132,7 @@ export const Nesting: Story = {
  */
 export const Overflow: Story = {
   args: {
-    ...Example.args,
+    ...Inheritance.args,
     overflow: 'truncate',
   },
   decorators: [
@@ -152,7 +145,7 @@ export const Overflow: Story = {
   render: (args) => (
     <Text {...args}>
       This is a span of text that includes a{' '}
-      <Text as="strong" colour="error" weight="medium">
+      <Text as="strong" colour="error" font="inherit">
         nested span of text.
       </Text>
     </Text>

--- a/src/core/text/text.tsx
+++ b/src/core/text/text.tsx
@@ -4,10 +4,19 @@ import { elText } from './styles'
 import type { FontSize, FontWeight, TextColour } from './types'
 import type { HTMLAttributes, QuoteHTMLAttributes, TimeHTMLAttributes } from 'react'
 
+type FontStyle = `text-${FontSize}/${FontWeight}` | 'inherit'
+
 interface BaseTextProps {
   colour?: TextColour
+  /**
+   * Defines the font style the text should use. Defaults to `inherit` when not provided.
+   * When both `font` and `size`/`weight` are provided, `font` takes precedence.
+   */
+  font?: FontStyle
   overflow?: 'truncate'
+  /** @deprecated Use `font` prop instead */
   size?: FontSize
+  /** @deprecated Use `font` prop instead */
   weight?: FontWeight
 }
 
@@ -70,19 +79,56 @@ export function Text({
   as: Element = 'span',
   className,
   colour = 'inherit',
+  font,
   overflow,
-  size = 'base',
-  weight = 'regular',
+  size: deprecatedSizeProp,
+  weight: deprecatedWeightProp,
   ...rest
 }: TextProps) {
+  // We use the deprecated props if neither font, size nor weight are specified, OR if no font is specified
+  // but at least one of size or weight are.
+  const useDeprecatedProps =
+    (!font && !deprecatedSizeProp && !deprecatedWeightProp) || (!font && (deprecatedSizeProp || deprecatedWeightProp))
+
+  // NOTE: we default `font` to "inherit" here, instead of in our props destructuring above, because
+  // we need to know when `font` is explicitly provided vs when it's not so we can know whether we
+  // should be using the size and weight derived from it versus using the deprecated size/weight props.
+  const { size, weight } = parseFont(font ?? 'inherit')
+
   return (
     <Element
       className={cx(elText, className)}
       data-colour={colour}
       data-overflow={overflow}
-      data-font-size={size}
-      data-font-weight={weight}
+      data-font-size={useDeprecatedProps ? deprecatedSizeProp ?? 'base' : size}
+      data-font-weight={useDeprecatedProps ? deprecatedWeightProp ?? 'regular' : weight}
       {...(rest as HTMLAttributes<HTMLElement>)}
     />
   )
+}
+
+type InferFontSize<T extends FontStyle> = T extends `text-${infer Size}/${string}` ? Size : 'inherit'
+type InferFontWeight<T extends FontStyle> = T extends `text-${string}/${infer Weight}` ? Weight : 'inherit'
+
+interface ParseFontResult<T extends FontStyle> {
+  size: InferFontSize<T>
+  weight: InferFontWeight<T>
+}
+
+/**
+ * Parses a font style string like "text-base/regular" into its size and weight components.
+ *
+ * @example
+ * const { size, weight } = parseFont('text-base/regular')
+ * // size === 'base' and weight === 'regular'
+ */
+function parseFont<T extends FontStyle>(font: T): ParseFontResult<T> {
+  if (font === 'inherit') {
+    return { size: 'inherit', weight: 'inherit' } as ParseFontResult<T>
+  }
+
+  const [textSize, weight] = font.split('/')
+  const size = textSize.replace('text-', '')
+
+  return { size, weight } as ParseFontResult<T>
 }


### PR DESCRIPTION
### Context

- One of the key annoyances of `Text` is the inability to inherit font styles.
- This is largely because size and weight are always explicitly paired together in our design tokens, so we cannot, at the CSS level, inherit one but not the other. That is, we cannot compute what design token would be applied if size should inherit but weight changes.
- Further, when one of size or weight are specified, but not the other, the code reads as though only the specified value is changing, but this is not the case. Rather, the unspecified value will use the prop's default value; for size, this is `base`, and for weight, this is `regular`. This is not obvious to readers.

### This PR

- Adds a new prop called `font` to the `Text` component. This prop must be given a string that matches a valid size/weight combination, or the special `'inherit'` value; e.g., `text-sm/medium` or `text-3xl/bold`.
- Deprecates the existing `size` and `weight` props and maintains backwards compatibility with them.
- Updates usage within the new table atoms to prefer `font` over `size`/`weight`.