### PR TITLE
chore: apply namespace pattern for component props (part 1)

### DIFF
--- a/src/core/accordion/accordion.tsx
+++ b/src/core/accordion/accordion.tsx
@@ -5,21 +5,23 @@ import { useId } from 'react'
 
 import type { DetailsHTMLAttributes, ReactNode } from 'react'
 
-export interface AccordionProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
-  /**
-   * The content to be shown/hidden when the accordion is toggled.
-   */
-  children: ReactNode
-  /**
-   * Whether the accordion is open or not. Even if this is provided, the accordion will be uncontrolled by default.
-   * If you need to control this state, you will also need to handle click events on the accordion's summary element.
-   */
-  open?: boolean
-  /**
-   * The summary/header for the accordion. Will typically be an `Accordion.Summary`. If a custom element is
-   * rendered, it should be a `<summary>` element.
-   */
-  summary: ReactNode
+export namespace Accordion {
+  export interface Props extends DetailsHTMLAttributes<HTMLDetailsElement> {
+    /**
+     * The content to be shown/hidden when the accordion is toggled.
+     */
+    children: ReactNode
+    /**
+     * Whether the accordion is open or not. Even if this is provided, the accordion will be uncontrolled by default.
+     * If you need to control this state, you will also need to handle click events on the accordion's summary element.
+     */
+    open?: boolean
+    /**
+     * The summary/header for the accordion. Will typically be an `Accordion.Summary`. If a custom element is
+     * rendered, it should be a `<summary>` element.
+     */
+    summary: ReactNode
+  }
 }
 
 /**
@@ -29,7 +31,7 @@ export interface AccordionProps extends DetailsHTMLAttributes<HTMLDetailsElement
  * **Note:** The open state of the accordion is uncontrolled by default. If you need to control this state,
  * you can do so via the `open` prop, but please surface your use-case with the Elements team first.
  */
