### PR TITLE
feat: add `ChipSelect.determineNextControlledState`

### DIFF
--- a/src/core/chip-select/chip-select.stories.tsx
+++ b/src/core/chip-select/chip-select.stories.tsx
@@ -1,7 +1,8 @@
 import { ChipSelect } from './chip-select'
 import { StarIcon } from '#src/icons/star'
-import { useId } from 'react'
+import { useId, useState } from 'react'
 
+import type { ChangeEventHandler } from 'react'
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
@@ -88,6 +89,54 @@ export const MultiSelect: Story = {
   args: {
     ...Example.args,
     multiple: true,
+  },
+}
+
+/**
+ * Since chips are native checkbox elements (`<input type="checkbox">`), their checked state can be
+ * controlled in the same manner as any other checkbox. However, when controlling the checked state of
+ * an option, consumers become responsible for managing the single- or multi-select behaviour of the
+ * `ChipSelect`.
+ *
+ * When using controlled form state management libraries like Formik, the multi-select behaviour will
+ * often be handled out-of-the-box, as that's the default behaviour of standard checkbox groups. For
+ * single-select behaviour, however, manual intervention will be required. To assist with this, the
+ * `ChipSelect.determineNextControlledState` helper is provided.
+ *
+ * Whether single- or multi-select behaviour is desired, the controlled state must be an array.
+ *
+ * This example demonstrates a controlled usage of the `ChipSelect` via simple local component state
+ * (`useState`) and `ChipSelect.determineNextControlledState`.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Example.args,
+  },
+  argTypes: { children: { control: false } },
+  parameters: { docs: { source: { type: 'code' } } },
+  render: () => {
+    // Our controlled state. We start with the option whose value is "1" checked.
+    const [state, setState] = useState(['1'])
+
+    const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+      // NOTE: we get a reference to the current target outside of our state setter function
+      // because the state setter may be called after the synthetic event has been cleaned up
+      // and it's reference to the current target lost.
+      const option = event.currentTarget
+
+      // `determineNextControlledState` does the heavy lifting for us, returning the appropriate
+      // next state given the current state and the option whose checked state has changed.
+      setState((state) => ChipSelect.determineNextControlledState(state, option))
+    }
+
+    // Since we're not using a form, we don't need to specify a name for each chip; rather,
+    // we're directly controlling each chip's checked state.
+    return (
+      <ChipSelect size="small">
+        <ChipSelect.Option checked={state.includes('1')} icon={<StarIcon />} onChange={onChange} value="1" />
+        <ChipSelect.Option checked={state.includes('2')} icon={<StarIcon />} onChange={onChange} value="2" />
+      </ChipSelect>
+    )
   },
 }
 

--- a/src/core/chip-select/chip-select.tsx
+++ b/src/core/chip-select/chip-select.tsx
@@ -1,5 +1,6 @@
 import { ChipSelectContextProvider } from './context'
 import { ChipSelectOption } from './chip-select-option'
+import { determineNextControlledState } from './chip'
 import { ElChipSelect } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
@@ -57,3 +58,4 @@ export function ChipSelect({
 }
 
 ChipSelect.Option = ChipSelectOption
+ChipSelect.determineNextControlledState = determineNextControlledState

--- a/src/core/chip-select/chip/__tests__/chip.test.tsx
+++ b/src/core/chip-select/chip/__tests__/chip.test.tsx
@@ -99,6 +99,14 @@ test('applies `data-size` to the root element', () => {
   expect(container.firstElementChild).toHaveAttribute('data-size', 'large')
 })
 
+test('applies `data-exclusive` to the input element', () => {
+  const { rerender } = render(<ChipSelectChip isExclusive size="large" value="foo" />)
+  expect(screen.getByRole('checkbox')).toHaveAttribute('data-exclusive', 'true')
+
+  rerender(<ChipSelectChip size="large" value="foo" />)
+  expect(screen.getByRole('checkbox')).toHaveAttribute('data-exclusive', 'false')
+})
+
 test('applies `data-overflow="truncate"` to label text when `overflow="truncate"` is provided', () => {
   render(
     <ChipSelectChip overflow="truncate" size="small" value="foo">

--- a/src/core/chip-select/chip/__tests__/determine-next-controlled-state.test.ts
+++ b/src/core/chip-select/chip/__tests__/determine-next-controlled-state.test.ts
@@ -1,0 +1,38 @@
+import { determineNextControlledState } from '../determine-next-controlled-state'
+
+test("when exclusive option is checked, returns an array with that option's value", () => {
+  const currentValue = ['option1']
+  const option = createInputOption('option2', true, true)
+  const result = determineNextControlledState(currentValue, option)
+  expect(result).toEqual(['option2'])
+})
+
+test('when exclusive option is unchecked, returns empty array', () => {
+  const currentValue = ['option1']
+  const option = createInputOption('option1', false, true)
+  const result = determineNextControlledState(currentValue, option)
+  expect(result).toEqual([])
+})
+
+test("when non-exclusive option checked, returns array with option's value appended to existing values", () => {
+  const currentValue = ['option1', 'option2']
+  const option = createInputOption('option3', true, false)
+  const result = determineNextControlledState(currentValue, option)
+  expect(result).toEqual(['option1', 'option2', 'option3'])
+})
+
+test("when non-exclusive option unchecked, returns array with option's value removed from existing values", () => {
+  const currentValue = ['option1', 'option2', 'option3']
+  const option = createInputOption('option2', false, false)
+  const result = determineNextControlledState(currentValue, option)
+  expect(result).toEqual(['option1', 'option3'])
+})
+
+function createInputOption(value: string, checked: boolean, exclusive: boolean): HTMLInputElement {
+  const input = document.createElement('input')
+  input.type = 'checkbox'
+  input.value = value
+  input.checked = checked
+  input.dataset.exclusive = exclusive.toString()
+  return input
+}

--- a/src/core/chip-select/chip/chip.stories.tsx
+++ b/src/core/chip-select/chip/chip.stories.tsx
@@ -1,7 +1,6 @@
 import { ChipSelectChip } from './chip'
 import { SproutIcon } from '#src/icons/sprout'
 import { StarIcon } from '#src/icons/star'
-import { useArgs } from 'storybook/preview-api'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
@@ -220,20 +219,4 @@ export const MultiSelect: Story = {
   },
   argTypes: SingleSelect.argTypes,
   render: SingleSelect.render,
-}
-
-/**
- * Since chips are native checkbox elements (`<input type="checkbox">`). As such, their checked state
- * can be controlled in the same manner as any other checkbox. However, when controlling the checked
- * state of an option, consumers become responsible for any side effects that may need to occur, such as
- * unchecking other options in the `ChipSelect`.
- */
-export const Controlled: Story = {
-  args: {
-    ...Example.args,
-  },
-  render: (args) => {
-    const [, setArgs] = useArgs()
-    return <ChipSelectChip {...args} onChange={(event) => setArgs({ checked: event.currentTarget.checked })} />
-  },
 }

