### PR TITLE
feat: add `Input` with support for `type='checkbox'`

### DIFF
--- a/src/core/input/__tests__/input.test.tsx
+++ b/src/core/input/__tests__/input.test.tsx
@@ -1,0 +1,7 @@
+import { Input } from '../input'
+import { render, screen } from '@testing-library/react'
+
+test('can render a checkbox element', () => {
+  render(<Input type="checkbox" />)
+  expect(screen.getByRole('checkbox')).toBeVisible()
+})

--- a/src/core/input/checkbox/__tests__/checkbox.test.tsx
+++ b/src/core/input/checkbox/__tests__/checkbox.test.tsx
@@ -1,0 +1,49 @@
+import { InputCheckbox } from '../checkbox'
+import { render, screen } from '@testing-library/react'
+
+test('renders a checkbox element in a container div', () => {
+  const { container } = render(<InputCheckbox />)
+  expect(container.firstElementChild?.tagName).toBe('DIV')
+  expect(screen.getByRole('checkbox')).toBeVisible()
+  expect(screen.getByRole('checkbox').parentElement).toBe(container.firstElementChild)
+})
+
+// NOTE: we can't test the CSS `display: none` behaviour of the checkbox component
+// because it relies CSS behaviour that does not appear to be supported by RTL or behaviour
+// fake DOM environment. Hence, we simply test for the presence of the icons in the DOM.
+test('displays an ARIA hidden unchecked icon with `data-show-when="unchecked"` attribute', () => {
+  const { container } = render(<InputCheckbox />)
+  const uncheckedIcon = container.querySelector('[data-show-when="unchecked"]')
+  expect(uncheckedIcon).toBeInTheDocument()
+  expect(uncheckedIcon).toHaveAttribute('aria-hidden', 'true')
+})
+
+test('displays an ARIA hidden checked icon with `data-show-when="checked"` attribute', () => {
+  const { container } = render(<InputCheckbox checked />)
+  const checkedIcon = container.querySelector('[data-show-when="checked"]')
+  expect(checkedIcon).toBeInTheDocument()
+  expect(checkedIcon).toHaveAttribute('aria-hidden', 'true')
+})
+
+test('displays an ARIA hidden indeterminate icon with `data-show-when="indeterminate"` attribute', () => {
+  const { container } = render(<InputCheckbox />)
+  const indeterminateIcon = container.querySelector('[data-show-when="indeterminate"]')
+  expect(indeterminateIcon).toBeInTheDocument()
+  expect(indeterminateIcon).toHaveAttribute('aria-hidden', 'true')
+})
+
+test('forwards `className` to the root container element', () => {
+  const { container } = render(<InputCheckbox className="my-class" />)
+  expect(container.firstElementChild).toHaveClass('my-class')
+  expect(screen.getByRole('checkbox')).not.toHaveClass('my-class')
+})
+
+test('forwards `style` to the root container element', () => {
+  const { container } = render(<InputCheckbox style={{ color: 'red' }} />)
+  expect(container.firstElementChild).toHaveStyle({ color: 'red' })
+})
+
+test('forwards additional props to the checkbox element', () => {
+  render(<InputCheckbox data-testid="my-checkbox" />)
+  expect(screen.getByRole('checkbox')).toHaveAttribute('data-testid', 'my-checkbox')
+})

--- a/src/core/input/checkbox/checkbox.tsx
+++ b/src/core/input/checkbox/checkbox.tsx
@@ -1,0 +1,32 @@
+import { CheckboxIcon } from '#src/icons/checkbox'
+import { CheckboxIndeterminateIcon } from '#src/icons/checkbox-indeterminate'
+import { CheckboxSelectedIcon } from '#src/icons/checkbox-selected'
+import { ElInputCheckbox, ElInputCheckboxContainer, elInputCheckboxIcon } from './styles'
+import { forwardRef } from 'react'
+
+import type { InputHTMLAttributes } from 'react'
+
+// NOTE: we omit...
+// - type, because this should always be a checkbox-type input.
+type AttributesToOmit = 'type'
+
+export interface CheckboxInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {}
+
+/**
+ * A basic `<input type="checkbox">` component. Used internally by `Input`; not intended for direct use.
+ */
+export const InputCheckbox = forwardRef<HTMLInputElement, CheckboxInputProps>(({ className, style, ...rest }, ref) => {
+  return (
+    // Consumer-supplied class names and inline styles are applied to the root "container" element,
+    // not the input. This is because we don't want consumers to _easily_ override the input's styles
+    // as they're specific to the correct functioning of the component.
+    <ElInputCheckboxContainer className={className} style={style}>
+      <ElInputCheckbox {...rest} ref={ref} type="checkbox" />
+      <CheckboxIndeterminateIcon aria-hidden className={elInputCheckboxIcon} data-show-when="indeterminate" />
+      <CheckboxSelectedIcon aria-hidden className={elInputCheckboxIcon} data-show-when="checked" />
+      <CheckboxIcon aria-hidden className={elInputCheckboxIcon} data-show-when="unchecked" />
+    </ElInputCheckboxContainer>
+  )
+})
+
+InputCheckbox.displayName = 'CheckboxInput'

