### PR TITLE
chore: add links to form integration examples to `ChipSelect` docs

### DIFF
--- a/src/core/chip-select/chip-select.stories.tsx
+++ b/src/core/chip-select/chip-select.stories.tsx
@@ -103,10 +103,12 @@ export const MultiSelect: Story = {
  * single-select behaviour, however, manual intervention will be required. To assist with this, the
  * `ChipSelect.determineNextControlledState` helper is provided.
  *
- * Whether single- or multi-select behaviour is desired, the controlled state must be an array.
- *
- * This example demonstrates a controlled usage of the `ChipSelect` via simple local component state
- * (`useState`) and `ChipSelect.determineNextControlledState`.
+ * Whether single- or multi-select behaviour is desired, the controlled state must be an array of
+ * string values. The example here demonstrates a controlled usage of the `ChipSelect` via simple
+ * local component state (`useState`) and `ChipSelect.determineNextControlledState`. Examples that
+ * demonstrate integration with [Formik](https://codesandbox.io/p/sandbox/eloquent-julien-hkgfgy)
+ * and [React Hook Form](https://codesandbox.io/p/sandbox/strange-lederberg-thzzwv)
+ * are also available.
  */
 export const Controlled: Story = {
   args: {

--- a/src/core/chip-select/chip-select.tsx
+++ b/src/core/chip-select/chip-select.tsx
@@ -1,4 +1,4 @@
-import { ChipSelectContextProvider } from './context'
+import { ChipSelectContext, ChipSelectContextProvider, useChipSelectContext } from './context'
 import { ChipSelectOption } from './chip-select-option'
 import { determineNextControlledState } from './chip'
 import { ElChipSelect } from './styles'
@@ -37,6 +37,10 @@ export interface ChipSelectProps extends HTMLAttributes<HTMLDivElement> {
  * both single-select and multi-select modes depending on the use case. Importantly, single-select
  * behaviour in controlled scenarios (that is, where the checked state of each option is controlled
  * by the consumer) must be handled by the consumers given they are responsible for the state.
+ *
+ * See [ChipSelect x Formik](https://codesandbox.io/p/sandbox/eloquent-julien-hkgfgy)
+ * and [ChipSelect x React Hook Form](https://codesandbox.io/p/sandbox/strange-lederberg-thzzwv)
+ * for integration examples with popular form state management libraries.
  */
 export function ChipSelect({
   children,
@@ -59,3 +63,6 @@ export function ChipSelect({
 
 ChipSelect.Option = ChipSelectOption
 ChipSelect.determineNextControlledState = determineNextControlledState
+
+ChipSelect.Context = ChipSelectContext
+ChipSelect.useContext = useChipSelectContext

--- a/src/core/chip-select/index.ts
+++ b/src/core/chip-select/index.ts
@@ -1,4 +1,5 @@
 export * from './chip'
 export * from './chip-select'
 export * from './chip-select-option'
+export * from './context'
 export * from './styles'

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -18,7 +18,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 
 ### **5.0.0-beta.50 - ??/??/25**
 
-- TBC
+- **chore:** Add Formik and React Hook Form integration examples for `ChipSelect`.
 
 ### **5.0.0-beta.49 - 09/09/25**
 


### PR DESCRIPTION
### This PR

- Adds links to example integrations with [Formik](https://codesandbox.io/p/sandbox/eloquent-julien-hkgfgy) and [React Hook Form](https://codesandbox.io/p/sandbox/strange-lederberg-thzzwv) to the `ChipSelect` docs.
- Small scout to export the chip select's context, as well as make it available via `ChipSelect.Context` and `ChipSelect.useContext`.

<img width="1032" height="390" alt="Screenshot 2025-09-10 at 7 39 58 am" src="https://github.com/user-attachments/assets/877599a4-895f-4aa9-a0e0-e9aa0e473195" />
<img width="1019" height="451" alt="Screenshot 2025-09-10 at 7 40 10 am" src="https://github.com/user-attachments/assets/c8b989ca-c8c7-4b10-b740-d0ff793fd7ae" />