--- a/src/core/chip-select/chip/chip.tsx
+++ b/src/core/chip-select/chip/chip.tsx
@@ -48,10 +48,17 @@ export interface ChipSelectChipProps extends Omit<InputHTMLAttributes<HTMLInputE
  * controlled (or uncontrolled) like any other native input. Typically used via `ChipSelect.Option`.
  */
 export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
-  ({ 'aria-label': ariaLabel, children, icon, isExclusive, maxWidth, onChange, overflow, size, ...rest }, ref) => {
+  (
+    { 'aria-label': ariaLabel, children, icon, isExclusive = false, maxWidth, onChange, overflow, size, ...rest },
+    ref,
+  ) => {
     const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
       (event) => {
-        maybeDeselectOtherOptions(event.currentTarget)
+        // We only need to deselect other options if the one whose checked state is changing
+        // has been checked. If it has been unchecked, there's nothing to do.
+        if (event.currentTarget.checked) {
+          maybeDeselectOtherOptions(event.currentTarget)
+        }
         onChange?.(event)
       },
       [onChange],
@@ -65,6 +72,7 @@ export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
       >
         <ElChipSelectChipInput
           {...rest}
+          // NOTE: this attribute is tightly coupled to the `isExclusiveOption` helper.
           data-exclusive={isExclusive}
           onChange={handleChange}
           ref={ref}

--- a/src/core/chip-select/chip/determine-next-controlled-state.ts
+++ b/src/core/chip-select/chip/determine-next-controlled-state.ts
@@ -1,0 +1,34 @@
+import { isExclusiveOption } from './is-exclusive-option'
+
+/**
+ * Returns the next controlled state value given the current value and an option whose checked
+ * state has changed.
+ */
+export function determineNextControlledState(
+  /** The current controlled state for the chip select. */
+  currentValue: string[],
+  /** The chip select option whose checked state has changed. */
+  option: HTMLInputElement,
+): string[] {
+  const value = option.value
+
+  if (option.checked) {
+    // If the chip select option has just been checked, it's value needs to be added to the
+    // controlled state. For exclusive options, they're value replaces the current one.
+    // For non-exclusive options, their value is appended.
+    if (isExclusiveOption(option)) {
+      return [value]
+    } else {
+      return [...currentValue, value]
+    }
+  } else {
+    // If the chip select option has just been unchecked, it's value needs to be removed from
+    // the controlled state. For exclusive options, the new controlled state is an empty array.
+    // For non-exclusive options, their value is simply removed from the controlled state.
+    if (option.dataset.exclusive === 'true') {
+      return []
+    } else {
+      return currentValue.filter((v) => v !== value)
+    }
+  }
+}

--- a/src/core/chip-select/chip/index.ts
+++ b/src/core/chip-select/chip/index.ts
@@ -1,2 +1,3 @@
 export * from './chip'
+export * from './determine-next-controlled-state'
 export * from './styles'

--- a/src/core/chip-select/chip/is-exclusive-option.ts
+++ b/src/core/chip-select/chip/is-exclusive-option.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns true if the given input has `data-exclusive="true"` and false otherwise.
+ */
+export function isExclusiveOption(option: HTMLInputElement): boolean {
+  return option.dataset.exclusive === 'true'
+}

--- a/src/core/chip-select/chip/maybe-deselect-other-options.ts
+++ b/src/core/chip-select/chip/maybe-deselect-other-options.ts
@@ -1,3 +1,5 @@
+import { isExclusiveOption } from './is-exclusive-option'
+
 /**
  * Deselects options related to the newly selected option, if any. Deselection will only occur if
  * the options are associated with the same form, share the same name, and the newly selected option
@@ -6,14 +8,13 @@
  * @param newlySelectedOption the chip select option that has just been selected
  */
 export function maybeDeselectOtherOptions(newlySelectedOption: HTMLInputElement): void {
-  // We can only safely automate single-selection handling if the options are associated with a form
-  // and they have been given the same name. Also, we only deselect other options if the newly selected
-  // option is an "exclusive" option, meaning it has `data-exclusive="true"`.
-  const isExclusive = newlySelectedOption.dataset.exclusive === 'true'
   const form = newlySelectedOption.form
   const name = newlySelectedOption.name
 
-  if (isExclusive && form && name) {
+  // We can only safely automate single-selection handling if the options are associated with a form
+  // and they have been given the same name. Also, we only deselect other options if the newly selected
+  // option is an "exclusive" option, meaning it has `data-exclusive="true"`.
+  if (isExclusiveOption(newlySelectedOption) && form && name) {
     const formControlsWithSameName = form.elements.namedItem(name)
     // If we have an instance of RadioNodeList, we have more than one form control with the same
     // name (this is expected for a option select that has multiple options). We want to uncheck


### PR DESCRIPTION
### This PR

- For part 1, see #757 
- For part 2, see #758 
- Part 3 of #424 
- Adds new `ChipSelect.determineNextControlledState` helper for consumers that must control the checked state of the chip select's options.
- Added new story to `ChipSelect` docs.

<img width="921" height="426" alt="Screenshot 2025-09-09 at 8 56 57 pm" src="https://github.com/user-attachments/assets/5b8799d6-ed10-4298-b0b4-aee0f9d3125a" />
