### PR TITLE
feat: add `readOnly` support to `ChipSelect`

### DIFF
--- a/src/core/chip-select/chip/__tests__/chip.test.tsx
+++ b/src/core/chip-select/chip/__tests__/chip.test.tsx
@@ -20,26 +20,57 @@ test('checkbox is correctly labelled', () => {
   expect(screen.getByRole('checkbox', { name: 'Label' })).toBeVisible()
 })
 
-test('calls `onChange` when clicked', () => {
-  const handleChange = vi.fn()
+test('applies readOnly attribute to checkbox when read-only', () => {
   render(
-    <ChipSelectChip onChange={handleChange} size="small" value="foo">
+    <ChipSelectChip readOnly size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  expect(screen.getByRole('checkbox')).toHaveAttribute('readonly')
+})
+
+test('checked state does not change when read-only', () => {
+  render(
+    <ChipSelectChip readOnly size="small" value="foo">
       Label
     </ChipSelectChip>,
   )
   fireEvent.click(screen.getByRole('checkbox'))
-  expect(handleChange).toHaveBeenCalled()
+  expect(screen.getByRole('checkbox')).not.toBeChecked()
 })
 
-test('calls `onChange` when label is clicked', () => {
-  const handleChange = vi.fn()
+test('calls `onClick` when clicked', () => {
+  const handleClick = vi.fn()
   render(
-    <ChipSelectChip onChange={handleChange} size="small" value="foo">
+    <ChipSelectChip onClick={handleClick} readOnly size="small" value="foo">
       Label
     </ChipSelectChip>,
   )
   fireEvent.click(screen.getByText('Label'))
-  expect(handleChange).toHaveBeenCalled()
+  expect(handleClick).toHaveBeenCalled()
+})
+
+test('calls `onChange` when clicked', () => {
+  const onClick = vi.fn()
+  const onChange = vi.fn()
+  render(
+    <ChipSelectChip onClick={onClick} onChange={onChange} size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  fireEvent.click(screen.getByRole('checkbox'))
+  expect(onChange).toHaveBeenCalled()
+})
+
+test('does not call `onChange` when read-only', () => {
+  const handleChange = vi.fn()
+  render(
+    <ChipSelectChip onChange={handleChange} readOnly size="small" value="foo">
+      Label
+    </ChipSelectChip>,
+  )
+  fireEvent.click(screen.getByText('Label'))
+  expect(handleChange).not.toHaveBeenCalled()
 })
 
 test('checkbox has `type="checkbox"` attribute', () => {

--- a/src/core/chip-select/chip/chip.stories.tsx
+++ b/src/core/chip-select/chip/chip.stories.tsx
@@ -64,6 +64,7 @@ export const Example: Story = {
     name: 'foo',
     onChange: undefined,
     overflow: undefined,
+    readOnly: false,
     size: 'small',
     value: 'abc-123',
   },
@@ -137,7 +138,20 @@ export const Selected: Story = {
 }
 
 /**
- * Chips can also be disabled. Importantly, disabled chips do not participate in form submission.
+ * Chips can be read-only. When they are, they will still be focusable and, if checked, will participate
+ * in form submission, but their checked state will not be changed when clicked or activated.
+ */
+export const ReadOnly: Story = {
+  name: 'Read-only',
+  args: {
+    ...Example.args,
+    readOnly: true,
+  },
+}
+
+/**
+ * Chips can also be disabled. While they look the same as readonly chips, disabled chips do not
+ * participate in form submission.
  */
 export const Disabled: Story = {
   args: {

--- a/src/core/chip-select/chip/chip.tsx
+++ b/src/core/chip-select/chip/chip.tsx
@@ -7,18 +7,21 @@ import {
 import { forwardRef, useCallback } from 'react'
 import { maybeDeselectOtherOptions } from './maybe-deselect-other-options'
 
-import type { ChangeEventHandler, InputHTMLAttributes, ReactNode } from 'react'
+import type { ChangeEventHandler, MouseEventHandler, InputHTMLAttributes, ReactNode } from 'react'
 
 // We omit a few attributes from the base input element:
+// - onClick, because we want the onClick to be handled by the label, not the input
 // - size, because we use this for our own sizing
 // - type, because chip select options are always checkboxes
-type AttributesToOmit = 'size' | 'type'
+type AttributesToOmit = 'onClick' | 'size' | 'type'
 
 export interface ChipSelectChipProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
   /** The accessible name of the chip. Should be considered mandatory when no visual label is provided. */
   'aria-label'?: string
   /** The visual label of the chip. */
   children?: ReactNode
+  /** Whether the chip is disabled. Disabled chips, even if checked, will not be submitted. */
+  disabled?: boolean
   /**
    * The icon of the chip. All chips in the same chip select should either have an icon or not.
    * If there is no visual label provided via `children`, the icon should be considered mandatory.
@@ -35,8 +38,12 @@ export interface ChipSelectChipProps extends Omit<InputHTMLAttributes<HTMLInputE
   name?: string
   /** Callback called when the chip's checked state changes. */
   onChange?: ChangeEventHandler<HTMLInputElement>
+  /** Callback called when the chip is clicked. */
+  onClick?: MouseEventHandler<HTMLLabelElement>
   /** Whether the label of the chip should be truncated if it is too long */
   overflow?: 'truncate'
+  /** Whether the chip is read-only. */
+  readOnly?: boolean
   /** The size of the chip. All chips in the same chip select should have the same size. */
   size: 'small' | 'medium' | 'large'
   /** The value of the form control. */
@@ -49,11 +56,29 @@ export interface ChipSelectChipProps extends Omit<InputHTMLAttributes<HTMLInputE
  */
 export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
   (
-    { 'aria-label': ariaLabel, children, icon, isExclusive = false, maxWidth, onChange, overflow, size, ...rest },
+    {
+      'aria-label': ariaLabel,
+      children,
+      icon,
+      isExclusive = false,
+      maxWidth,
+      onChange,
+      onClick,
+      overflow,
+      readOnly,
+      size,
+      ...rest
+    },
     ref,
   ) => {
     const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
       (event) => {
+        // If the chip is read-only, do nothing.
+        if (readOnly) {
+          event.preventDefault()
+          return
+        }
+
         // We only need to deselect other options if the one whose checked state is changing
         // has been checked. If it has been unchecked, there's nothing to do.
         if (event.currentTarget.checked) {
@@ -61,13 +86,27 @@ export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
         }
         onChange?.(event)
       },
-      [onChange],
+      [onChange, readOnly],
+    )
+
+    const handleClick = useCallback<MouseEventHandler<HTMLLabelElement>>(
+      (event) => {
+        // Since the read-only attribute has no effect on checkbox inputs, we need to manually prevent
+        // click events on chips that have been marked as read-only in order to prevent the preventDefault
+        // behaviour of changing their checked state.
+        if (readOnly) {
+          event.preventDefault()
+        }
+        onClick?.(event)
+      },
+      [onClick, readOnly],
     )
 
     return (
       <ElChipSelectChip
         aria-label={ariaLabel}
         data-size={size}
+        onClick={handleClick}
         style={{ maxWidth: maxWidth ? `var(${maxWidth})` : undefined }}
       >
         <ElChipSelectChipInput
@@ -75,6 +114,7 @@ export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
           // NOTE: this attribute is tightly coupled to the `isExclusiveOption` helper.
           data-exclusive={isExclusive}
           onChange={handleChange}
+          readOnly={readOnly}
           ref={ref}
           type="checkbox"
         />

--- a/src/core/chip-select/chip/styles.ts
+++ b/src/core/chip-select/chip/styles.ts
@@ -45,6 +45,10 @@ export const ElChipSelectChip = styled.label<ElChipSelectChipProps>`
 
   &:has(input:disabled) {
     cursor: not-allowed;
+  }
+
+  &:has(input:disabled),
+  &:has(input[readonly]) {
     background: var(--comp-interactive_chip-colour-fill-disabled-unselected);
     border-color: var(--comp-interactive_chip-colour-fill-disabled-unselected);
     color: var(--comp-interactive_chip-colour-text-disabled-unselected);
@@ -108,11 +112,11 @@ export const ElChipSelectChipIconContainer = styled.span`
     color: var(--comp-interactive_chip-colour-icon-hover-selected);
   }
 
-  input:disabled ~ & {
+  input:is(:disabled, [readonly]) ~ & {
     color: var(--comp-interactive_chip-colour-icon-disabled-unselected);
   }
 
-  input:disabled:checked ~ & {
+  input:is(:disabled, [readonly]):checked ~ & {
     color: var(--comp-interactive_chip-colour-icon-disabled-selected);
   }
 
@@ -145,7 +149,7 @@ export const ElChipSelectChipLabelText = styled.span<ElChipSelectChipLabelTextPr
     color: var(--neutral-700);
   }
 
-  input:disabled ~ * & {
+  input:is(:disabled, [readonly]) ~ * & {
     color: var(--neutral-400);
   }
 


### PR DESCRIPTION
### This PR

- Adds support for `readOnly` to `ChipSelectChip`.

<img width="1013" height="249" alt="Screenshot 2025-09-10 at 11 00 11 am" src="https://github.com/user-attachments/assets/3caee7e6-495f-43a0-aabe-c6708a5e5024" />
