### PR TITLE
fix: `InputCheckbox` focus outline

### DIFF
--- a/src/core/input/checkbox/styles.ts
+++ b/src/core/input/checkbox/styles.ts
@@ -70,7 +70,7 @@ export const elInputCheckboxIcon = css`
   input:focus-visible ~ & {
     border-radius: var(--border-radius-m);
     outline: var(--border-width-double) solid var(--colour-border-focus);
-    outline-offset: -1px;
+    outline-offset: var(--border-width-default);
   }
 
   /* When the checkbox is indeterminate, hide all but the indeterminate icon */


### PR DESCRIPTION
The new `InputCheckbox` component (used internally by `Input`) based it's focus outline styles on the Checkbox component in Figma, but these styles are non-standard. This PR updates them to match the focus outline styles shown for the row selection checkboxes in the table design in Figma.