-export function Accordion({ 'aria-labelledby': ariaLabelledBy, children, summary, ...rest }: AccordionProps) {
+export function Accordion({ 'aria-labelledby': ariaLabelledBy, children, summary, ...rest }: Accordion.Props) {
   const labelId = ariaLabelledBy ?? useId()
 
   return (
@@ -41,3 +43,6 @@ export function Accordion({ 'aria-labelledby': ariaLabelledBy, children, summary
 }
 
 Accordion.Summary = AccordionSummary
+
+/** @deprecated Use Accordion.Props instead */
+export type AccordionProps = Accordion.Props

--- a/src/core/accordion/summary/summary.tsx
+++ b/src/core/accordion/summary/summary.tsx
@@ -9,15 +9,17 @@ import {
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface AccordionSummaryProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * The accordion's title. This will also serve as the accessible label for the accordion.
-   */
-  children: ReactNode
-  /**
-   * Optional information to display on the right side of the summary
-   */
-  rightInfo?: ReactNode
+export namespace AccordionSummary {
+  export interface Props extends HTMLAttributes<HTMLElement> {
+    /**
+     * The accordion's title. This will also serve as the accessible label for the accordion.
+     */
+    children: ReactNode
+    /**
+     * Optional information to display on the right side of the summary
+     */
+    rightInfo?: ReactNode
+  }
 }
 
 /**
@@ -28,7 +30,7 @@ interface AccordionSummaryProps extends HTMLAttributes<HTMLElement> {
  * ⚠️ **Important**: `<summary>` elements are not interactive outside of a parent `<details>` element.
  * This component should only be used as the summary for an Accordion component.
  */
-export function AccordionSummary({ children, rightInfo, ...rest }: AccordionSummaryProps) {
+export function AccordionSummary({ children, rightInfo, ...rest }: AccordionSummary.Props) {
   const labelId = useAccordionLabelIdContext()
   return (
     <ElAccordionSummary {...rest}>

--- a/src/core/avatar-rectangle/avatar-rectangle.tsx
+++ b/src/core/avatar-rectangle/avatar-rectangle.tsx
@@ -9,17 +9,22 @@ import {
   ElAvatarRectResidentialSmallPlaceholder,
 } from './styles'
 
-export interface AvatarRectangle extends HTMLAttributes<HTMLDivElement> {
-  variant: 'residential' | 'commercial'
-  size: 'medium' | 'small'
-  src?: string
-  alt?: string
+export namespace AvatarRectangle {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    variant: 'residential' | 'commercial'
+    size: 'medium' | 'small'
+    src?: string
+    alt?: string
+  }
 }
+
+/** @deprecated Use AvatarRectangle.Props instead */
+export type AvatarRectangle = AvatarRectangle.Props
 
 /**
  * A versatile component designed to render property image.
  */
-export const AvatarRectangle: FC<AvatarRectangle> = ({
+export const AvatarRectangle: FC<AvatarRectangle.Props> = ({
   size = 'medium',
   variant = 'residential',
   src,

--- a/src/core/avatar/avatar.tsx
+++ b/src/core/avatar/avatar.tsx
@@ -1,19 +1,25 @@
-import { FC, HTMLAttributes } from 'react'
 import { ElAvatar } from './styles'
 
-export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
-  /** The colour of the avatar. */
-  colour?: 'default' | 'purple'
-  /** The shape of the avatar. */
-  shape?: 'circle' | 'square'
-  /** The size of the avatar. */
-  size?: 'medium' | 'small'
+import type { FC, HTMLAttributes } from 'react'
+
+export namespace Avatar {
+  export interface Props extends HTMLAttributes<HTMLSpanElement> {
+    /** The colour of the avatar. */
+    colour?: 'default' | 'purple'
+    /** The shape of the avatar. */
+    shape?: 'circle' | 'square'
+    /** The size of the avatar. */
+    size?: 'medium' | 'small'
+  }
 }
+
+/** @deprecated Use Avatar.Props instead */
+export type AvatarProps = Avatar.Props
 
 /**
  * A simple avatar component that can be used to represent a user or other entity.
  */
-export const Avatar: FC<AvatarProps> = ({
+export const Avatar: FC<Avatar.Props> = ({
   colour = 'default',
   children,
   shape = 'circle',

--- a/src/core/badge/badge.tsx
+++ b/src/core/badge/badge.tsx
@@ -4,19 +4,21 @@ import { Tooltip } from '#src/core/tooltip'
 import type { BadgeColour } from './styles'
 import { useId, type HTMLAttributes, type ReactNode } from 'react'
 
-interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
-  /** The label for the badge. This is considered mandatory for icon-only badges. */
-  'aria-label'?: string
-  /** The badge label. */
-  children?: ReactNode
-  /** The colour of the badge. */
-  colour: BadgeColour
-  /** The left icon of the badge. */
-  iconLeft?: ReactNode
-  /** The right icon of the badge. */
-  iconRight?: ReactNode
-  /** Whether the badge is reversed. */
-  variant?: 'default' | 'reversed'
+export namespace Badge {
+  export interface Props extends HTMLAttributes<HTMLSpanElement> {
+    /** The label for the badge. This is considered mandatory for icon-only badges. */
+    'aria-label'?: string
+    /** The badge label. */
+    children?: ReactNode
+    /** The colour of the badge. */
+    colour: BadgeColour
+    /** The left icon of the badge. */
+    iconLeft?: ReactNode
+    /** The right icon of the badge. */
+    iconRight?: ReactNode
+    /** Whether the badge is reversed. */
+    variant?: 'default' | 'reversed'
+  }
 }
 
 /**
@@ -31,7 +33,7 @@ export function Badge({
   id,
   variant = 'default',
   ...rest
-}: BadgeProps) {
+}: Badge.Props) {
   // It's an icon-only badge if there's no label text and only one icon
   const isIconOnly = !children && (iconLeft || iconRight) && !(iconLeft && iconRight)
   const useTooltip = isIconOnly && ariaLabel

--- a/src/core/button-group/button-group.tsx
+++ b/src/core/button-group/button-group.tsx
@@ -1,10 +1,12 @@
 import { FC, HTMLAttributes, ReactNode } from 'react'
 import { ElButtonGroup } from './styles'
 
-interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode
+export namespace ButtonGroup {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    children: ReactNode
+  }
 }
 
-export const ButtonGroup: FC<ButtonGroupProps> = ({ children, ...rest }) => {
+export const ButtonGroup: FC<ButtonGroup.Props> = ({ children, ...rest }) => {
   return <ElButtonGroup {...rest}>{children}</ElButtonGroup>
 }

--- a/src/core/button/anchor-button.tsx
+++ b/src/core/button/anchor-button.tsx
@@ -1,11 +1,13 @@
 import { ButtonBase } from './button-base'
 
 import type { AnchorHTMLAttributes } from 'react'
-import type { CommonButtonBaseProps } from './button-base'
+import type { ButtonBase as ButtonBaseNamespace } from './button-base'
 
-export interface AnchorButtonProps extends CommonButtonBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** The URL to which this anchor button navigates */
-  href: string
+export namespace AnchorButton {
+  export interface Props extends ButtonBaseNamespace.CommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** The URL to which this anchor button navigates */
+    href: string
+  }
 }
 
 /**
@@ -15,6 +17,6 @@ export interface AnchorButtonProps extends CommonButtonBaseProps, AnchorHTMLAttr
  * Use `AnchorButton` when you need button-like styling but want to navigate to a URL. Use `Button` when the action
  * needs to occur on click.
  */
-export function AnchorButton(props: AnchorButtonProps) {
+export function AnchorButton(props: AnchorButton.Props) {
   return <ButtonBase as="a" {...props} />
 }

--- a/src/core/button/button-base.tsx
+++ b/src/core/button/button-base.tsx
@@ -5,47 +5,49 @@ import { useCallback } from 'react'
 
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
 
-export interface CommonButtonBaseProps {
-  /**
-   * Whether the button is disabled. This can be used to make the button appear disabled to users, but still be
-   * focusable. ARIA disabled buttons, whether they are button or anchor DOM elements, will ignore click events.
-   * Using `aria-disabled` is preferred when the button should still be focusable while it's disabled; for example,
-   * to allow a tooltip to be displayed that explains why the button is disabled.
-   */
-  'aria-disabled'?: boolean | 'true' | 'false'
-  /** The button's label */
-  children?: ReactNode
-  /** Remove default padding. Only applies to tertiary buttons. */
-  hasNoPadding?: boolean
-  /** Icon to display on the left side */
-  iconLeft?: ReactNode
-  /** Icon to display on the right side */
-  iconRight?: ReactNode
-  /**
-   * Whether the button is in a busy state. A busy button will be `aria-disabled`, so will be focusable. However,
-   * click events will be ignored while it is busy.
-   */
-  isBusy?: boolean
-  /** Whether the button represents a destructive action */
-  isDestructive?: boolean
-  /** The size of the button */
-  size: 'small' | 'medium' | 'large'
-  /** Whether to use link-style appearance. Only applies to tertiary buttons. */
-  useLinkStyle?: boolean
-  /** The visual variant of the button */
-  variant: 'primary' | 'secondary' | 'tertiary'
-}
+export namespace ButtonBase {
+  export interface CommonProps {
+    /**
+     * Whether the button is disabled. This can be used to make the button appear disabled to users, but still be
+     * focusable. ARIA disabled buttons, whether they are button or anchor DOM elements, will ignore click events.
+     * Using `aria-disabled` is preferred when the button should still be focusable while it's disabled; for example,
+     * to allow a tooltip to be displayed that explains why the button is disabled.
+     */
+    'aria-disabled'?: boolean | 'true' | 'false'
+    /** The button's label */
+    children?: ReactNode
+    /** Remove default padding. Only applies to tertiary buttons. */
+    hasNoPadding?: boolean
+    /** Icon to display on the left side */
+    iconLeft?: ReactNode
+    /** Icon to display on the right side */
+    iconRight?: ReactNode
+    /**
+     * Whether the button is in a busy state. A busy button will be `aria-disabled`, so will be focusable. However,
+     * click events will be ignored while it is busy.
+     */
+    isBusy?: boolean
+    /** Whether the button represents a destructive action */
+    isDestructive?: boolean
+    /** The size of the button */
+    size: 'small' | 'medium' | 'large'
+    /** Whether to use link-style appearance. Only applies to tertiary buttons. */
+    useLinkStyle?: boolean
+    /** The visual variant of the button */
+    variant: 'primary' | 'secondary' | 'tertiary'
+  }
 
-export interface ButtonBaseAsButtonProps extends CommonButtonBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
-  as: 'button'
-}
+  export interface AsButtonProps extends CommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
+    as: 'button'
+  }
 
-export interface ButtonBaseAsAnchorProps extends CommonButtonBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
-  as: 'a'
-  href: string
-}
+  export interface AsAnchorProps extends CommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+    as: 'a'
+    href: string
+  }
 
-export type ButtonBaseProps = ButtonBaseAsButtonProps | ButtonBaseAsAnchorProps
+  export type Props = AsButtonProps | AsAnchorProps
+}
 
 /**
  * A polymorphic button foundation that can render as either a button or anchor element.
@@ -67,7 +69,7 @@ export function ButtonBase({
   useLinkStyle,
   variant,
   ...rest
-}: ButtonBaseProps) {
+}: ButtonBase.Props) {
   // It's an icon-only button if there's no label text and only one icon
   const isIconOnly = !children && (iconLeft || iconRight) && !(iconLeft && iconRight)
 

--- a/src/core/button/button.tsx
+++ b/src/core/button/button.tsx
@@ -1,14 +1,16 @@
 import { ButtonBase } from './button-base'
 
 import type { ButtonHTMLAttributes } from 'react'
-import type { CommonButtonBaseProps } from './button-base'
+import type { ButtonBase as ButtonBaseNamespace } from './button-base'
 
-export interface ButtonProps extends CommonButtonBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
-  /**
-   * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will not be
-   * focusable or interactive.
-   */
-  disabled?: boolean
+export namespace Button {
+  export interface Props extends ButtonBaseNamespace.CommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
+    /**
+     * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will not be
+     * focusable or interactive.
+     */
+    disabled?: boolean
+  }
 }
 
 /**
@@ -18,6 +20,6 @@ export interface ButtonProps extends CommonButtonBaseProps, ButtonHTMLAttributes
  * Use `Button` when the action needs to occur on click. Use `AnchorButton` when you need button-like styling but want
  * to navigate to a URL.
  */
-export function Button(props: ButtonProps) {
+export function Button(props: Button.Props) {
   return <ButtonBase as="button" {...props} />
 }

--- a/src/core/chip-group/chip-group-item.tsx
+++ b/src/core/chip-group/chip-group-item.tsx
@@ -3,12 +3,14 @@ import { Chip } from '../chip/chip'
 
 import type { ComponentProps } from 'react'
 
-interface ChipGroupItemProps extends ComponentProps<typeof Chip> {}
+export namespace ChipGroupItem {
+  export interface Props extends ComponentProps<typeof Chip> {}
+}
 
 /**
  * A thin wrapper around a chip to ensure it is rendered as a list item inside the chip group.
  */
-export function ChipGroupItem(props: ChipGroupItemProps) {
+export function ChipGroupItem(props: ChipGroupItem.Props) {
   return (
     <ElChipGroupListItem>
       <Chip {...props} />

--- a/src/core/chip-group/chip-group.tsx
+++ b/src/core/chip-group/chip-group.tsx
@@ -3,20 +3,22 @@ import { ElChipGroupList } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface ChipGroupProps extends HTMLAttributes<HTMLUListElement> {
-  /** The chip group items. */
-  children: ReactNode
-  /** Whether the chip group should wrap or not. */
-  flow?: 'wrap' | 'nowrap'
-  /** What overflow behaviour the chip group should exhibit. */
-  overflow?: 'auto' | 'visible'
+export namespace ChipGroup {
+  export interface Props extends HTMLAttributes<HTMLUListElement> {
+    /** The chip group items. */
+    children: ReactNode
+    /** Whether the chip group should wrap or not. */
+    flow?: 'wrap' | 'nowrap'
+    /** What overflow behaviour the chip group should exhibit. */
+    overflow?: 'auto' | 'visible'
+  }
 }
 
 /**
  * Groups multiple chips together. Should only be used to group chips of the same variant. By default,
  * chips will wrap within the group, though horizontal scrolling can be permitted when required.
  */
-export function ChipGroup({ children, flow = 'wrap', overflow = 'visible', ...rest }: ChipGroupProps) {
+export function ChipGroup({ children, flow = 'wrap', overflow = 'visible', ...rest }: ChipGroup.Props) {
   return (
     <ElChipGroupList {...rest} data-flow={flow} data-overflow={overflow}>
       {children}

--- a/src/core/chip/chip.tsx
+++ b/src/core/chip/chip.tsx
@@ -4,34 +4,36 @@ import { useCallback } from 'react'
 
 import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react'
 
-type ElementAttributes = ButtonHTMLAttributes<HTMLButtonElement>
+export namespace Chip {
+  type ElementAttributes = ButtonHTMLAttributes<HTMLButtonElement>
 
-// We omit a few attributes from the base ElChip component (itself based on a <button>):
-// - `disabled`: we use `isDisabled` instead (which maps to `aria-disabled`).
-// - `type`: chips should never be used as form submit or reset buttons.
-type ElementAttributesToOmit = Extract<keyof ElementAttributes, 'disabled' | 'type'>
+  // We omit a few attributes from the base ElChip component (itself based on a <button>):
+  // - `disabled`: we use `isDisabled` instead (which maps to `aria-disabled`).
+  // - `type`: chips should never be used as form submit or reset buttons.
+  type ElementAttributesToOmit = Extract<keyof ElementAttributes, 'disabled' | 'type'>
 
-interface ChipProps extends Omit<ElementAttributes, ElementAttributesToOmit> {
-  /**
-   * Whether the chip is disabled. This can be used to make the chip appear disabled to users, but still be
-   * focusable. ARIA disabled chips, whether they are button or anchor DOM elements, will ignore click events.
-   * Using `aria-disabled` is preferred when the chip should still be focusable while it's disabled; for example,
-   * to allow a tooltip to be displayed that explains why the chip is disabled.
-   */
-  'aria-disabled'?: boolean | 'true' | 'false'
-  /** The label of the chip */
-  children: ReactNode
-  /**
-   * Whether the button is disabled or not. Unlike `aria-disabled`, chips disabled with this prop will not be
-   * focusable or interactive.
-   */
-  disabled?: boolean
-  /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
-  maxWidth?: `--size-${string}`
-  /** Whether the label of the chip should be truncated if it is too long */
-  overflow?: 'truncate'
-  /** The variant of the chip */
-  variant: 'filter' | 'selection'
+  export interface Props extends Omit<ElementAttributes, ElementAttributesToOmit> {
+    /**
+     * Whether the chip is disabled. This can be used to make the chip appear disabled to users, but still be
+     * focusable. ARIA disabled chips, whether they are button or anchor DOM elements, will ignore click events.
+     * Using `aria-disabled` is preferred when the chip should still be focusable while it's disabled; for example,
+     * to allow a tooltip to be displayed that explains why the chip is disabled.
+     */
+    'aria-disabled'?: boolean | 'true' | 'false'
+    /** The label of the chip */
+    children: ReactNode
+    /**
+     * Whether the button is disabled or not. Unlike `aria-disabled`, chips disabled with this prop will not be
+     * focusable or interactive.
+     */
+    disabled?: boolean
+    /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
+    maxWidth?: `--size-${string}`
+    /** Whether the label of the chip should be truncated if it is too long */
+    overflow?: 'truncate'
+    /** The variant of the chip */
+    variant: 'filter' | 'selection'
+  }
 }
 
 /**
@@ -45,7 +47,7 @@ export function Chip({
   overflow,
   variant,
   ...rest
-}: ChipProps) {
+}: Chip.Props) {
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (event) => {
       const element = event.currentTarget

--- a/src/core/compact-select-native/compact-select-native.tsx
+++ b/src/core/compact-select-native/compact-select-native.tsx
@@ -9,24 +9,26 @@ import type { ReactNode, SelectHTMLAttributes } from 'react'
 // - `multiple` because it is incompatible with our compact select design.
 type AttributesToOmit = 'size' | 'multiple'
 
-export interface CompactSelectNativeProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, AttributesToOmit> {
-  /** The accessible name of the select */
-  'aria-label': string
-  /**
-   * Specifies what, if any, permission the user agent has to provide automated assistance in filling
-   * out form field values, as well as guidance to the browser as to the type of information expected
-   * in the field. See [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
-   * docs on MDN.
-   *
-   * Default's to `off` to avoid PII being used in forms.
-   */
-  autoComplete?: 'off' | 'on' | (string & {})
-  /** The options for the select. Must be `<option>` or `<optgroup>` elements. */
-  children: ReactNode
-  /** The maximum width of the select */
-  maxWidth?: string
-  /** The size of the select */
-  size: 'small' | 'medium' | 'large'
+export namespace CompactSelectNative {
+  export interface Props extends Omit<SelectHTMLAttributes<HTMLSelectElement>, AttributesToOmit> {
+    /** The accessible name of the select */
+    'aria-label': string
+    /**
+     * Specifies what, if any, permission the user agent has to provide automated assistance in filling
+     * out form field values, as well as guidance to the browser as to the type of information expected
+     * in the field. See [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
+     * docs on MDN.
+     *
+     * Default's to `off` to avoid PII being used in forms.
+     */
+    autoComplete?: 'off' | 'on' | (string & {})
+    /** The options for the select. Must be `<option>` or `<optgroup>` elements. */
+    children: ReactNode
+    /** The maximum width of the select */
+    maxWidth?: string
+    /** The size of the select */
+    size: 'small' | 'medium' | 'large'
+  }
 }
 
 /**
@@ -36,7 +38,7 @@ export interface CompactSelectNativeProps extends Omit<SelectHTMLAttributes<HTML
  * size itself to the size of its content, up to the maximum inline size of its container, rather than
  * the width of the longest option. Importantly, it only supports single selection.
  */
-export const CompactSelectNative = forwardRef<HTMLSelectElement, CompactSelectNativeProps>(
+export const CompactSelectNative = forwardRef<HTMLSelectElement, CompactSelectNative.Props>(
   ({ autoComplete = 'off', children, maxWidth, size, ...rest }, ref) => {
     return (
       // NOTE: We have to wrap the select in a container so our chevron icon can be positioned absolutely
@@ -60,3 +62,6 @@ export const CompactSelectNative = forwardRef<HTMLSelectElement, CompactSelectNa
     )
   },
 )
+
+/** @deprecated Use CompactSelectNative.Props instead */
+export type CompactSelectNativeProps = CompactSelectNative.Props

--- a/src/core/divider/divider.tsx
+++ b/src/core/divider/divider.tsx
@@ -2,11 +2,13 @@ import { ElDivider } from './styles'
 
 import type { HTMLAttributes } from 'react'
 
-interface DividerProps extends HTMLAttributes<HTMLHRElement> {}
+export namespace Divider {
+  export interface Props extends HTMLAttributes<HTMLHRElement> {}
+}
 
 /**
  * A simple `<hr />` element used to separate sections of content.
  */
-export function Divider(props: DividerProps) {
+export function Divider(props: Divider.Props) {
   return <ElDivider {...props} />
 }

--- a/src/core/empty-data/empty-data.tsx
+++ b/src/core/empty-data/empty-data.tsx
@@ -4,15 +4,17 @@ import { ElEmptyData } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface EmptyDataProps extends HTMLAttributes<HTMLDivElement> {
-  /** The content of the empty data. Typically an action, description, or both. */
-  children: ReactNode
-  /**
-   * The height of the empty data. By default, the height will be determined by the content,
-   * but a fixed height can be specified via this prop. Care should be taken to ensure the content
-   * is not clipped.
-   */
-  height?: `--size-${string}`
+export namespace EmptyData {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The content of the empty data. Typically an action, description, or both. */
+    children: ReactNode
+    /**
+     * The height of the empty data. By default, the height will be determined by the content,
+     * but a fixed height can be specified via this prop. Care should be taken to ensure the content
+     * is not clipped.
+     */
+    height?: `--size-${string}`
+  }
 }
 
 /**
@@ -20,7 +22,7 @@ interface EmptyDataProps extends HTMLAttributes<HTMLDivElement> {
  * At minimum, either an action ([EmptyData.Action](?path=/docs/core-emptydata-action--docs)) or description
  * ([EmptyData.Description](?path=/docs/core-emptydata-description--docs)) should be provided.
  */
-export function EmptyData({ children, height, style, ...rest }: EmptyDataProps) {
+export function EmptyData({ children, height, style, ...rest }: EmptyData.Props) {
   return (
     <ElEmptyData {...rest} style={{ ...style, height: height ? `var(${height})` : undefined }}>
       {children}


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

### This PR

Applies this namespace pattern for component props to the first group of components:
- `Accordion`
- `Avatar`
- `AvatarRectangle`
- `Badge`
- `Button`
- `ButtonGroup`
- `Chip`
- `ChipGroup`
- `CompactSelectNative`
- `Divider`
- `EmptyData`