### PR TITLE
feat: add `Table.Checkbox`

### DIFF
--- a/src/core/input/checkbox/styles.ts
+++ b/src/core/input/checkbox/styles.ts
@@ -2,12 +2,19 @@ import { css } from '@linaria/core'
 import { styled } from '@linaria/react'
 
 export const ElInputCheckboxContainer = styled.div`
+  /* We need relative positioning to allow the input to be absolutely positioned covers
+   * the whole container. */
   position: relative;
 
-  /* We want the container to "shrinkwrap" its content so that the sizing is determined by
-   * out checkbox icons */
-  width: min-content;
-  height: min-content;
+  /* We place these styles inside a layer to allow them to be easily overridden by a
+    * consumer-supplied class that would otherwise have a lower specificity and therefore
+    * have no effect or require the use of !important */
+  @layer {
+    /* By default, We want the container to "shrinkwrap" its content so that the sizing is
+     * determined by the checkbox icons */
+    width: min-content;
+    height: min-content;
+  }
 `
 
 export const ElInputCheckbox = styled.input`

--- a/src/core/input/input.stories.tsx
+++ b/src/core/input/input.stories.tsx
@@ -12,6 +12,14 @@ const meta = {
     type: {
       control: 'text',
     },
+    value: {
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string | number | readonly string[] | undefined',
+        },
+      },
+    },
   },
 } satisfies Meta<typeof Input>
 

--- a/src/core/input/input.tsx
+++ b/src/core/input/input.tsx
@@ -24,7 +24,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** Type of form control. */
   type: 'checkbox'
   /** The value of the form control. */
-  value?: string
+  value?: InputHTMLAttributes<HTMLInputElement>['value']
 }
 
 /**

--- a/src/core/table/body-cell/body-cell.stories.tsx
+++ b/src/core/table/body-cell/body-cell.stories.tsx
@@ -5,6 +5,7 @@ import { StarIcon } from '#src/icons/star'
 import { StatusIndicator } from '#src/core/status-indicator'
 import { SupplementaryInfo } from '../../supplementary-info'
 import { TableBodyCell } from './body-cell'
+import { TableCellCheckbox } from '../checkbox'
 import { TableCellDoubleLineLayout } from '../double-line-layout/double-line-layout'
 import { TableCellPrimaryData } from '../primary-data'
 import { TagGroup } from '#src/core/tag-group'
@@ -77,6 +78,7 @@ const meta = {
             <TagGroup.Item>Tag 3</TagGroup.Item>
           </TagGroup>
         ),
+        Checkbox: <TableCellCheckbox aria-label="Select Mary Jane" name="selections" value="1" />,
         Skeleton: <Skeleton />,
       },
       table: {
@@ -233,6 +235,33 @@ export const Alignment: Story = {
   },
   decorators: [
     useTableDecorator('body-cell', '300px'),
+    (Story) => (
+      // NOTE: This div wraps the entire table.
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: 'min-content' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * In some cases, the content of the cell may want to fill the full height of the row and the full
+ * width of the column. In this case, `hasNoPadding` can be used to remove the cell's default padding.
+ * This is particularly useful for allowing a checkbox's hit area to fill the whole cell to help avoid
+ * miss-clicks that activate the row's primary action (if one is present).
+ *
+ * This example demonstrates this with a [Table.Checkbox](./?path=/docs/core-table-checkbox--docs) in
+ * a fixed-width column (typically, we'd use `min-content` for a row selection column). Since
+ * `Table.Checkbox` is designed to fill its parent, its hit area includes the entire cell.
+ */
+export const NoPadding: Story = {
+  args: {
+    ...Example.args,
+    children: 'Checkbox',
+    hasNoPadding: true,
+  },
+  decorators: [
+    useTableDecorator('body-cell', 'var(--size-64)'),
     (Story) => (
       // NOTE: This div wraps the entire table.
       <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: 'min-content' }}>

--- a/src/core/table/body-cell/body-cell.tsx
+++ b/src/core/table/body-cell/body-cell.tsx
@@ -4,6 +4,11 @@ import { elTableBodyCell } from './styles'
 import type { HTMLAttributes, ReactNode, TdHTMLAttributes, ThHTMLAttributes } from 'react'
 
 interface TableBodyCellCommonProps {
+  /**
+   * Remove default padding. Useful for cells that contain an interactive element whose hit area
+   * should fill the entire cell.
+   */
+  hasNoPadding?: boolean
   /** The alignment of the cell's content. */
   justifySelf?: 'start' | 'center' | 'end'
 }
@@ -35,10 +40,23 @@ type TableBodyCellProps = TableBodyCellAsTdProps | TableBodyCellAsThProps | Tabl
  * A basic cell for a table's body. Does little more than render its children in a `<td>`,
  * `<th>`, or `<div>` element. Typically used via `Table.BodyCell`.
  */
-export function TableBodyCell({ as: Element = 'td', children, className, justifySelf, ...rest }: TableBodyCellProps) {
+export function TableBodyCell({
+  as: Element = 'td',
+  children,
+  className,
+  hasNoPadding,
+  justifySelf,
+  ...rest
+}: TableBodyCellProps) {
   const thElementScope = Element === 'th' ? { scope: 'row' } : undefined
   return (
-    <Element {...rest} {...thElementScope} className={cx(elTableBodyCell, className)} data-justify-self={justifySelf}>
+    <Element
+      {...rest}
+      {...thElementScope}
+      className={cx(elTableBodyCell, className)}
+      data-has-no-padding={hasNoPadding}
+      data-justify-self={justifySelf}
+    >
       {children}
     </Element>
   )

--- a/src/core/table/body-cell/styles.ts
+++ b/src/core/table/body-cell/styles.ts
@@ -16,6 +16,10 @@ export const elTableBodyCell = css`
 
   overflow: hidden;
 
