### PR TITLE
fix: `Table.HeaderCell` renders as a `td` when it has no cell content

### DIFF
--- a/src/core/table/header-cell/__tests__/header-cell.test.tsx
+++ b/src/core/table/header-cell/__tests__/header-cell.test.tsx
@@ -4,9 +4,14 @@ import { render, screen } from '@testing-library/react'
 
 const wrapper = buildTableWrapper('header-cell')
 
-test('can render as a header cell by default', () => {
+test('renders as a header cell by default', () => {
   render(<TableHeaderCell as="th">Content</TableHeaderCell>, { wrapper })
   expect(screen.getByRole('columnheader')).toBeVisible()
+})
+
+test('renders as a cell when its empty and not being explicitly rendered as a div', () => {
+  render(<TableHeaderCell />, { wrapper })
+  expect(screen.getByRole('cell')).toBeVisible()
 })
 
 test('can render as a div with no implicit role', () => {

--- a/src/core/table/header-cell/header-cell.tsx
+++ b/src/core/table/header-cell/header-cell.tsx
@@ -4,6 +4,8 @@ import { elTableHeaderCell } from './styles'
 import type { HTMLAttributes, ReactNode, ThHTMLAttributes } from 'react'
 
 interface TableHeaderCellCommonProps {
+  /** The cell content. */
+  children?: ReactNode
   /** The alignment of the cell's content. */
   justifySelf?: 'start' | 'center' | 'end'
 }
@@ -15,16 +17,12 @@ interface TableHeaderCellAsThProps
   /** The sort direction currently applied to the column. */
   'aria-sort'?: 'ascending' | 'descending'
   as?: 'th'
-  /** The cell content. */
-  children: ReactNode
 }
 
 interface TableHeaderCellAsDivProps extends TableHeaderCellCommonProps, HTMLAttributes<HTMLDivElement> {
   /** The sort direction currently applied to the column. */
   'aria-sort'?: 'ascending' | 'descending'
   as: 'div'
-  /** The cell content. */
-  children: ReactNode
 }
 
 type TableHeaderCellProps = TableHeaderCellAsThProps | TableHeaderCellAsDivProps
@@ -34,12 +32,15 @@ type TableHeaderCellProps = TableHeaderCellAsThProps | TableHeaderCellAsDivProps
  * `<div>` element. Typically used via `Table.HeaderCell`.
  */
 export function TableHeaderCell({
-  as: Element = 'th',
+  as: ElementProp = 'th',
   children,
   className,
   justifySelf,
   ...rest
 }: TableHeaderCellProps) {
+  // If there's no children (i.e. it's an empty cell), we need to render as a <td>, not a <th>, but this
+  // only relevant if we're rendering as a <th> element in the first-place.
+  const Element = !children && ElementProp === 'th' ? 'td' : ElementProp
   const thElementScope = Element === 'th' ? { scope: 'col' } : undefined
   return (
     <Element {...rest} {...thElementScope} className={cx(elTableHeaderCell, className)} data-justify-self={justifySelf}>

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -30,6 +30,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
   - Table head: `Table.Head`, `Table.HeaderRow`, `Table.HeaderCell`, and `Table.SortButton`
   - Table body: `Table.Body`, `Table.BodyRow`, `Table.BodyCell`, `Table.PrimaryAction`,`Table.PrimaryActionButton`, `Table.MoreActions`, `Table.DoubleLineLayout` and `Table.PrimaryData`.
 - **chore!:** Refactored `Pagination` to now support anchor-based pagination links instead of being restricted to buttons. The `onPageChange` prop has been deprecated and will be removed in a future version, while the `currentPage` prop has been renamed to `pageNumber`.
+- **fix:** `Table.HeaderCell` now renders as a `<td>` if it has no cell content and is not being rendered as a `<div>`.
 
 ### **5.0.0-beta.46 - 25/08/25**
 


### PR DESCRIPTION
What it says on the tin.

Header cells are not permitted to have empty content: https://dequeuniversity.com/rules/axe/4.8/empty-table-header?application=axeAPI