### PR TITLE
fix: `Tag` text now has the correct colour

### DIFF
--- a/src/core/tag/styles.ts
+++ b/src/core/tag/styles.ts
@@ -6,6 +6,7 @@ export const ElTag = styled.span`
 
   border-radius: var(--comp-tag-border-radius);
   background: var(--comp-tag-colour-fill);
+  color: var(--comp-tag-colour-text);
 
   ${font('xs', 'medium')}
   white-space: nowrap;

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.48 - ??/??/25**
 
-- TBC
+- **fix:** `Tag` text now has the correct colour.
 
 ### **5.0.0-beta.47 - 03/09/25**
 


### PR DESCRIPTION
### Before
<img width="75" height="43" alt="Screenshot 2025-09-04 at 11 57 14 am" src="https://github.com/user-attachments/assets/f965f334-96cd-47e6-be5c-6a142e8b38e5" />

### After
<img width="82" height="44" alt="Screenshot 2025-09-04 at 11 57 04 am" src="https://github.com/user-attachments/assets/e51160e8-2bb9-4d7e-b60b-849309750eaa" />