+  &[data-has-no-padding='true'] {
+    padding: 0;
+  }
+
   &[data-justify-self='start'] {
     --__table-column-justification: start;
     justify-self: start;

--- a/src/core/table/body-row/body-row.stories.tsx
+++ b/src/core/table/body-row/body-row.stories.tsx
@@ -2,6 +2,7 @@ import { Avatar } from '#src/core/avatar'
 import { Menu } from '#src/core/menu'
 import { TableBodyCell } from '../body-cell'
 import { TableBodyRow } from './body-row'
+import { TableCellCheckbox } from '../checkbox'
 import { TableCellDoubleLineLayout } from '../double-line-layout'
 import { TableRowPrimaryAction } from '../primary-action'
 import { TableRowMoreActions } from '../more-actions'
@@ -27,11 +28,11 @@ const meta = {
     children: {
       control: 'select',
       description: 'The row content.',
-      options: ['Plain text', 'Primary action', 'Double-line'],
+      options: ['Plain text', 'Primary action', 'Double-line', 'Selectable', 'Selected'],
       mapping: {
         'Plain text': (
           <>
-            <TableBodyCell>10 Hay St, Melbourne 3100</TableBodyCell>
+            <TableBodyCell as="th">10 Hay St, Melbourne 3100</TableBodyCell>
             <TableBodyCell>Data</TableBodyCell>
             <TableBodyCell>Data</TableBodyCell>
             <TableBodyCell>
@@ -44,7 +45,7 @@ const meta = {
         ),
         'Primary action': (
           <>
-            <TableBodyCell as="th" scope="row">
+            <TableBodyCell as="th">
               <TableRowPrimaryAction href={href}>10 Hay St, Melbourne 3100</TableRowPrimaryAction>
             </TableBodyCell>
             <TableBodyCell>Data</TableBodyCell>
@@ -59,7 +60,47 @@ const meta = {
         ),
         'Double-line': (
           <>
+            <TableBodyCell as="th">
+              <TableCellDoubleLineLayout mediaItem={<Avatar>MJ</Avatar>} supplementaryData="Engineer">
+                <TableRowPrimaryAction href={href}>Mary Jane</TableRowPrimaryAction>
+              </TableCellDoubleLineLayout>
+            </TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
             <TableBodyCell>
+              <TableRowMoreActions aria-label="More actions for Mary Jane">
+                <Menu.Item>Action 1</Menu.Item>
+                <Menu.Item>Action 2</Menu.Item>
+              </TableRowMoreActions>
+            </TableBodyCell>
+          </>
+        ),
+        Selectable: (
+          <>
+            <TableBodyCell>
+              <TableCellCheckbox aria-label="Select Mary Jane" name="selections" value="1" />
+            </TableBodyCell>
+            <TableBodyCell as="th">
+              <TableCellDoubleLineLayout mediaItem={<Avatar>MJ</Avatar>} supplementaryData="Engineer">
+                <TableRowPrimaryAction href={href}>Mary Jane</TableRowPrimaryAction>
+              </TableCellDoubleLineLayout>
+            </TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+            <TableBodyCell>Data</TableBodyCell>
+            <TableBodyCell>
+              <TableRowMoreActions aria-label="More actions for Mary Jane">
+                <Menu.Item>Action 1</Menu.Item>
+                <Menu.Item>Action 2</Menu.Item>
+              </TableRowMoreActions>
+            </TableBodyCell>
+          </>
+        ),
+        Selected: (
+          <>
+            <TableBodyCell>
+              <TableCellCheckbox aria-label="Select Mary Jane" checked name="selections" value="1" />
+            </TableBodyCell>
+            <TableBodyCell as="th">
               <TableCellDoubleLineLayout mediaItem={<Avatar>MJ</Avatar>} supplementaryData="Engineer">
                 <TableRowPrimaryAction href={href}>Mary Jane</TableRowPrimaryAction>
               </TableCellDoubleLineLayout>
@@ -133,6 +174,30 @@ export const DoubleLineContent: Story = {
     children: 'Double-line',
   },
   decorators: [useTableDecorator('body-row')],
+}
+
+/**
+ * When rows are selectable, they will have a [Table.Checkbox](./?path=/docs/core-table-checkbox--docs)
+ * present in the leading column.
+ */
+export const Selectable: Story = {
+  args: {
+    ...Example.args,
+    children: 'Selectable',
+  },
+  decorators: [useTableDecorator('body-row', 'min-content 1fr 1fr 1fr min-content')],
+}
+
+/**
+ * When the row's selection checkbox is checked, the row will be visually highlighted to indicate it
+ * has been selected.
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    children: 'Selected',
+  },
+  decorators: Selectable.decorators,
 }
 
 /**

--- a/src/core/table/body-row/styles.ts
+++ b/src/core/table/body-row/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@linaria/core'
-import { elTableRowPrimaryAction } from '../primary-action/styles'
+import { elTableRowPrimaryAction } from '../primary-action'
 
 // NOTE: This is a plain class so that we have an exportable class name
 // available for consumers that want table row styling on an element not
@@ -24,6 +24,13 @@ export const elTableBodyRow = css`
 
   min-height: var(--size-10);
   max-height: var(--size-18);
+
+  /* For now, we don't differentiate between individual checked inputs (which may include checkboxes
+   * or radio buttons) in the row. Rather, we assume the only checked input in the row is the one for
+   * selecting the row. This may change in future, but it's the simplest approach for now. */
+  &:has(input:checked) {
+    background: var(--colour-fill-action-lightest);
+  }
 
   &:has(.${elTableRowPrimaryAction}):hover {
     background: var(--colour-fill-neutral-lightest);

--- a/src/core/table/body/body.stories.tsx
+++ b/src/core/table/body/body.stories.tsx
@@ -3,6 +3,7 @@ import { Menu } from '#src/core/menu'
 import { TableBody } from './body'
 import { TableBodyCell } from '../body-cell'
 import { TableBodyRow } from '../body-row'
+import { TableCellCheckbox } from '../checkbox'
 import { TableCellDoubleLineLayout } from '../double-line-layout'
 import { TableRowPrimaryAction } from '../primary-action'
 import { TableRowMoreActions } from '../more-actions'
@@ -50,7 +51,7 @@ export const Example: Story = {
     as: 'tbody',
     children: 'Double-line',
   },
-  decorators: [useTableDecorator('body')],
+  decorators: [useTableDecorator('body', 'min-content 1fr 1fr 1fr min-content')],
 }
 
 /**
@@ -86,6 +87,9 @@ function buildRows(type: 'single-line' | 'double-line') {
       return (
         <>
           <TableBodyRow>
+            <TableBodyCell>
+              <TableCellCheckbox aria-label="Select 10 Hay St, Melbourne 3100" name="selections" value="1" />
+            </TableBodyCell>
             <TableBodyCell as="th">
               <TableRowPrimaryAction href={href}>10 Hay St, Melbourne 3100</TableRowPrimaryAction>
             </TableBodyCell>
@@ -100,6 +104,13 @@ function buildRows(type: 'single-line' | 'double-line') {
           </TableBodyRow>
 
           <TableBodyRow>
+            <TableBodyCell>
+              <TableCellCheckbox
+                aria-label="Select 45 Queen Elizabeth St, Melbourne 3100"
+                name="selections"
+                value="2"
+              />
+            </TableBodyCell>
             <TableBodyCell as="th">
               <TableRowPrimaryAction href={href}>45 Queen Elizabeth St, Melbourne 3100</TableRowPrimaryAction>
             </TableBodyCell>
@@ -119,6 +130,9 @@ function buildRows(type: 'single-line' | 'double-line') {
       return (
         <>
           <TableBodyRow>
+            <TableBodyCell>
+              <TableCellCheckbox aria-label="Select Mary Jane" name="selections" value="1" />
+            </TableBodyCell>
             <TableBodyCell as="th">
               <TableCellDoubleLineLayout mediaItem={<Avatar>MJ</Avatar>} supplementaryData="Engineer">
                 <TableRowPrimaryAction href={href}>Mary Jane</TableRowPrimaryAction>
@@ -135,6 +149,9 @@ function buildRows(type: 'single-line' | 'double-line') {
           </TableBodyRow>
 
           <TableBodyRow>
+            <TableBodyCell>
+              <TableCellCheckbox aria-label="Select John Smith" name="selections" value="2" />
+            </TableBodyCell>
             <TableBodyCell as="th">
               <TableCellDoubleLineLayout mediaItem={<Avatar>JS</Avatar>} supplementaryData="Engineer">
                 <TableRowPrimaryAction href={href}>John Smith</TableRowPrimaryAction>

--- a/src/core/table/checkbox/__tests__/checkbox.test.tsx
+++ b/src/core/table/checkbox/__tests__/checkbox.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { TableCellCheckbox } from '../checkbox'
+
+test('renders as a checkbox element', () => {
+  render(<TableCellCheckbox />)
+  expect(screen.getByRole('checkbox')).toBeVisible()
+})
+
+test('has .el-table-cell-checkbox class', () => {
+  const { container } = render(<TableCellCheckbox />)
+  // NOTE: We don't use getByRole here because it's not the checkbox element that receives
+  // the class, rather it's the checkbox's parent. To rely on this knowledge here would be to couple
+  // this test to an implementation concern. For the purpose of testing this subject, we just want
+  // to ensure the el-table-cell-checkbox class is present on _some_ element.
+  expect(container.querySelector('.el-table-cell-checkbox')).toHaveClass('el-table-cell-checkbox')
+})
+
+test('accepts other classes', () => {
+  // NOTE: Again, we don't use getByRole here because it's not the checkbox element that receives
+  // the class, rather it's the checkbox's parent. To rely on this knowledge here would be to couple
+  // this test to an implementation concern. For the purpose of testing this subject, we just want
+  // to ensure our custom class also reaches the DOM.
+  const { container } = render(<TableCellCheckbox className="custom-class" />)
+  expect(container.querySelector('.el-table-cell-checkbox')).toHaveClass('el-table-cell-checkbox custom-class')
+})
+
+test('forwards additional props to the checkbox element', () => {
+  render(<TableCellCheckbox data-testid="test-id" />)
+  expect(screen.getByTestId('test-id')).toBe(screen.getByRole('checkbox'))
+})

--- a/src/core/table/checkbox/checkbox.stories.tsx
+++ b/src/core/table/checkbox/checkbox.stories.tsx
@@ -1,0 +1,78 @@
+import { TableCellCheckbox } from './checkbox'
+import { useArgs } from 'storybook/preview-api'
+import { useEffect, useRef } from 'react'
+
+import type { ChangeEventHandler } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/Table/Checkbox',
+  component: TableCellCheckbox,
+  argTypes: {
+    checked: {
+      control: 'boolean',
+    },
+    value: {
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string | number | readonly string[] | undefined',
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof TableCellCheckbox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * The checkbox is designed to fill its parent container. In the case of tables, this should mean it will
+ * fill the entire cell (i.e., the full height of the row and the full width of the column). This is to
+ * ensure the checkbox has a larger hit area than it would naturally possess to help avoid miss-clicks.
+ *
+ * Importantly, since table cells apply padding by default, this padding should typically be disabled toto
+ * allow the checkbox to trully take up the maximum space possible. See
+ * [the No Padding story for Table.BodyCell](./?path=/docs/core-table-bodycell--nopadding) and
+ * [the No Padding story for Table.HeaderCell](./?path=/docs/core-table-headercell--nopadding) for
+ * examples on how to do this.
+ */
+export const Example: Story = {
+  args: {
+    'aria-label': 'Select 10 Hay St, Melbourne 3100',
+    checked: undefined,
+    disabled: false,
+    form: undefined,
+    name: 'selectedRows',
+    value: 'abc-123',
+  },
+  render: (args) => {
+    const [, setArgs] = useArgs()
+    const updateSortDirection: ChangeEventHandler<HTMLInputElement> = (event) => {
+      setArgs({ checked: event.currentTarget.checked })
+    }
+    return <TableCellCheckbox {...args} onChange={updateSortDirection} />
+  },
+}
+
+/**
+ * While it does not support an indeterminate prop that can be controlled by consumers, the checkbox
+ * does support an indeterminate state via the
+ * [:indeterminate](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) CSS pseudo-class.
+ * Like any native checkbox, this state can be activated by setting the input element's `indeterminate`
+ * property programmatically.
+ */
+export const Indeterminate: Story = {
+  args: {
+    ...Example.args,
+  },
+  render: (args) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = true
+      }
+    }, [])
+    return <TableCellCheckbox {...args} ref={inputRef} />
+  },
+}

--- a/src/core/table/checkbox/checkbox.tsx
+++ b/src/core/table/checkbox/checkbox.tsx
@@ -1,0 +1,40 @@
+import { cx } from '@linaria/core'
+import { elTableCellCheckbox } from './styles'
+import { Input } from '#src/core/input'
+
+import { forwardRef, type InputHTMLAttributes } from 'react'
+
+// NOTE: we omit...
+// - type, because this component will always be a checkbox input
+type AttributesToOmit = 'type'
+
+export interface TableCellCheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
+  /** The accessible name for the checkbox. */
+  'aria-label': string
+  /** Indicates whether the checkbox or radio is checked. */
+  checked?: boolean
+  /** Whether the checkbox is disabled. Typically, row selection checkboxes should avoid being disabled. */
+  disabled?: boolean
+  /** The form this checkbox is associated with. */
+  form?: string
+  /**
+   * Name of the checkbox. Submitted as part of a name/value pair. Will typically be the same name as
+   * all other checkboxes in the same column of the table.
+   */
+  name?: string
+  /**
+   * The value that should be submitted with a form when the checkbox is checked. Will typically be
+   * the ID of the entity represented by the row this checkbox is a descendant of.
+   */
+  value?: InputHTMLAttributes<HTMLInputElement>['value']
+}
+
+/**
+ * A thin wrapper around [Input's checkbox implementation](./?path=/docs/core-input--docs) that is geared
+ * for use in tables built with [Table](./?path=/docs/core-table--docs).
+ */
+export const TableCellCheckbox = forwardRef<HTMLInputElement, TableCellCheckboxProps>(({ className, ...rest }, ref) => {
+  return <Input {...rest} className={cx(elTableCellCheckbox, className)} ref={ref} type="checkbox" />
+})
+
+TableCellCheckbox.displayName = 'TableCellCheckbox'

--- a/src/core/table/checkbox/index.ts
+++ b/src/core/table/checkbox/index.ts
@@ -1,0 +1,2 @@
+export * from './checkbox'
+export * from './styles'

--- a/src/core/table/checkbox/styles.ts
+++ b/src/core/table/checkbox/styles.ts
@@ -1,0 +1,16 @@
+import { css } from '@linaria/core'
+import { TABLE_ROW_INTERACTIVE_ELEMENT_Z_INDEX } from '../constants'
+
+export const elTableCellCheckbox = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  height: 100%;
+  width: 100%;
+  min-width: var(--size-10);
+  padding: var(--spacing-2);
+
+  /* NOTE: This ensures the checkbox is layered above the table row's primary action */
+  z-index: ${TABLE_ROW_INTERACTIVE_ELEMENT_Z_INDEX};
+`

--- a/src/core/table/header-cell/header-cell.stories.tsx
+++ b/src/core/table/header-cell/header-cell.stories.tsx
@@ -1,4 +1,5 @@
 import { TableHeaderCell } from './header-cell'
+import { TableCellCheckbox } from '../checkbox'
 import { TableCellSortButton } from '../sort-button'
 import { Text } from '#src/core/text'
 import { Tooltip } from '#src/core/tooltip'
@@ -39,6 +40,7 @@ const meta = {
             Amount
           </TableCellSortButton>
         ),
+        Checkbox: <TableCellCheckbox aria-label="Select all rows" name="selectAll" />,
       },
       table: {
         type: {
@@ -138,6 +140,33 @@ export const Alignment: Story = {
   decorators: [
     useTableDecorator('header-cell', '150px'),
     (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: 'min-content' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * In some cases, the content of the cell may want to fill the full height of the row and the full
+ * width of the column. In this case, `hasNoPadding` can be used to remove the cell's default padding.
+ * This is particularly useful for allowing a checkbox's hit area to fill the whole cell to help avoid
+ * miss-clicks that activate the row's primary action (if one is present).
+ *
+ * This example demonstrates this with a [Table.Checkbox](./?path=/docs/core-table-checkbox--docs) in
+ * a fixed-width column (typically, we'd use `min-content` for a row selection column). Since
+ * `Table.Checkbox` is designed to fill its parent, its hit area includes the entire cell.
+ */
+export const NoPadding: Story = {
+  args: {
+    ...Example.args,
+    children: 'Checkbox',
+    hasNoPadding: true,
+  },
+  decorators: [
+    useTableDecorator('header-cell', 'var(--size-64)'),
+    (Story) => (
+      // NOTE: This div wraps the entire table.
       <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: 'min-content' }}>
         <Story />
       </div>

--- a/src/core/table/header-cell/header-cell.tsx
+++ b/src/core/table/header-cell/header-cell.tsx
@@ -6,6 +6,11 @@ import type { HTMLAttributes, ReactNode, ThHTMLAttributes } from 'react'
 interface TableHeaderCellCommonProps {
   /** The cell content. */
   children?: ReactNode
+  /**
+   * Remove default padding. Useful for cells that contain an interactive element whose hit area
+   * should fill the entire cell.
+   */
+  hasNoPadding?: boolean
   /** The alignment of the cell's content. */
   justifySelf?: 'start' | 'center' | 'end'
 }
@@ -35,6 +40,7 @@ export function TableHeaderCell({
   as: ElementProp = 'th',
   children,
   className,
+  hasNoPadding,
   justifySelf,
   ...rest
 }: TableHeaderCellProps) {
@@ -43,7 +49,13 @@ export function TableHeaderCell({
   const Element = !children && ElementProp === 'th' ? 'td' : ElementProp
   const thElementScope = Element === 'th' ? { scope: 'col' } : undefined
   return (
-    <Element {...rest} {...thElementScope} className={cx(elTableHeaderCell, className)} data-justify-self={justifySelf}>
+    <Element
+      {...rest}
+      {...thElementScope}
+      className={cx(elTableHeaderCell, className)}
+      data-has-no-padding={hasNoPadding}
+      data-justify-self={justifySelf}
+    >
       {children}
     </Element>
   )

--- a/src/core/table/header-cell/styles.ts
+++ b/src/core/table/header-cell/styles.ts
@@ -19,6 +19,10 @@ export const elTableHeaderCell = css`
   text-align: var(--__table-column-justification);
   text-transform: uppercase;
 
+  &[data-has-no-padding='true'] {
+    padding: 0;
+  }
+
   &[data-justify-self='start'] {
     --__table-column-justification: start;
     justify-self: start;

--- a/src/core/table/primary-data/primary-data.stories.tsx
+++ b/src/core/table/primary-data/primary-data.stories.tsx
@@ -6,7 +6,7 @@ import { StatusIndicator } from '#src/core/status-indicator'
 import { TableCellPrimaryData } from './primary-data'
 import { TagGroup } from '#src/core/tag-group'
 import { Text } from '#src/core/text'
-import { Tooltip } from '../../tooltip'
+import { Tooltip } from '#src/core/tooltip'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 

--- a/src/core/table/sort-button/sort-button.stories.tsx
+++ b/src/core/table/sort-button/sort-button.stories.tsx
@@ -1,12 +1,12 @@
 import { getNextSortDirection } from './sort-direction'
 import { TableCellSortButton } from './sort-button'
+import { Text } from '#src/core/text'
+import { Tooltip } from '#src/core/tooltip'
 import { useArgs } from 'storybook/preview-api'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { MouseEventHandler } from 'react'
 import type { SortDirection } from './sort-direction'
-import { Text } from '../../text'
-import { Tooltip } from '../../tooltip'
 
 const meta = {
   title: 'Core/Table/SortButton',

--- a/src/core/table/styles.ts
+++ b/src/core/table/styles.ts
@@ -6,10 +6,9 @@ export const elTable = css`
   display: grid;
   grid-auto-flow: row;
   grid-auto-rows: auto;
-  grid-template-columns: var(--__table-columns);
   justify-items: var(--__table-column-justification);
   justify-content: var(--__table-column-justification);
-  width: '100%';
+  width: 100%;
 
   &[data-justify-items='start'] {
     --__table-column-justification: start;

--- a/src/core/table/table.tsx
+++ b/src/core/table/table.tsx
@@ -14,6 +14,7 @@ import { TableRowPrimaryAction } from './primary-action'
 import { TableRowPrimaryActionButton } from './primary-action/primary-action-button'
 
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
+import { TableCellCheckbox } from './checkbox'
 
 interface CommonTablePros {
   /**
@@ -51,16 +52,18 @@ type TableProps = TableAsTableProps | TableAsDivProps
  * Tables are built by composing the following components:
  * - **Table head:** [Table.Head](./?path=/docs/core-table-head--docs),
  * [Table.HeaderRow](./?path=/docs/core-table-headerrow--docs),
- * [Table.HeaderCell](./?path=/docs/core-table-headercell--docs), and
- * [Table.SortButton](./?path=/docs/core-table-sortbutton--docs)
+ * [Table.HeaderCell](./?path=/docs/core-table-headercell--docs),
+ * [Table.SortButton](./?path=/docs/core-table-sortbutton--docs), and
+ * [Table.Checkbox](./?path=/docs/core-table-checkbox--docs)
  *
  * - **Table body:** [Table.Body](./?path=/docs/core-table-body--docs),
  * [Table.BodyRow](./?path=/docs/core-table-bodyrow--docs),
  * [Table.BodyCell](./?path=/docs/core-table-bodycell--docs),
  * [Table.PrimaryAction](./?path=/docs/core-table-primaryaction--docs),
  * [Table.MoreActions](./?path=/docs/core-table-moreactions--docs),
- * [Table.DoubleLineLayout](./?path=/docs/core-table-doublelinelayout--docs), and
- * [Table.PrimaryData](./?path=/docs/core-table-primarydata--docs)
+ * [Table.DoubleLineLayout](./?path=/docs/core-table-doublelinelayout--docs),
+ * [Table.PrimaryData](./?path=/docs/core-table-primarydata--docs), and
+ * [Table.Checkbox](./?path=/docs/core-table-checkbox--docs)
  */
 export function Table({
   as: Element = 'table',
@@ -96,3 +99,5 @@ Table.Head = TableHead
 Table.HeaderCell = TableHeaderCell
 Table.HeaderRow = TableHeaderRow
 Table.SortButton = TableCellSortButton
+
+Table.Checkbox = TableCellCheckbox

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -34,6 +34,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Added new `Input` component. Currently, it only supports `type="checkbox"`, but this will be expanded in future.
 - **chore!:** Remove `CheckboxDisabledIcon`.
 - **chore!:** Remove `RadioDisabledIcon`.
+- **feat:** Added new `Table.Checkbox` component. This forms the first foundational component for enabling row selection and batch actions in tables.
 
 ### **5.0.0-beta.46 - 25/08/25**
 


### PR DESCRIPTION
### Context

- We have table atoms in `@reapit/elements/lab/table`, but these don't facilitate the level of nuance required by the DS. For example:
  - They are pinned to semantic table elements like `td`, `tr` and so on, but we may need the flexibility of using them in a div-based DOM structure instead.
  - They do not provide any solution for the primary row action (which is meant to _appear_ like the row itself is interactive).
  - They do not provide any solution for rendering row header cells.
  - They require column widths to be defined at the cell-level of the table rather than once at the table-level.
- We want to enhance the capability of our table atoms when implementing "official" core versions of them (i.e. the table atoms that will be available via `@reapit/elements/core/table`.
- The first chunk of this work focused on atoms involved in the table's body and was completed over a number of PRs: #715, #716, #717, #718, #719, #720 and #721.
- The second chunk of work focused on the atoms involved in the table's head: #725, #726, #727, #728.
- The next chunk of work is focused on row selection and batch actions and will include:
  - Part 1: Table checkbox (this PR)
  - Part 2: Table toolbar
  - (maybe) Part 3: Batch actions

### This PR

- Adds `TableCellCheckbox`.
- Updates `TableBodyCell` and `TableHeaderCell` to support the removal of their default padding.
- Updates `TableBodyRow` to support "selected" styling.
- Adds row selection examples to some docs.

### `TableCheckbox`
<img width="824" height="596" alt="Screenshot 2025-09-02 at 4 09 52 pm" src="https://github.com/user-attachments/assets/b327114a-b51c-43e8-8966-aba13ab7090a" />
<img width="820" height="665" alt="Screenshot 2025-09-02 at 4 10 01 pm" src="https://github.com/user-attachments/assets/c472e880-5517-4728-ba47-69e4dddaac59" />

### `TableBodyCell` and `TableHeaderCell`
<img width="819" height="280" alt="Screenshot 2025-09-02 at 4 10 16 pm" src="https://github.com/user-attachments/assets/2e5a6300-de91-40c9-a01a-5f02a44d5770" />

### `TableBodyRow`
<img width="821" height="439" alt="Screenshot 2025-09-02 at 4 10 26 pm" src="https://github.com/user-attachments/assets/65ec0fe6-253f-4666-bda6-022f9c9dbbd2" />

### `TableBody`
<img width="815" height="228" alt="Screenshot 2025-09-02 at 4 10 38 pm" src="https://github.com/user-attachments/assets/39046466-d48a-45f4-8bec-67172bde472d" />