--- a/src/core/input/checkbox/index.ts
+++ b/src/core/input/checkbox/index.ts
@@ -1,0 +1,2 @@
+export * from './checkbox'
+export * from './styles'

--- a/src/core/input/checkbox/styles.ts
+++ b/src/core/input/checkbox/styles.ts
@@ -1,0 +1,90 @@
+import { css } from '@linaria/core'
+import { styled } from '@linaria/react'
+
+export const ElInputCheckboxContainer = styled.div`
+  position: relative;
+
+  /* We want the container to "shrinkwrap" its content so that the sizing is determined by
+   * out checkbox icons */
+  width: min-content;
+  height: min-content;
+`
+
+export const ElInputCheckbox = styled.input`
+  /* We absolutely position the checkbox input so that it covers the whole container.
+   * this ensures any padding applied to the container by a consumer is "included" in
+   * the input's "hit area". */
+  position: absolute;
+  inset: 0;
+
+  width: 100%;
+  height: 100%;
+
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`
+
+export const elInputCheckboxIcon = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  /* We don't want any pointer events for these icons. Rather, we want the pointer events
+   * to be received by the input element. */
+  pointer-events: none;
+
+  width: var(--icon_size-l);
+  height: var(--icon_size-l);
+
+  /* Unchecked colours */
+  color: var(--comp-select-colour-icon-default-unchecked);
+
+  input:invalid ~ & {
+    color: var(--comp-select-colour-icon-error-unchecked);
+  }
+
+  input:disabled ~ & {
+    color: var(--comp-select-colour-icon-disabled-unchecked);
+  }
+
+  /* Checked/indeterminate colours */
+  input:is(:checked, :indeterminate) ~ & {
+    color: var(--comp-select-colour-icon-default-checked);
+  }
+
+  input:invalid:is(:checked, :indeterminate) ~ & {
+    color: var(--comp-select-colour-icon-error-checked);
+  }
+
+  input:disabled:is(input:checked, input:indeterminate) ~ & {
+    color: var(--comp-select-colour-icon-disabled-checked);
+  }
+
+  /* Focus outline */
+  input:focus-visible ~ & {
+    border-radius: var(--border-radius-m);
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: -1px;
+  }
+
+  /* When the checkbox is indeterminate, hide all but the indeterminate icon */
+  input:indeterminate ~ &:not([data-show-when='indeterminate']) {
+    display: none;
+  }
+
+  /* When the checkbox is checked, but not indeterminate, hide all but the checked icon */
+  input:checked:not(:indeterminate) ~ &:not([data-show-when='checked']) {
+    display: none;
+  }
+
+  /* When the checkbox is neither checked nor indeterminate, hide all but the unchecked icon */
+  input:not(:checked, :indeterminate) ~ &:not([data-show-when='unchecked']) {
+    display: none;
+  }
+`

--- a/src/core/input/index.ts
+++ b/src/core/input/index.ts
@@ -1,0 +1,2 @@
+export * from './checkbox'
+export * from './input'

--- a/src/core/input/input.stories.tsx
+++ b/src/core/input/input.stories.tsx
@@ -1,0 +1,69 @@
+import { Input } from './input'
+import { useArgs } from 'storybook/preview-api'
+import { useEffect, useRef } from 'react'
+
+import type { ChangeEventHandler } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Input',
+  component: Input,
+  argTypes: {
+    type: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof Input>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Example: Story = {
+  args: {
+    'aria-label': 'My input',
+    disabled: false,
+    name: 'myInput',
+    readOnly: false,
+    type: 'checkbox',
+    value: 'Hello!',
+  },
+}
+
+/**
+ * Like any native input, the checkbox can be controlled or uncontrolled by consumers.
+ */
+export const Checkbox: Story = {
+  args: {
+    ...Example.args,
+    type: 'checkbox',
+  },
+  render: (args) => {
+    const [, setArgs] = useArgs()
+    const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+      setArgs({ checked: event.currentTarget.checked })
+    }
+    return <Input {...args} onChange={onChange} />
+  },
+}
+
+/**
+ * While it does not support an indeterminate prop that can be controlled by consumers, the checkbox
+ * does support an indeterminate state via the
+ * [:indeterminate](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) CSS pseudo-class.
+ * Like any native checkbox, this state can be activated by setting the input element's `indeterminate`
+ * property programmatically.
+ */
+export const IndeterminateCheckbox: Story = {
+  args: {
+    ...Checkbox.args,
+  },
+  render: (args) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = true
+      }
+    }, [])
+    return <Input {...args} ref={inputRef} />
+  },
+}

--- a/src/core/input/input.tsx
+++ b/src/core/input/input.tsx
@@ -1,0 +1,36 @@
+import { InputCheckbox } from './checkbox'
+import { forwardRef } from 'react'
+
+import type { InputHTMLAttributes } from 'react'
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Used to name the form control when there is no other visual or accessible name. */
+  'aria-label'?: string
+  /** Indicates whether the checkbox or radio is checked. */
+  checked?: boolean
+  /** Whether the form control is disabled. */
+  disabled?: boolean
+  /** Name of the form control. Submitted with the form as part of a name/value pair. */
+  name?: string
+  /**
+   * Whether the input's value is editable. Does not apply to `hidden`, `range`, `color`,
+   * `checkbox`, or `radio` inputs.
+   */
+  readOnly?: boolean
+  /**
+   * Whether a value is required or must be checked for the form to be submittable.
+   */
+  required?: boolean
+  /** Type of form control. */
+  type: 'checkbox'
+  /** The value of the form control. */
+  value?: string
+}
+
+/**
+ * A thin, low-level wrapper around the native HTML `<input>` element. Like its native counterpart,
+ * labels and custom validation messages are BYO.
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  return <InputCheckbox {...props} ref={ref} />
+})

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -31,6 +31,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
   - Table body: `Table.Body`, `Table.BodyRow`, `Table.BodyCell`, `Table.PrimaryAction`,`Table.PrimaryActionButton`, `Table.MoreActions`, `Table.DoubleLineLayout` and `Table.PrimaryData`.
 - **chore!:** Refactored `Pagination` to now support anchor-based pagination links instead of being restricted to buttons. The `onPageChange` prop has been deprecated and will be removed in a future version, while the `currentPage` prop has been renamed to `pageNumber`.
 - **fix:** `Table.HeaderCell` now renders as a `<td>` if it has no cell content and is not being rendered as a `<div>`.
+- **feat:** Added new `Input` component. Currently, it only supports `type="checkbox"`, but this will be expanded in future.
 
 ### **5.0.0-beta.46 - 25/08/25**
 


### PR DESCRIPTION
### Context

- We're delivering new core table components and we require a checkbox component to enable row selection.
- The existing Checkbox component includes a lot of functionality that is simply irrelevant to row selection (such as visual labels and supplementary information).
- Ideally, we want a thin wrapper around an `<input type="checkbox">` so that we have the correct checkbox visual appearance, without any of the additional label handling. That way, this low-level input component can be used internally by Checkbox and our row selection table component.

### This PR

- Adds a new `Input` component with support for `type="checkbox"`. This component will be expanded to support other input types and represents the lowest-level styled input component in Elements.

<img width="824" height="691" alt="Screenshot 2025-09-02 at 7 39 13 am" src="https://github.com/user-attachments/assets/dda10948-c2d4-4c91-a440-278cd5002475" />
<img width="825" height="671" alt="Screenshot 2025-09-02 at 7 39 22 am" src="https://github.com/user-attachments/assets/9d4ab28d-ed73-4425-889e-1fd241d387e1" />
