### PR TITLE
feat: add `SelectNative`

### DIFF
--- a/src/core/compact-select-native/compact-select-native.tsx
+++ b/src/core/compact-select-native/compact-select-native.tsx
@@ -1,6 +1,6 @@
-import { forwardRef } from 'react'
-import { ElCompactSelectNative, ElCompactSelectNativeContainer, ElCompactSelectNativeIconContainer } from './styles'
 import { ChevronDownIcon } from '#src/icons/chevron-down'
+import { ElCompactSelectNative, ElCompactSelectNativeContainer, ElCompactSelectNativeIconContainer } from './styles'
+import { forwardRef } from 'react'
 
 import type { ReactNode, SelectHTMLAttributes } from 'react'
 
@@ -12,6 +12,15 @@ type AttributesToOmit = 'size' | 'multiple'
 export interface CompactSelectNativeProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, AttributesToOmit> {
   /** The accessible name of the select */
   'aria-label': string
+  /**
+   * Specifies what, if any, permission the user agent has to provide automated assistance in filling
+   * out form field values, as well as guidance to the browser as to the type of information expected
+   * in the field. See [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
+   * docs on MDN.
+   *
+   * Default's to `off` to avoid PII being used in forms.
+   */
+  autoComplete?: 'off' | 'on' | (string & {})
   /** The options for the select. Must be `<option>` or `<optgroup>` elements. */
   children: ReactNode
   /** The maximum width of the select */
@@ -21,22 +30,27 @@ export interface CompactSelectNativeProps extends Omit<SelectHTMLAttributes<HTML
 }
 
 /**
- * A space-saving version of a select input with smaller padding and font size, used in dense layouts or limited
- * screen space. Compact select (native) is preferred for mobile responsiveness. On browsers that support
- * [field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing), the select will size itself to
- * the size of its content, rather than the width of the longest option.
- *
- * **Note:** We do not support the `multiple` attribute because it is incompatible with the compact select's design.
+ * A space-saving version of a select input with smaller padding and font size, used in dense layouts or
+ * limited screen space. Compact select (native) is preferred for mobile responsiveness. On browsers that
+ * support [field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing), the select will
+ * size itself to the size of its content, up to the maximum inline size of its container, rather than
+ * the width of the longest option. Importantly, it only supports single selection.
  */
 export const CompactSelectNative = forwardRef<HTMLSelectElement, CompactSelectNativeProps>(
-  ({ children, maxWidth, size, ...rest }, ref) => {
+  ({ autoComplete = 'off', children, maxWidth, size, ...rest }, ref) => {
     return (
       // NOTE: We have to wrap the select in a container so our chevron icon can be positioned absolutely
       // at the select's right edge. This is the simplest way for us to achieve the visual requirements of
       // the component while still using a native select element. The main downside is we have more DOM elements
       // involved than we would prefer.
       <ElCompactSelectNativeContainer>
-        <ElCompactSelectNative {...rest} data-size={size} ref={ref} style={{ '--select-max-width': maxWidth }}>
+        <ElCompactSelectNative
+          {...rest}
+          autoComplete={autoComplete}
+          data-size={size}
+          ref={ref}
+          style={{ '--select-max-width': maxWidth }}
+        >
           {children}
         </ElCompactSelectNative>
         <ElCompactSelectNativeIconContainer aria-hidden>

--- a/src/core/compact-select-native/styles.ts
+++ b/src/core/compact-select-native/styles.ts
@@ -7,6 +7,7 @@ export const ElCompactSelectNativeContainer = styled.div`
   position: relative;
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
 `
 
 interface ElCompactSelectNativeProps {
@@ -16,7 +17,7 @@ interface ElCompactSelectNativeProps {
 }
 
 export const ElCompactSelectNative = styled.select<ElCompactSelectNativeProps>`
-  max-width: var(--select-max-width);
+  max-width: var(--select-max-width, 100%);
 
   appearance: none;
   background-color: transparent;
@@ -34,7 +35,7 @@ export const ElCompactSelectNative = styled.select<ElCompactSelectNativeProps>`
   }
 
   /* NOTE: We need to create space for the absolutely positioned icon. */
-  padding-inline-end: calc(var(--spacing-1) + var(--icon_size-s));
+  padding-inline-end: calc(var(--spacing-2) + var(--icon_size-s));
 
   &:focus-visible {
     outline: var(--border-width-double) solid var(--colour-border-focus);

--- a/src/core/select-native/__tests__/select-native.test.tsx
+++ b/src/core/select-native/__tests__/select-native.test.tsx
@@ -1,0 +1,179 @@
+import { SelectNative } from '../select-native'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+test('renders a select element', () => {
+  render(
+    <SelectNative {...defaultProps}>
+      <option value="">Select portfolio</option>
+      <option value="portfolio1">Portfolio 1</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toBeVisible()
+})
+
+test('defaults autocomplete attribute to `off`', () => {
+  render(
+    <SelectNative {...defaultProps} size="large">
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toHaveAttribute('autocomplete', 'off')
+})
+
+test('accepts explicit autocomplete values', () => {
+  render(
+    <SelectNative {...defaultProps} autoComplete="on" size="large">
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toHaveAttribute('autocomplete', 'on')
+})
+
+test('defaults data-is-touched to `false`', () => {
+  render(
+    <SelectNative {...defaultProps} size="large">
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toHaveAttribute('data-is-touched', 'false')
+})
+
+test('applies correct data-is-touched attribute', () => {
+  render(
+    <SelectNative {...defaultProps} isTouched size="large">
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toHaveAttribute('data-is-touched', 'true')
+})
+
+test('applies correct data-size attribute', () => {
+  render(
+    <SelectNative {...defaultProps} size="large">
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toHaveAttribute('data-size', 'large')
+})
+
+test('options are accessible', () => {
+  render(
+    <SelectNative {...defaultProps}>
+      <option value="">Select portfolio</option>
+      <option value="portfolio1">Portfolio 1</option>
+      <option value="portfolio2">Portfolio 2</option>
+    </SelectNative>,
+  )
+
+  expect(screen.getByRole('option', { name: 'Select portfolio' })).toBeVisible()
+  expect(screen.getByRole('option', { name: 'Portfolio 1' })).toBeVisible()
+  expect(screen.getByRole('option', { name: 'Portfolio 2' })).toBeVisible()
+})
+
+test('option groups are accessible', () => {
+  render(
+    <SelectNative {...defaultProps}>
+      <option value="">Select portfolio</option>
+      <optgroup label="Personal">
+        <option value="personal1">Personal 1</option>
+      </optgroup>
+      <optgroup label="Business">
+        <option value="business1">Business 1</option>
+      </optgroup>
+    </SelectNative>,
+  )
+
+  expect(screen.getByRole('group', { name: 'Personal' })).toBeVisible()
+  expect(screen.getByRole('group', { name: 'Business' })).toBeVisible()
+})
+
+test("the select's default value can be specified", () => {
+  render(
+    <SelectNative {...defaultProps} defaultValue="portfolio1">
+      <option value="">Select portfolio</option>
+      <option value="portfolio1">Portfolio 1</option>
+      <option value="portfolio2">Portfolio 2</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toHaveValue('portfolio1')
+})
+
+test('handles changes to the selected value when uncontrolled', () => {
+  const handleChange = vi.fn()
+
+  render(
+    <SelectNative {...defaultProps} onChange={handleChange}>
+      <option value="">Select portfolio</option>
+      <option value="portfolio1">Portfolio 1</option>
+      <option value="portfolio2">Portfolio 2</option>
+    </SelectNative>,
+  )
+
+  const select = screen.getByRole('combobox')
+  fireEvent.change(select, { target: { value: 'portfolio2' } })
+
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(select).toHaveValue('portfolio2')
+})
+
+test("the select's value can be controlled", () => {
+  const handleChange = vi.fn()
+
+  render(
+    <SelectNative {...defaultProps} onChange={handleChange} value="portfolio1">
+      <option value="">Select portfolio</option>
+      <option value="portfolio1">Portfolio 1</option>
+      <option value="portfolio2">Portfolio 2</option>
+    </SelectNative>,
+  )
+
+  const select = screen.getByRole('combobox')
+  // The value is pinned to "Portfolio 1" so selecting a different option should not change the selected value.
+  fireEvent.change(select, { target: { value: 'portfolio2' } })
+
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(select).toHaveValue('portfolio1')
+})
+
+test('can be disabled', () => {
+  render(
+    <SelectNative {...defaultProps} disabled>
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByRole('combobox')).toBeDisabled()
+})
+
+test('forwards ref to select element', () => {
+  const ref = vi.fn()
+
+  render(
+    <SelectNative {...defaultProps} ref={ref}>
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+
+  expect(ref).toHaveBeenCalledWith(expect.any(HTMLSelectElement))
+})
+
+test('forwards additional props to select element', () => {
+  render(
+    <SelectNative {...defaultProps} data-testid="custom-select">
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(screen.getByTestId('custom-select')).toBeVisible()
+})
+
+test('renders chevron icon', () => {
+  const { container } = render(
+    <SelectNative {...defaultProps}>
+      <option value="">Select portfolio</option>
+    </SelectNative>,
+  )
+  expect(container.querySelector('svg')).toBeVisible()
+})
+
+const defaultProps = {
+  size: 'small',
+} as const

--- a/src/core/select-native/index.ts
+++ b/src/core/select-native/index.ts
@@ -1,0 +1,2 @@
+export * from './select-native'
+export * from './styles'

--- a/src/core/select-native/select-native.stories.tsx
+++ b/src/core/select-native/select-native.stories.tsx
@@ -1,10 +1,10 @@
-import { CompactSelectNative } from './compact-select-native'
+import { SelectNative } from './select-native'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
-  title: 'Core/CompactSelectNative',
-  component: CompactSelectNative,
+  title: 'Core/SelectNative',
+  component: SelectNative,
   argTypes: {
     children: {
       control: 'radio',
@@ -12,11 +12,10 @@ const meta = {
       mapping: {
         Simple: (
           <>
-            <option value="">Select portfolio</option>
-            <option value="portfolio1">Portfolio 1</option>
-            <option value="portfolio2">Portfolio 2</option>
-            <option value="portfolio3">Portfolio 3</option>
-            <option value="portfolio4">Portfolio 4 with a long name</option>
+            <option value="">Select an option</option>
+            <option value="commercial">Commercial</option>
+            <option value="residential">Residential</option>
+            <option value="other">Some other option with a long name</option>
           </>
         ),
         'With Groups': (
@@ -40,7 +39,7 @@ const meta = {
       options: ['small', 'medium', 'large'],
     },
   },
-} satisfies Meta<typeof CompactSelectNative>
+} satisfies Meta<typeof SelectNative>
 
 export default meta
 
@@ -48,9 +47,15 @@ type Story = StoryObj<typeof meta>
 
 export const Example: Story = {
   args: {
-    'aria-label': 'Portfolio',
+    autoComplete: 'off',
     children: 'Simple',
+    defaultValue: undefined,
+    form: undefined,
+    maxWidth: undefined,
+    name: 'mySelect',
+    required: false,
     size: 'small',
+    value: undefined,
   },
 }
 
@@ -78,18 +83,31 @@ export const Sizes: Story = {
   },
   decorators: [
     (Story) => (
-      <div style={{ display: 'flex', gap: 'var(--spacing-6)', alignItems: 'center' }}>
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)', alignItems: 'start' }}>
         <Story />
       </div>
     ),
   ],
   render: (args) => (
     <>
-      <CompactSelectNative {...args} size="small" />
-      <CompactSelectNative {...args} size="medium" />
-      <CompactSelectNative {...args} size="large" />
+      <SelectNative {...args} size="small" />
+      <SelectNative {...args} size="medium" />
+      <SelectNative {...args} size="large" />
     </>
   ),
+}
+
+/**
+ * Like all form controls, the native select will display in an invalid state when it's value
+ * does not meet the validation constraints applied to it, such as being required, when it has
+ * been "touched", meaning the control has been focused then blurred.
+ */
+export const Invalid: Story = {
+  args: {
+    ...Example.args,
+    isTouched: true,
+    required: true,
+  },
 }
 
 /**
@@ -99,20 +117,20 @@ export const DefaultValue: Story = {
   name: 'Default value',
   args: {
     ...Example.args,
-    defaultValue: 'portfolio1',
+    defaultValue: 'residential',
   },
 }
 
 /**
  * The value of the select can be controlled by providing an explicit `value`. In this example, the select's value is
- * pinned to "Portfolio 1" and, because that controlled value is not updated when another option is selected, it does
+ * pinned to "Commercial" and, because that controlled value is not updated when another option is selected, it does
  * not change.
  */
 export const ControlledValue: Story = {
   name: 'Controlled value',
   args: {
     ...Example.args,
-    value: 'portfolio1',
+    value: 'commercial',
   },
 }
 
@@ -122,7 +140,7 @@ export const ControlledValue: Story = {
 export const Overflow: Story = {
   args: {
     ...Example.args,
-    defaultValue: 'portfolio4',
+    defaultValue: 'other',
   },
   decorators: [
     (Story) => (
@@ -140,7 +158,7 @@ export const Overflow: Story = {
 export const MaxWidth: Story = {
   args: {
     ...Overflow.args,
-    defaultValue: 'portfolio4',
+    defaultValue: 'other',
     maxWidth: '100px',
   },
   decorators: Overflow.decorators,

--- a/src/core/select-native/select-native.tsx
+++ b/src/core/select-native/select-native.tsx
@@ -1,0 +1,66 @@
+import { ChevronDownIcon } from '#src/icons/chevron-down'
+import { ElSelectNative, ElSelectNativeContainer, ElSelectNativeIconContainer } from './styles'
+import { forwardRef } from 'react'
+
+import type { ReactNode, SelectHTMLAttributes } from 'react'
+
+// NOTE: We omit:
+// - `size` because we want our own string-based size prop to be available.
+// - `multiple` because it is incompatible with our compact select design.
+type AttributesToOmit = 'size' | 'multiple'
+
+export interface SelectNativeProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, AttributesToOmit> {
+  /**
+   * Specifies what, if any, permission the user agent has to provide automated assistance in filling
+   * out form field values, as well as guidance to the browser as to the type of information expected
+   * in the field. See [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
+   * docs on MDN.
+   *
+   * Default's to `off` to avoid PII being used in forms.
+   */
+  autoComplete?: 'off' | 'on' | (string & {})
+  /** The options for the select. Must be `<option>` or `<optgroup>` elements. */
+  children: ReactNode
+  /** Specifies the initially selected value. By default, the first option will be selected. */
+  defaultValue?: string
+  /** The ID of the `<form>` element to associate this select with. */
+  form?: string
+  /**
+   * Whether the select has been touched, meaning it has received focus, then been blurred. The select
+   * must be touched for it's validity to be visually communicated.
+   */
+  isTouched?: boolean
+  /** The maximum width of the select */
+  maxWidth?: string
+  /** The name of the control */
+  name?: string
+  /** Used to indicate whether an option with a non-empty string value must be selected. */
+  required?: boolean
+  /** The size of the select */
+  size: 'small' | 'medium' | 'large'
+  /** Controls which option is selected. Must match the value of some `<option>`. */
+  value?: string
+}
+
+/**
+ * A simple, native select. By default, the select will size itself to fill the inline size of its
+ * container. Importantly, it only supports single selection.
+ */
+export const SelectNative = forwardRef<HTMLSelectElement, SelectNativeProps>(
+  ({ autoComplete = 'off', children, isTouched, maxWidth, size, ...rest }, ref) => {
+    return (
+      // NOTE: We have to wrap the select in a container so our chevron icon can be positioned absolutely
+      // at the select's right edge. This is the simplest way for us to achieve the visual requirements of
+      // the component while still using a native select element. The main downside is we have more DOM
+      // elements involved than we would prefer.
+      <ElSelectNativeContainer style={{ '--select-max-width': maxWidth }}>
+        <ElSelectNative {...rest} autoComplete={autoComplete} data-is-touched={!!isTouched} data-size={size} ref={ref}>
+          {children}
+        </ElSelectNative>
+        <ElSelectNativeIconContainer aria-hidden>
+          <ChevronDownIcon />
+        </ElSelectNativeIconContainer>
+      </ElSelectNativeContainer>
+    )
+  },
+)

--- a/src/core/select-native/styles.ts
+++ b/src/core/select-native/styles.ts
@@ -1,0 +1,96 @@
+import { styled } from '@linaria/react'
+import { font } from '../text'
+
+import type { CSSProperties } from 'react'
+
+interface ElSelectNativeContainerProps {
+  // NOTE: We use a CSS variable for the max-width rather than simply using the max-width inline
+  // style because we want the max-width to be available to both the container and select elements.
+  style?: CSSProperties & {
+    '--select-max-width'?: string
+  }
+}
+
+export const ElSelectNativeContainer = styled.div<ElSelectNativeContainerProps>`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: var(--select-max-width, 100%);
+  width: 100%;
+`
+
+interface ElSelectNativeProps {
+  'data-is-touched': boolean
+}
+
+export const ElSelectNative = styled.select<ElSelectNativeProps>`
+  width: 100%;
+  /* NOTE: --select-max-width comes from ElSelectNativeContainer */
+  max-width: var(--select-max-width, 100%);
+
+  appearance: none;
+  background: transparent;
+  border-radius: var(--comp-input-border-radius);
+  border: var(--comp-input-border-width) solid var(--comp-input-colour-border-default);
+  outline: none;
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+
+  cursor: pointer;
+  color: var(--comp-input-colour-text-default-input);
+
+  padding-inline-start: var(--spacing-2);
+  /* NOTE: We need to create space for the absolutely positioned icon. */
+  padding-inline-end: calc(var(--spacing-2) + var(--icon_size-s) + var(--spacing-2));
+
+  /* NOTE: Invalid styles should only be used if the control has been "touched" (focused then blurred).
+   * We use :where to avoid the presence of the isTouched attribute increasing the selector's
+   * specificity and, therefore, overriding our focus styles. When a touched and invalid field is
+   * focused, we want the focus styles to take precedence. */
+  &:where([data-is-touched='true']):invalid,
+  &:where([data-is-touched='true']):user-invalid {
+    border-color: var(--comp-input-colour-border-error);
+    background: var(--comp-input-colour-fill-error-background);
+  }
+
+  /* NOTE: focus styles come after invalid styles to ensure they take precedence */
+  &:focus-visible {
+    border-color: var(--comp-input-colour-border-focused);
+    background: transparent;
+  }
+
+  /* Sizes */
+  &[data-size='small'] {
+    height: var(--size-8);
+    ${font('xs', 'regular')}
+  }
+
+  &[data-size='medium'] {
+    height: var(--size-9);
+    ${font('sm', 'regular')}
+  }
+
+  &[data-size='large'] {
+    height: var(--size-10);
+    ${font('base', 'regular')}
+  }
+`
+
+export const ElSelectNativeIconContainer = styled.span`
+  position: absolute;
+  right: var(--spacing-2);
+
+  /* NOTE: We don't want this element or its children to capture pointer events. Instead, we want those
+   * events to be captured by the select element, which this icon container is above. */
+  pointer-events: none;
+
+  display: inline-flex;
+  align-items: center;
+
+  color: var(--comp-input-colour-icon-default);
+
+  width: var(--icon_size-s);
+  height: var(--icon_size-s);
+`

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -19,6 +19,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 ### **5.0.0-beta.49 - ??/??/25**
 
 - **feat:** Experimental `SelectCustom` now available via `@reapit/elements/lab/select-custom`
+- **feat:** Added new `SelectNative`. It is available via `@reapit/elements/core/select-native`
 
 ### **5.0.0-beta.48 - 04/09/25**
 


### PR DESCRIPTION
### Context

- Form controls are foundational to any product, so it's important we provide implementations of the form controls in the Design System.
- Native components are low-hanging fruit, so we're starting with them.

### This PR

- Adds new `SelectNative` component. It's largely identical to the `CompactSelectNative` component already available in Elements, only this one has styles for when the form control is validated as part of a form and its value is determined to be invalid. Importantly, error styles are only applied when the form control is marked as "touched."

<img width="829" height="673" alt="Screenshot 2025-09-05 at 5 21 01 pm" src="https://github.com/user-attachments/assets/ed0f14bf-26d5-4369-8209-13a1504230e7" />
<img width="824" height="557" alt="Screenshot 2025-09-05 at 5 21 09 pm" src="https://github.com/user-attachments/assets/54095188-c1e8-4688-afb9-6bef6f13583d" />
<img width="828" height="600" alt="Screenshot 2025-09-05 at 5 21 16 pm" src="https://github.com/user-attachments/assets/c3bd3182-57ca-4166-b669-696a53629c40" />
<img width="817" height="593" alt="Screenshot 2025-09-05 at 5 21 22 pm" src="https://github.com/user-attachments/assets/26b6ed92-d813-4eb9-824c-e5276ae8e40b" />
<img width="826" height="209" alt="Screenshot 2025-09-05 at 5 21 27 pm" src="https://github.com/user-attachments/assets/5a56258d-aa00-4382-b67a-752dc9f810cc" />
