### PR TITLE
feat: add `ChipSelectChip`

### DIFF
--- a/src/core/chip-select/chip/__tests__/chip.test.tsx
+++ b/src/core/chip-select/chip/__tests__/chip.test.tsx
@@ -1,0 +1,184 @@
+import { ChipSelectChip } from '../chip'
+import { expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+test('renders as checkbox element', () => {
+  render(
+    <ChipSelectChip size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox')).toBeVisible()
+})
+
+test('checkbox is correctly labelled', () => {
+  render(
+    <ChipSelectChip size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox', { name: 'Label' })).toBeVisible()
+})
+
+test('calls `onChange` when clicked', () => {
+  const handleChange = vi.fn()
+  render(
+    <ChipSelectChip onChange={handleChange} size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  fireEvent.click(screen.getByRole('checkbox'))
+  expect(handleChange).toHaveBeenCalled()
+})
+
+test('calls `onChange` when label is clicked', () => {
+  const handleChange = vi.fn()
+  render(
+    <ChipSelectChip onChange={handleChange} size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  fireEvent.click(screen.getByText('Label'))
+  expect(handleChange).toHaveBeenCalled()
+})
+
+test('checkbox has `type="checkbox"` attribute', () => {
+  render(
+    <ChipSelectChip size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox')).toHaveAttribute('type', 'checkbox')
+})
+
+test('checkbox is unchecked by default', () => {
+  render(
+    <ChipSelectChip size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox')).not.toBeChecked()
+})
+
+test('checkbox is checked when `checked` prop is true', () => {
+  render(
+    <ChipSelectChip checked onChange={vi.fn()} size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox')).toBeChecked()
+})
+
+test('checkbox is disabled when `disabled` prop is true', () => {
+  render(
+    <ChipSelectChip disabled size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox')).toBeDisabled()
+})
+
+test('disabled checkbox does not call `onChange`', () => {
+  const handleChange = vi.fn()
+  render(
+    <ChipSelectChip disabled onChange={handleChange} size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  fireEvent.click(screen.getByRole('checkbox'))
+  expect(handleChange).not.toHaveBeenCalled()
+})
+
+test('applies `aria-label` to the root element', () => {
+  const { container } = render(<ChipSelectChip aria-label="Test label" size="small" value="foo" />)
+  expect(container.firstElementChild).toHaveAttribute('aria-label', 'Test label')
+})
+
+test('applies `data-size` to the root element', () => {
+  const { container } = render(<ChipSelectChip aria-label="Test label" size="large" value="foo" />)
+  expect(container.firstElementChild).toHaveAttribute('data-size', 'large')
+})
+
+test('applies `data-overflow="truncate"` to label text when `overflow="truncate"` is provided', () => {
+  render(
+    <ChipSelectChip overflow="truncate" size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByText('Label')).toHaveAttribute('data-overflow', 'truncate')
+})
+
+test('displays the icon when provided', () => {
+  render(<ChipSelectChip icon="Fake icon" size="small" value="foo" />)
+  expect(screen.getByText('Fake icon')).toBeVisible()
+})
+
+test('icon is `aria-hidden`', () => {
+  render(<ChipSelectChip icon="Fake icon" size="small" value="foo" />)
+  expect(screen.getByText('Fake icon')).toHaveAttribute('aria-hidden', 'true')
+})
+
+test('forwards ref to the checkbox input', () => {
+  const ref = vi.fn()
+  render(
+    <ChipSelectChip ref={ref} size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement))
+})
+
+test('forwards additional attributes to the checkbox', () => {
+  render(
+    <ChipSelectChip data-testid="custom-chip" name="test-name" size="small" value="test-value">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByTestId('custom-chip')).toBe(screen.getByRole('checkbox'))
+})
+
+test('prevents other chips being selected when `isExclusive`', () => {
+  render(
+    <form>
+      <ChipSelectChip isExclusive name="test" size="small" value="foo">
+        Foo
+      </ChipSelectChip>
+      <ChipSelectChip isExclusive name="test" size="small" value="bar">
+        Bar
+      </ChipSelectChip>
+    </form>,
+  )
+  expect(screen.getByRole('checkbox', { name: 'Foo' })).not.toBeChecked()
+  expect(screen.getByRole('checkbox', { name: 'Bar' })).not.toBeChecked()
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Foo' }))
+  expect(screen.getByRole('checkbox', { name: 'Foo' })).toBeChecked()
+  expect(screen.getByRole('checkbox', { name: 'Bar' })).not.toBeChecked()
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Bar' }))
+  expect(screen.getByRole('checkbox', { name: 'Foo' })).not.toBeChecked()
+  expect(screen.getByRole('checkbox', { name: 'Bar' })).toBeChecked()
+})
+
+test('allows other chips to be selected when NOT `isExclusive`', () => {
+  render(
+    <form>
+      <ChipSelectChip name="test" size="small" value="foo">
+        Foo
+      </ChipSelectChip>
+      <ChipSelectChip name="test" size="small" value="bar">
+        Bar
+      </ChipSelectChip>
+    </form>,
+  )
+  expect(screen.getByRole('checkbox', { name: 'Foo' })).not.toBeChecked()
+  expect(screen.getByRole('checkbox', { name: 'Bar' })).not.toBeChecked()
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Foo' }))
+  expect(screen.getByRole('checkbox', { name: 'Foo' })).toBeChecked()
+  expect(screen.getByRole('checkbox', { name: 'Bar' })).not.toBeChecked()
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Bar' }))
+  expect(screen.getByRole('checkbox', { name: 'Foo' })).toBeChecked()
+  expect(screen.getByRole('checkbox', { name: 'Bar' })).toBeChecked()
+})

--- a/src/core/chip-select/chip/__tests__/maybe-deselect-other-options.test.ts
+++ b/src/core/chip-select/chip/__tests__/maybe-deselect-other-options.test.ts
@@ -1,0 +1,142 @@
+import { maybeDeselectOtherOptions } from '../maybe-deselect-other-options'
+
+test('deselects other checked options when newly selected option is exclusive', () => {
+  const option1 = createInput({ name: 'test-options', checked: true, exclusive: true })
+  const option2 = createInput({ name: 'test-options', checked: true })
+  const option3 = createInput({ name: 'test-options', checked: false })
+
+  const form = createFormWithInputs([option1, option2, option3])
+  mockRadioNodeList([option1, option2, option3], form)
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option1.checked).toBe(true) // Newly selected option remains checked
+  expect(option2.checked).toBe(false) // Other checked option gets unchecked
+  expect(option3.checked).toBe(false) // Already unchecked option remains unchecked
+})
+
+test('does not deselect other options when newly selected option is not exclusive', () => {
+  const option1 = createInput({ name: 'test-options', checked: true })
+  const option2 = createInput({ name: 'test-options', checked: true })
+
+  const form = createFormWithInputs([option1, option2])
+  mockRadioNodeList([option1, option2], form)
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option1.checked).toBe(true)
+  expect(option2.checked).toBe(true) // Should remain checked
+})
+
+test('does not deselect other options when exclusive is set to false', () => {
+  const option1 = createInput({ name: 'test-options', checked: true, exclusive: false })
+  const option2 = createInput({ name: 'test-options', checked: true })
+
+  const form = createFormWithInputs([option1, option2])
+  mockRadioNodeList([option1, option2], form)
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option1.checked).toBe(true)
+  expect(option2.checked).toBe(true) // Should remain checked
+})
+
+test('does not deselect when option has no associated form', () => {
+  const option1 = createInput({ name: 'test-options', checked: true, exclusive: true })
+  const option2 = createInput({ name: 'test-options', checked: true })
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option1.checked).toBe(true)
+  expect(option2.checked).toBe(true) // Should remain checked
+})
+
+test('does not deselect when option has no name', () => {
+  const option1 = createInput({ checked: true, exclusive: true })
+  const option2 = createInput({ checked: true })
+
+  createFormWithInputs([option1, option2])
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option1.checked).toBe(true)
+  expect(option2.checked).toBe(true) // Should remain checked
+})
+
+test('handles single option case gracefully', () => {
+  const option1 = createInput({ name: 'test-options', checked: true, exclusive: true })
+
+  const form = createFormWithInputs([option1])
+  vi.spyOn(form.elements, 'namedItem').mockReturnValue(option1)
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option1.checked).toBe(true) // Should remain checked
+})
+
+test('only unchecks options that are currently checked', () => {
+  const option1 = createInput({ name: 'test-options', checked: true, exclusive: true })
+  const option2 = createInput({ name: 'test-options', checked: true })
+  const option3 = createInput({ name: 'test-options', checked: false })
+
+  const form = createFormWithInputs([option1, option2, option3])
+  mockRadioNodeList([option1, option2, option3], form)
+
+  // Spy on setting checked property to verify behavior
+  const option2CheckedSetter = vi.fn()
+  const option3CheckedSetter = vi.fn()
+
+  Object.defineProperty(option2, 'checked', {
+    get: () => true,
+    set: option2CheckedSetter,
+  })
+
+  Object.defineProperty(option3, 'checked', {
+    get: () => false,
+    set: option3CheckedSetter,
+  })
+
+  maybeDeselectOtherOptions(option1)
+
+  expect(option2CheckedSetter).toHaveBeenCalledWith(false)
+  expect(option3CheckedSetter).not.toHaveBeenCalled() // Already unchecked, shouldn't be touched
+})
+
+interface CreateInputOptions {
+  name?: string
+  checked?: boolean
+  exclusive?: boolean | string
+  type?: string
+}
+
+function createInput(options: CreateInputOptions = {}): HTMLInputElement {
+  const input = document.createElement('input')
+  input.type = options.type || 'checkbox'
+
+  if (options.name) {
+    input.name = options.name
+  }
+
+  if (options.checked !== undefined) {
+    input.checked = options.checked
+  }
+
+  if (options.exclusive !== undefined) {
+    input.dataset.exclusive = String(options.exclusive)
+  }
+
+  return input
+}
+
+function createFormWithInputs(inputs: HTMLInputElement[]): HTMLFormElement {
+  const form = document.createElement('form')
+  inputs.forEach((input) => form.appendChild(input))
+  return form
+}
+
+function mockRadioNodeList(inputs: HTMLInputElement[], form: HTMLFormElement): void {
+  const mockRadioNodeList = inputs as any
+  mockRadioNodeList.forEach = Array.prototype.forEach
+  Object.setPrototypeOf(mockRadioNodeList, RadioNodeList.prototype)
+  vi.spyOn(form.elements, 'namedItem').mockReturnValue(mockRadioNodeList)
+}

--- a/src/core/chip-select/chip/chip.stories.tsx
+++ b/src/core/chip-select/chip/chip.stories.tsx
@@ -1,0 +1,239 @@
+import { ChipSelectChip } from './chip'
+import { SproutIcon } from '#src/icons/sprout'
+import { StarIcon } from '#src/icons/star'
+import { useArgs } from 'storybook/preview-api'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Core/ChipSelect/Chip',
+  component: ChipSelectChip,
+  argTypes: {
+    checked: {
+      control: 'boolean',
+    },
+    children: {
+      control: 'text',
+    },
+    icon: {
+      control: 'select',
+      options: ['None', 'Star', 'Sprout'],
+      mapping: {
+        None: undefined,
+        Star: <StarIcon />,
+        Sprout: <SproutIcon />,
+      },
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    maxWidth: {
+      control: 'text',
+      table: { type: { summary: '--size-*' } },
+    },
+    onChange: {
+      control: false,
+    },
+    overflow: {
+      control: 'text',
+      table: { type: { summary: '"truncate"' } },
+    },
+    value: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof ChipSelectChip>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * In their simplest form, chips consist of a visual label. Importantly, all chips within a `ChipSelect`
+ * should have the same visual style.
+ */
+export const Example: Story = {
+  args: {
+    'aria-label': undefined,
+    checked: undefined,
+    children: 'Label',
+    disabled: false,
+    form: undefined,
+    icon: 'None',
+    isExclusive: false,
+    maxWidth: undefined,
+    name: 'foo',
+    onChange: undefined,
+    overflow: undefined,
+    size: 'small',
+    value: 'abc-123',
+  },
+}
+
+/**
+ * Icons can be placed in front of the chip's label. Again, if one chip in the `ChipSelect` has an icon,
+ * all chips should have an icon.
+ */
+export const Icons: Story = {
+  args: {
+    ...Example.args,
+    icon: 'Sprout',
+  },
+}
+
+/**
+ * When no visual label is provided, an icon and accessible label should both be considered mandatory.
+ * Again, if one chip in the `ChipSelect` uses an icon-only style, all other chips should also use
+ * an icon-only style.
+ */
+export const IconOnly: Story = {
+  name: 'Icon-only',
+  args: {
+    ...Example.args,
+    'aria-label': 'Label',
+    children: undefined,
+    icon: 'Sprout',
+  },
+}
+
+/**
+ * There are three sizes available for chips. Like labels and icons, all chips within a `ChipSelect`
+ * should have the same size.
+ */
+export const Sizes: Story = {
+  args: {
+    ...Icons.args,
+  },
+  argTypes: {
+    size: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', gap: 'var(--spacing-6)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <>
+      <ChipSelectChip {...args} size="small" />
+      <ChipSelectChip {...args} size="medium" />
+      <ChipSelectChip {...args} size="large" />
+    </>
+  ),
+}
+
+/**
+ * When a chip is selected, it's checked state will be true. This can either be controlled, just like
+ * any native checkbox input, or uncontrolled. This example takes an uncontrolled approach, defaulting
+ * the checked state to `true` using `defaultChecked`.
+ */
+export const Selected: Story = {
+  args: {
+    ...Example.args,
+    defaultChecked: true,
+  },
+}
+
+/**
+ * Chips can also be disabled. Importantly, disabled chips do not participate in form submission.
+ */
+export const Disabled: Story = {
+  args: {
+    ...Example.args,
+    disabled: true,
+  },
+}
+
+/**
+ * Long labels will truncate when there is not enough space available.
+ */
+export const Truncation: Story = {
+  args: {
+    ...Example.args,
+    children: 'Truncation can be applied when necessary',
+    overflow: 'truncate',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ boxSizing: 'content-box', border: '1px solid #FA00FF', width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * In some cases, it may be necessary to limit the width of an option directly, rather than rely on
+ * its parent container. This is achieved using the `maxWidth` prop.
+ */
+export const MaxWidth: Story = {
+  name: 'Max-width',
+  args: {
+    ...Example.args,
+    children: 'This chip option has its own maximum width constraint',
+    maxWidth: '--size-80',
+  },
+}
+
+/**
+ * When multiple chips with the same name and associated with the same form are marked as "exclusive",
+ * they will ensure all other related chips are unchecked when they themselves are checked. This results
+ * in radio-group-like behaviour, only individual chips can still be unchecked.
+ *
+ * Importantly, this behaviour works out-of-the-box when the checked state of each chip is uncontrolled.
+ * In cases where the checked state is controlled, it is the consumer's responsibility to facilitate
+ * this behaviour.
+ */
+export const SingleSelect: Story = {
+  name: 'Single-select',
+  args: {
+    ...IconOnly.args,
+    isExclusive: true,
+  },
+  argTypes: {
+    value: {
+      control: false,
+    },
+  },
+  render: (args) => {
+    return (
+      <form style={{ display: 'inline-flex', gap: 'var(--spacing-2)' }}>
+        <ChipSelectChip {...args} defaultChecked value="1" />
+        <ChipSelectChip {...args} value="2" />
+      </form>
+    )
+  },
+}
+
+/**
+ * In contrast, when chips are NOT marked as exclusive, they behave like a normal checkbox group, where
+ * multiple chips can be checked at the same time.
+ */
+export const MultiSelect: Story = {
+  name: 'Multi-select',
+  args: {
+    ...IconOnly.args,
+    isExclusive: false,
+  },
+  argTypes: SingleSelect.argTypes,
+  render: SingleSelect.render,
+}
+
+/**
+ * Since chips are native checkbox elements (`<input type="checkbox">`). As such, their checked state
+ * can be controlled in the same manner as any other checkbox. However, when controlling the checked
+ * state of an option, consumers become responsible for any side effects that may need to occur, such as
+ * unchecking other options in the `ChipSelect`.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Example.args,
+  },
+  render: (args) => {
+    const [, setArgs] = useArgs()
+    return <ChipSelectChip {...args} onChange={(event) => setArgs({ checked: event.currentTarget.checked })} />
+  },
+}

--- a/src/core/chip-select/chip/chip.tsx
+++ b/src/core/chip-select/chip/chip.tsx
@@ -1,0 +1,80 @@
+import {
+  ElChipSelectChip,
+  ElChipSelectChipIconContainer,
+  ElChipSelectChipInput,
+  ElChipSelectChipLabelText,
+} from './styles'
+import { forwardRef, useCallback } from 'react'
+import { maybeDeselectOtherOptions } from './maybe-deselect-other-options'
+
+import type { ChangeEventHandler, InputHTMLAttributes, ReactNode } from 'react'
+
+// We omit a few attributes from the base input element:
+// - size, because we use this for our own sizing
+// - type, because chip select options are always checkboxes
+type AttributesToOmit = 'size' | 'type'
+
+export interface ChipSelectChipProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
+  /** The accessible name of the chip. Should be considered mandatory when no visual label is provided. */
+  'aria-label'?: string
+  /** The visual label of the chip. */
+  children?: ReactNode
+  /**
+   * The icon of the chip. All chips in the same chip select should either have an icon or not.
+   * If there is no visual label provided via `children`, the icon should be considered mandatory.
+   */
+  icon?: ReactNode
+  /**
+   * Whether the chip is exclusive. That is, when it's selected, all other related chips will be
+   * deselected. Exclusive and non-exclusive chips should not be mixed in the same chip select.
+   */
+  isExclusive?: boolean
+  /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
+  maxWidth?: `--size-${string}`
+  /** Name of the form control. Submitted with the form as part of a name/value pair. */
+  name?: string
+  /** Callback called when the chip's checked state changes. */
+  onChange?: ChangeEventHandler<HTMLInputElement>
+  /** Whether the label of the chip should be truncated if it is too long */
+  overflow?: 'truncate'
+  /** The size of the chip. All chips in the same chip select should have the same size. */
+  size: 'small' | 'medium' | 'large'
+  /** The value of the form control. */
+  value: InputHTMLAttributes<HTMLInputElement>['value']
+}
+
+/**
+ * An option for a `ChipSelect`. It is a styled native checkbox input, so it's checked state can be
+ * controlled (or uncontrolled) like any other native input. Typically used via `ChipSelect.Option`.
+ */
+export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
+  ({ 'aria-label': ariaLabel, children, icon, isExclusive, maxWidth, onChange, overflow, size, ...rest }, ref) => {
+    const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+      (event) => {
+        maybeDeselectOtherOptions(event.currentTarget)
+        onChange?.(event)
+      },
+      [onChange],
+    )
+
+    return (
+      <ElChipSelectChip
+        aria-label={ariaLabel}
+        data-size={size}
+        style={{ maxWidth: maxWidth ? `var(${maxWidth})` : undefined }}
+      >
+        <ElChipSelectChipInput
+          {...rest}
+          data-exclusive={isExclusive}
+          onChange={handleChange}
+          ref={ref}
+          type="checkbox"
+        />
+        {icon && <ElChipSelectChipIconContainer aria-hidden>{icon}</ElChipSelectChipIconContainer>}
+        {children && <ElChipSelectChipLabelText data-overflow={overflow}>{children}</ElChipSelectChipLabelText>}
+      </ElChipSelectChip>
+    )
+  },
+)
+
+ChipSelectChip.displayName = 'ChipSelectOption'

--- a/src/core/chip-select/chip/index.ts
+++ b/src/core/chip-select/chip/index.ts
@@ -1,0 +1,2 @@
+export * from './chip'
+export * from './styles'

--- a/src/core/chip-select/chip/maybe-deselect-other-options.ts
+++ b/src/core/chip-select/chip/maybe-deselect-other-options.ts
@@ -1,0 +1,29 @@
+/**
+ * Deselects options related to the newly selected option, if any. Deselection will only occur if
+ * the options are associated with the same form, share the same name, and the newly selected option
+ * is "exclusive", meaning when it is selected, it should be the only selected option.
+ *
+ * @param newlySelectedOption the chip select option that has just been selected
+ */
+export function maybeDeselectOtherOptions(newlySelectedOption: HTMLInputElement): void {
+  // We can only safely automate single-selection handling if the options are associated with a form
+  // and they have been given the same name. Also, we only deselect other options if the newly selected
+  // option is an "exclusive" option, meaning it has `data-exclusive="true"`.
+  const isExclusive = newlySelectedOption.dataset.exclusive === 'true'
+  const form = newlySelectedOption.form
+  const name = newlySelectedOption.name
+
+  if (isExclusive && form && name) {
+    const formControlsWithSameName = form.elements.namedItem(name)
+    // If we have an instance of RadioNodeList, we have more than one form control with the same
+    // name (this is expected for a option select that has multiple options). We want to uncheck
+    // each of these, except for `newlySelectedOption`.
+    if (formControlsWithSameName instanceof RadioNodeList) {
+      formControlsWithSameName.forEach((control) => {
+        if (newlySelectedOption !== control && control.checked) {
+          control.checked = false
+        }
+      })
+    }
+  }
+}

--- a/src/core/chip-select/chip/styles.ts
+++ b/src/core/chip-select/chip/styles.ts
@@ -1,0 +1,159 @@
+import { font } from '#src/core/text/index'
+import { styled } from '@linaria/react'
+
+interface ElChipSelectChipProps {
+  'data-size': 'small' | 'medium' | 'large'
+}
+
+export const ElChipSelectChip = styled.label<ElChipSelectChipProps>`
+  display: inline-flex;
+  gap: var(--spacing-1);
+
+  width: fit-content;
+  /* NOTE: max-width can be overridden via inline styles when an explicit maxWidth prop is provided
+   * to ChipSelectOption */
+  max-width: 100%;
+
+  background: var(--colour-white);
+
+  align-items: center;
+  border: var(--comp-interactive_chip-border-width) solid var(--comp-interactive_chip-colour-border-default);
+  border-radius: var(--comp-interactive_chip-border-radius);
+  cursor: pointer;
+
+  &:has(input:checked) {
+    border-color: var(--comp-interactive_chip-colour-fill-default-selected);
+    background: var(--comp-interactive_chip-colour-fill-default-selected);
+    color: var(--comp-interactive_chip-colour-text-default-selected);
+  }
+
+  &:hover {
+    background: var(--comp-interactive_chip-colour-fill-hover-unselected);
+    border-color: var(--comp-interactive_chip-colour-border-hover);
+
+    &:has(input:checked) {
+      border-color: var(--comp-interactive_chip-colour-fill-hover-selected);
+      background: var(--comp-interactive_chip-colour-fill-hover-selected);
+      color: var(--comp-interactive_chip-colour-text-hover-selected);
+    }
+  }
+
+  &:has(input:focus-visible) {
+    outline: var(--border-width-double) solid var(--colour-border-focus);
+    outline-offset: var(--border-width-default);
+  }
+
+  &:has(input:disabled) {
+    cursor: not-allowed;
+    background: var(--comp-interactive_chip-colour-fill-disabled-unselected);
+    border-color: var(--comp-interactive_chip-colour-fill-disabled-unselected);
+    color: var(--comp-interactive_chip-colour-text-disabled-unselected);
+
+    &:has(input:checked) {
+      border-color: var(--comp-interactive_chip-colour-fill-disabled-selected);
+      background: var(--comp-interactive_chip-colour-fill-disabled-selected);
+      color: var(--comp-interactive_chip-colour-text-disabled-selected);
+    }
+  }
+
+  &[data-size='small'] {
+    height: var(--size-8);
+    padding-inline: var(--spacing-3);
+  }
+  &[data-size='medium'] {
+    height: var(--size-9);
+    padding-inline: var(--spacing-4);
+  }
+  &[data-size='large'] {
+    height: var(--size-10);
+    padding-inline: var(--spacing-4);
+  }
+`
+
+export const ElChipSelectChipInput = styled.input`
+  /* Visually hide the checkbox but keep it accessible */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  outline: none;
+  border: 0;
+`
+
+export const ElChipSelectChipIconContainer = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+
+  box-sizing: content-box;
+
+  padding: var(--spacing-half);
+
+  color: var(--comp-interactive_chip-colour-icon-default-unselected);
+
+  input:checked ~ & {
+    color: var(--comp-interactive_chip-colour-icon-default-selected);
+  }
+
+  label:hover ~ & {
+    color: var(--comp-interactive_chip-colour-icon-hover-unselected);
+  }
+
+  label:hover:has(input:checked) ~ & {
+    color: var(--comp-interactive_chip-colour-icon-hover-selected);
+  }
+
+  input:disabled ~ & {
+    color: var(--comp-interactive_chip-colour-icon-disabled-unselected);
+  }
+
+  input:disabled:checked ~ & {
+    color: var(--comp-interactive_chip-colour-icon-disabled-selected);
+  }
+
+  [data-size='small'] &,
+  [data-size='medium'] & {
+    width: var(--icon_size-s);
+    height: var(--icon_size-s);
+  }
+  [data-size='large'] & {
+    width: var(--icon_size-m);
+    height: var(--icon_size-m);
+  }
+`
+
+interface ElChipSelectChipLabelTextProps {
+  'data-overflow': 'truncate' | undefined
+}
+
+export const ElChipSelectChipLabelText = styled.span<ElChipSelectChipLabelTextProps>`
+  display: inline-block;
+  padding-inline: var(--spacing-half);
+
+  text-align: left;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  input:checked ~ * & {
+    color: var(--neutral-700);
+  }
+
+  input:disabled ~ * & {
+    color: var(--neutral-400);
+  }
+
+  [data-size='small'] &,
+  [data-size='medium'] & {
+    ${font('sm', 'medium')}
+  }
+  [data-size='large'] & {
+    ${font('base', 'medium')}
+  }
+`

--- a/src/core/select-native/styles.ts
+++ b/src/core/select-native/styles.ts
@@ -41,9 +41,8 @@ export const ElSelectNative = styled.select<ElSelectNativeProps>`
   cursor: pointer;
   color: var(--comp-input-colour-text-default-input);
 
-  padding-inline-start: var(--spacing-2);
   /* NOTE: We need to create space for the absolutely positioned icon. */
-  padding-inline-end: calc(var(--spacing-2) + var(--icon_size-s) + var(--spacing-2));
+  padding-inline: var(--spacing-2) calc(var(--spacing-2) + var(--icon_size-s) + var(--spacing-2));
 
   /* NOTE: Invalid styles should only be used if the control has been "touched" (focused then blurred).
    * We use :where to avoid the presence of the isTouched attribute increasing the selector's

--- a/src/lab/select-custom/styles.tsx
+++ b/src/lab/select-custom/styles.tsx
@@ -59,7 +59,7 @@ export const elPopover = css`
   border-radius: var(--comp-menu-border-radius);
   background: var(--comp-menu-colour-fill-background);
   /* elevation-xl */
-  box-shadow: 0 var(--size-1) var(--size-4) 0 rgba(34, 43, 51, 0.16);
+  box-shadow: 0 var(--size-1) var(--size-4) 0 rgb(34 43 51 / 0.16);
 
   [role='listbox'] {
     display: flex;


### PR DESCRIPTION
### This PR

- Part 1 of #424
- Adds new `ChipSelectChip` component. This is effectively a styled checkbox. When more than one are used together with the same name and in the same form, they work as a checkbox group.
- The chip has built-in handling for single-selection, though this only works when the checked state of the chips is uncontrolled. As soon as the checked state is controlled, the consumer bears the burden of ensuring the single-selection behaviour works when required. A future PR will add a helper function for consumers to use that will take care of most of this concern.

**note:** checkbox inputs were used over radio button because it was non-trivial to implement the required toggling functionality (clicking a chip will check OR uncheck it) on top of radio buttons. This is because radio buttons are not designed to be unchecked when clicked on. Further, radio button groups include special keyboard navigation handling that causes the checked radio to change as the options are navigated using arrow keys; this would only be appropriate in the single-selection context of the chip select. In the end, checkboxes seemed the better fit, with single-selection behaviour being the only "custom" behaviour we need to model.

<img width="821" height="644" alt="Screenshot 2025-09-09 at 10 38 12 am" src="https://github.com/user-attachments/assets/7fd59ee8-19b9-48b4-945c-a8e23950423c" />
<img width="825" height="514" alt="Screenshot 2025-09-09 at 10 38 23 am" src="https://github.com/user-attachments/assets/438b2bfb-09f4-4e20-adba-701942f35d85" />
<img width="824" height="621" alt="Screenshot 2025-09-09 at 10 38 29 am" src="https://github.com/user-attachments/assets/3dc585c9-8873-41b3-b847-720f285117d7" />
<img width="822" height="598" alt="Screenshot 2025-09-09 at 10 38 36 am" src="https://github.com/user-attachments/assets/515bb3f5-1513-4aae-bff0-1dce14e0249e" />
<img width="823" height="642" alt="Screenshot 2025-09-09 at 10 38 43 am" src="https://github.com/user-attachments/assets/a96f7c89-afe1-4759-b0ce-f57d05ddf637" />
<img width="819" height="415" alt="Screenshot 2025-09-09 at 10 38 47 am" src="https://github.com/user-attachments/assets/d8ac4ff6-5a51-48b8-8ab3-a3a525b5e471" />
