### PR TITLE
chore: apply namespace pattern for component props (part 2)

### DIFF
--- a/src/core/app-switcher/app-avatar/app-avatar.tsx
+++ b/src/core/app-switcher/app-avatar/app-avatar.tsx
@@ -21,18 +21,20 @@ import LettingsBDMDisabled from './icons/lettings-bdm-disabled.svg?url'
 
 import type { SupportedProductId } from '../config'
 
-interface AppAvatarProps {
-  /** Whether the currently logged in user has access to the specified product or not */
-  hasAccess: boolean
-  /** The specific product whose avatar should be displayed. */
-  productId: SupportedProductId
+export namespace AppAvatar {
+  export interface Props {
+    /** Whether the currently logged in user has access to the specified product or not */
+    hasAccess: boolean
+    /** The specific product whose avatar should be displayed. */
+    productId: SupportedProductId
+  }
 }
 
 /**
  * An avatar/logo for Reapit products. The visual appearance of the avatar changes based on the current user's
  * access to the product. When user's do not have access, the avatar will be greyed out.
  */
-export function AppAvatar({ hasAccess, productId }: AppAvatarProps) {
+export function AppAvatar({ hasAccess, productId }: AppAvatar.Props) {
   switch (productId) {
     case 'agentBox':
       return hasAccess ? <img src={ReapitSales} /> : <img src={ReapitSalesDisabled} />

--- a/src/core/app-switcher/app-switcher.tsx
+++ b/src/core/app-switcher/app-switcher.tsx
@@ -11,11 +11,13 @@ import { useId } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface AppSwitcherProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /**
-   * The menu groups and their items. Should typically be `AppSwitcher.ExploreMenuGroup`,
-   * `AppSwitcher.YourAppsMenuGroup`, and `AppSwitcher.ProductMenuItem` components */
-  children: ReactNode
+export namespace AppSwitcher {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    /**
+     * The menu groups and their items. Should typically be `AppSwitcher.ExploreMenuGroup`,
+     * `AppSwitcher.YourAppsMenuGroup`, and `AppSwitcher.ProductMenuItem` components */
+    children: ReactNode
+  }
 }
 
 /**
@@ -23,7 +25,7 @@ interface AppSwitcherProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * the products the current user has access to (in the Your Apps group), and other apps from Reapit (in the
  * Explore group).
  */
-export function AppSwitcher({ children, id, ...rest }: AppSwitcherProps) {
+export function AppSwitcher({ children, id, ...rest }: AppSwitcher.Props) {
   const triggerId = id ?? useId()
   const menuId = useId()
 

--- a/src/core/app-switcher/explore-menu-group/explore-menu-group.tsx
+++ b/src/core/app-switcher/explore-menu-group/explore-menu-group.tsx
@@ -3,11 +3,13 @@ import { Menu } from '#src/core/menu'
 
 import type { ReactNode } from 'react'
 
-interface AppSwitcherMenuGroupProps {
-  children: ReactNode
+export namespace AppSwitcherExploreMenuGroup {
+  export interface Props {
+    children: ReactNode
+  }
 }
 
-function AppSwitcherExploreMenuGroup({ children }: AppSwitcherMenuGroupProps) {
+export function AppSwitcherExploreMenuGroup({ children }: AppSwitcherExploreMenuGroup.Props) {
   return (
     <Menu.Group label={'EXPLORE'}>
       <AppSwitcherMenuGroupHasAccessContext.Provider value={false}>
@@ -16,5 +18,3 @@ function AppSwitcherExploreMenuGroup({ children }: AppSwitcherMenuGroupProps) {
     </Menu.Group>
   )
 }
-
-export { AppSwitcherExploreMenuGroup }

--- a/src/core/app-switcher/menu-item/menu-item.tsx
+++ b/src/core/app-switcher/menu-item/menu-item.tsx
@@ -14,12 +14,15 @@ import type { HTMLAttributes, ReactNode } from 'react'
 // - `aria-describedby`: we want exclusive control over what text is used to describe the menu item.
 type AttributesToOmit = 'aria-labelledby' | 'aria-describedby'
 
-export interface AppSwitcherMenuItemProps
-  extends ProductConfig,
-    Omit<HTMLAttributes<HTMLAnchorElement>, AttributesToOmit> {
-  avatar: ReactNode
-  href: string
+export namespace AppSwitcherMenuItem {
+  export interface Props extends ProductConfig, Omit<HTMLAttributes<HTMLAnchorElement>, AttributesToOmit> {
+    avatar: ReactNode
+    href: string
+  }
 }
+
+/** @deprecated Use AppSwitcherMenuItem.Props instead */
+export type AppSwitcherMenuItemProps = AppSwitcherMenuItem.Props
 
 /**
  * A basic menu item for the App Switcher. Displays a product's logo, name, and supplementary info. Typically,
@@ -35,7 +38,7 @@ export function AppSwitcherMenuItem({
   href,
   supplementaryInfo,
   ...rest
-}: AppSwitcherMenuItemProps) {
+}: AppSwitcherMenuItem.Props) {
   const labelId = useId()
   const descriptionId = useId()
 

--- a/src/core/app-switcher/nav-icon-button/nav-icon-button.tsx
+++ b/src/core/app-switcher/nav-icon-button/nav-icon-button.tsx
@@ -3,10 +3,12 @@ import { TopBarNavIconItemButton } from '../../top-bar'
 
 import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
 
-interface AppSwitcherNavIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  onClick?: MouseEventHandler<HTMLButtonElement>
+export namespace AppSwitcherNavIconButton {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    onClick?: MouseEventHandler<HTMLButtonElement>
+  }
 }
 
-export function AppSwitcherNavIconButton({ 'aria-label': ariaLabel, ...rest }: AppSwitcherNavIconButtonProps) {
+export function AppSwitcherNavIconButton({ 'aria-label': ariaLabel, ...rest }: AppSwitcherNavIconButton.Props) {
   return <TopBarNavIconItemButton {...rest} aria-label={ariaLabel ?? 'App Switcher'} icon={<AppSwitcherIcon />} />
 }

--- a/src/core/app-switcher/product-menu-item/product-menu-item.tsx
+++ b/src/core/app-switcher/product-menu-item/product-menu-item.tsx
@@ -1,17 +1,19 @@
 import { AppSwitcher } from '../app-switcher'
+import { AppSwitcherMenuItem } from '../menu-item'
 import { productConfigs } from '../config'
 import { useAppSwitcherMenuGroupHasAccessContext } from '../menu-group-has-access-context'
 
-import type { AppSwitcherMenuItemProps } from '../menu-item'
 import type { SupportedProductId } from '../config'
 import type { ReactNode } from 'react'
 
-// NOTE: We extend AppSwitcherMenuItemProps to allow overriding the appName, logo, and supplementaryInfo.
-// This is purely an escape hatch for consumers to reach for if they can't upgrade to the latest version
-// of Elements but need to make some UI updates for one or more products.
-interface AppSwitcherProductMenuItemProps extends Partial<AppSwitcherMenuItemProps> {
-  productId: SupportedProductId
-  href: string
+export namespace AppSwitcherProductMenuItem {
+  // NOTE: We extend AppSwitcherMenuItem.Props to allow overriding the appName, logo, and supplementaryInfo.
+  // This is purely an escape hatch for consumers to reach for if they can't upgrade to the latest version
+  // of Elements but need to make some UI updates for one or more products.
+  export interface Props extends Partial<AppSwitcherMenuItem.Props> {
+    productId: SupportedProductId
+    href: string
+  }
 }
 
 /**
@@ -29,7 +31,7 @@ export function AppSwitcherProductMenuItem({
   href,
   productId,
   supplementaryInfo: supplementaryInfoOverride,
-}: AppSwitcherProductMenuItemProps): ReactNode {
+}: AppSwitcherProductMenuItem.Props): ReactNode {
   const hasAccess = useAppSwitcherMenuGroupHasAccessContext()
   const { appName, supplementaryInfo } = productConfigs[productId]
   return (

--- a/src/core/app-switcher/your-apps-menu-group/your-apps-menu-group.tsx
+++ b/src/core/app-switcher/your-apps-menu-group/your-apps-menu-group.tsx
@@ -3,11 +3,13 @@ import { Menu } from '#src/core/menu'
 
 import type { ReactNode } from 'react'
 
-interface AppSwitcherMenuGroupProps {
-  children: ReactNode
+export namespace AppSwitcherYourAppsMenuGroup {
+  export interface Props {
+    children: ReactNode
+  }
 }
 
-function AppSwitcherYourAppsMenuGroup({ children }: AppSwitcherMenuGroupProps) {
+export function AppSwitcherYourAppsMenuGroup({ children }: AppSwitcherYourAppsMenuGroup.Props) {
   return (
     <Menu.Group label={'YOUR APPS'}>
       <AppSwitcherMenuGroupHasAccessContext.Provider value={true}>
@@ -16,5 +18,3 @@ function AppSwitcherYourAppsMenuGroup({ children }: AppSwitcherMenuGroupProps) {
     </Menu.Group>
   )
 }
-
-export { AppSwitcherYourAppsMenuGroup }

--- a/src/core/bottom-bar/bottom-bar.tsx
+++ b/src/core/bottom-bar/bottom-bar.tsx
@@ -6,17 +6,19 @@ import { useBottomBarObserver } from './use-bottom-bar-observer'
 
 import type { HTMLAttributes, ReactNode, RefObject } from 'react'
 
-export interface BottomBarProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The children of the bottom bar
-   **/
-  children: ReactNode
-  /**
-   * The reference of the scroll container the bottom bar is rendered within
-   *
-   * @description see the story for an example
-   */
-  scrollContainerRef: RefObject<HTMLElement>
+export namespace BottomBar {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The children of the bottom bar
+     **/
+    children: ReactNode
+    /**
+     * The reference of the scroll container the bottom bar is rendered within
+     *
+     * @description see the story for an example
+     */
+    scrollContainerRef: RefObject<HTMLElement>
+  }
 }
 
 /**
@@ -29,7 +31,7 @@ export function BottomBar({
   children,
   scrollContainerRef,
   ...rest
-}: BottomBarProps) {
+}: BottomBar.Props) {
   const isOpen = useBottomBarObserver(scrollContainerRef)
 
   return (
@@ -45,3 +47,6 @@ BottomBar.Item = BottomBarMenuList.Item
 BottomBar.ItemButton = BottomBarItemButton
 BottomBar.MenuItem = BottomBarMenuList.MenuItem
 BottomBar.MenuList = BottomBarMenuList
+
+/** @deprecated Use BottomBar.Props instead */
+export type BottomBarProps = BottomBar.Props

--- a/src/core/bottom-bar/item/item-anchor.tsx
+++ b/src/core/bottom-bar/item/item-anchor.tsx
@@ -2,17 +2,19 @@ import { BottomBarItemBase } from './item-base'
 
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-interface BottomBarItemAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** Whether the item represents the current page. */
-  'aria-current': 'page' | false
-  /** The visible name of the item. */
-  children: string
-  /** Optional badge to be displayed on the nav item */
-  hasBadge?: boolean
-  /** The URL to navigate to when the item is clicked. */
-  href: string
-  /** The item's icon. */
-  icon: ReactNode
+export namespace BottomBarItemAnchor {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** Whether the item represents the current page. */
+    'aria-current': 'page' | false
+    /** The visible name of the item. */
+    children: string
+    /** Optional badge to be displayed on the nav item */
+    hasBadge?: boolean
+    /** The URL to navigate to when the item is clicked. */
+    href: string
+    /** The item's icon. */
+    icon: ReactNode
+  }
 }
 
 /**
@@ -22,6 +24,6 @@ interface BottomBarItemAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElemen
  * **Important:** ⚠️ Typically you will use this component via `BottomBar.Item` as it wraps the anchor element in a
  * list item (`<li>`) to ensure good semantics and accessibility when used with `BottomBar`.
  */
-export function BottomBarItemAnchor(props: BottomBarItemAnchorProps) {
+export function BottomBarItemAnchor(props: BottomBarItemAnchor.Props) {
   return <BottomBarItemBase {...props} as="a" />
 }

--- a/src/core/bottom-bar/item/item-base.tsx
+++ b/src/core/bottom-bar/item/item-base.tsx
@@ -3,22 +3,24 @@ import { ElBottomBarItemBadge, ElBottomBarItemIcon, ElBottomBarItemLabel, elBott
 
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react'
 
-interface BottomBarItemCommonProps {
-  hasBadge?: boolean
-  icon: ReactNode
-}
+export namespace BottomBarItemBase {
+  interface CommonProps {
+    hasBadge?: boolean
+    icon: ReactNode
+  }
 
-export interface BottomBarItemAsAnchorProps extends BottomBarItemCommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
-  as: 'a'
-  children: ReactNode
-}
+  export interface AsAnchorProps extends CommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+    as: 'a'
+    children: ReactNode
+  }
 
-export interface BottomBarItemAsButtonProps extends BottomBarItemCommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
-  as: 'button'
-  children: ReactNode
-}
+  export interface AsButtonProps extends CommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
+    as: 'button'
+    children: ReactNode
+  }
 
-export type BottomBarItemBaseProps = BottomBarItemAsAnchorProps | BottomBarItemAsButtonProps
+  export type Props = AsAnchorProps | AsButtonProps
+}
 
 /**
  * A simple polymorphic item that can render as a button or link. It is used internally by the `BottomBar.ItemAnchor`
@@ -31,7 +33,7 @@ export function BottomBarItemBase({
   icon,
   hasBadge,
   ...rest
-}: BottomBarItemBaseProps) {
+}: BottomBarItemBase.Props) {
   return (
     // NOTE: We use a type assertion here to avoid having to narrow the type of `rest` to the specific `Element` type.
     <Element {...(rest as HTMLAttributes<HTMLElement>)} className={cx(elBottomBarItem, className)}>
@@ -43,3 +45,12 @@ export function BottomBarItemBase({
     </Element>
   )
 }
+
+/** @deprecated Use BottomBarItemBase.AsAnchorProps instead */
+export type BottomBarItemAsAnchorProps = BottomBarItemBase.AsAnchorProps
+
+/** @deprecated Use BottomBarItemBase.AsButtonProps instead */
+export type BottomBarItemAsButtonProps = BottomBarItemBase.AsButtonProps
+
+/** @deprecated Use BottomBarItemBase.Props instead */
+export type BottomBarItemBaseProps = BottomBarItemBase.Props

--- a/src/core/bottom-bar/item/item-button.tsx
+++ b/src/core/bottom-bar/item/item-button.tsx
@@ -2,15 +2,17 @@ import { BottomBarItemBase } from './item-base'
 
 import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react'
 
-export interface BottomBarItemButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** The accessible name of the nav icon item. */
-  children: ReactNode
-  /** Optional badge to be displayed on the nav item */
-  hasBadge?: boolean
-  /** The nav item's icon. */
-  icon: ReactNode
-  /** The click handler for the nav item. */
-  onClick?: MouseEventHandler<HTMLButtonElement>
+export namespace BottomBarItemButton {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    /** The accessible name of the nav icon item. */
+    children: ReactNode
+    /** Optional badge to be displayed on the nav item */
+    hasBadge?: boolean
+    /** The nav item's icon. */
+    icon: ReactNode
+    /** The click handler for the nav item. */
+    onClick?: MouseEventHandler<HTMLButtonElement>
+  }
 }
 
 /**
@@ -20,6 +22,9 @@ export interface BottomBarItemButtonProps extends ButtonHTMLAttributes<HTMLButto
  * **Important:** ⚠️ Typically you will use this component via `BottomBar.MenuItem` as it wraps the button element
  * in a list item (`<li>`) to ensure good semantics and accessibility when used with `BottomBar`.
  */
-export function BottomBarItemButton(props: BottomBarItemButtonProps) {
+export function BottomBarItemButton(props: BottomBarItemButton.Props) {
   return <BottomBarItemBase as="button" {...props} />
 }
+
+/** @deprecated Use BottomBarItemButton.Props instead */
+export type BottomBarItemButtonProps = BottomBarItemButton.Props

--- a/src/core/bottom-bar/menu-list/menu-list-item.tsx
+++ b/src/core/bottom-bar/menu-list/menu-list-item.tsx
@@ -3,7 +3,9 @@ import { ElBottomBarMenuListItem } from './styles'
 
 import type { ComponentProps } from 'react'
 
-interface BottomBarListItemProps extends ComponentProps<typeof BottomBarItemAnchor> {}
+export namespace BottomBarListItem {
+  export interface Props extends ComponentProps<typeof BottomBarItemAnchor> {}
+}
 
 /**
  * A thin wrapper around `BottomBarMenuItem` that ensures it is contained within a list item (`<li>`) for
@@ -11,7 +13,7 @@ interface BottomBarListItemProps extends ComponentProps<typeof BottomBarItemAnch
  *
  * All props are passed through to `BottomBarMenuItem`.
  */
-export function BottomBarListItem({ children, ...props }: BottomBarListItemProps) {
+export function BottomBarListItem({ children, ...props }: BottomBarListItem.Props) {
   return (
     <ElBottomBarMenuListItem>
       <BottomBarItemAnchor {...props}>{children}</BottomBarItemAnchor>

--- a/src/core/bottom-bar/menu-list/menu-list-menu-item.tsx
+++ b/src/core/bottom-bar/menu-list/menu-list-menu-item.tsx
@@ -7,12 +7,14 @@ import { useEffect, useId, useRef } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface BottomBarMenuListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode
-  icon?: ReactNode
-  label?: string
-  maxWidth?: `--size-${string}`
-  maxHeight?: `--size-${string}`
+export namespace BottomBarMenuListItem {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    children: ReactNode
+    icon?: ReactNode
+    label?: string
+    maxWidth?: `--size-${string}`
+    maxHeight?: `--size-${string}`
+  }
 }
 
 /**
@@ -29,7 +31,7 @@ export function BottomBarMenuListItem({
   maxHeight,
   maxWidth,
   ...rest
-}: BottomBarMenuListItemProps) {
+}: BottomBarMenuListItem.Props) {
   const menuId = useId()
   const triggerId = id ?? useId()
 

--- a/src/core/bottom-bar/menu-list/menu-list.tsx
+++ b/src/core/bottom-bar/menu-list/menu-list.tsx
@@ -4,7 +4,9 @@ import { ElBottomBarMenuList } from './styles'
 
 import type { ComponentProps } from 'react'
 
-interface BottomBarMenuListProps extends ComponentProps<typeof ElBottomBarMenuList> {}
+export namespace BottomBarMenuList {
+  export interface Props extends ComponentProps<typeof ElBottomBarMenuList> {}
+}
 
 /**
  * The menu list for the `BottomBar`. Typically provided a collection of `BottomBar.Item` and `BottomBar.MenuItem`
@@ -15,7 +17,7 @@ interface BottomBarMenuListProps extends ComponentProps<typeof ElBottomBarMenuLi
  * button. Further, it's automatic placement logic relies on the menu being close to the viewport's edge, which means
  * it always has room on Storybook docs pages to render below its trigger.
  */
-export function BottomBarMenuList({ children, ...rest }: BottomBarMenuListProps) {
+export function BottomBarMenuList({ children, ...rest }: BottomBarMenuList.Props) {
   return <ElBottomBarMenuList {...rest}>{children}</ElBottomBarMenuList>
 }
 

--- a/src/core/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/breadcrumbs/breadcrumbs.tsx
@@ -4,11 +4,13 @@ import { ElBreadcrumbs, ElBreadcrumbsList } from './styles'
 
 import type { HTMLAttributes } from 'react'
 
-interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * Force the breadcrumb trail to grow to its maximum content width, or to 100% of its parent container.
-   */
-  overflow?: 'scroll' | 'truncate'
+export namespace Breadcrumbs {
+  export interface Props extends HTMLAttributes<HTMLElement> {
+    /**
+     * Force the breadcrumb trail to grow to its maximum content width, or to 100% of its parent container.
+     */
+    overflow?: 'scroll' | 'truncate'
+  }
 }
 
 /**
@@ -23,7 +25,7 @@ interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
  *
  * This dynamic behaviour can be overridden by specifying the `width` property.
  */
-export function Breadcrumbs({ children, overflow, ...rest }: BreadcrumbsProps) {
+export function Breadcrumbs({ children, overflow, ...rest }: Breadcrumbs.Props) {
   return (
     <ElBreadcrumbs {...rest} data-overflow={overflow}>
       <ElBreadcrumbsList>{children}</ElBreadcrumbsList>
@@ -33,3 +35,6 @@ export function Breadcrumbs({ children, overflow, ...rest }: BreadcrumbsProps) {
 
 Breadcrumbs.Item = BreadcrumbItem
 Breadcrumbs.Link = BreadcrumbLink
+
+// Backward compatibility
+export type BreadcrumbsProps = Breadcrumbs.Props

--- a/src/core/breadcrumbs/item/item.tsx
+++ b/src/core/breadcrumbs/item/item.tsx
@@ -3,18 +3,20 @@ import { ElBreadcrumbItem, ElBreadcrumbItemSeparator } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface BreadcrumbItemProps extends HTMLAttributes<HTMLLIElement> {
-  /**
-   * The content of the breadcrumb item. Typically a `Breadcrumb.Link`.
-   */
-  children: ReactNode
+export namespace BreadcrumbItem {
+  export interface Props extends HTMLAttributes<HTMLLIElement> {
+    /**
+     * The content of the breadcrumb item. Typically a `Breadcrumb.Link`.
+     */
+    children: ReactNode
+  }
 }
 
 /**
  * A breadcrumb item component that provides a chevron separator for navigation hierarchy within the breadcrumb trail.
  * Will typically be provided a single `Breadcrumb.Link` as its child.
  */
-export function BreadcrumbItem({ children, ...rest }: BreadcrumbItemProps) {
+export function BreadcrumbItem({ children, ...rest }: BreadcrumbItem.Props) {
   return (
     <ElBreadcrumbItem {...rest}>
       {children}
@@ -24,3 +26,6 @@ export function BreadcrumbItem({ children, ...rest }: BreadcrumbItemProps) {
     </ElBreadcrumbItem>
   )
 }
+
+// Backward compatibility
+export type BreadcrumbItemProps = BreadcrumbItem.Props

--- a/src/core/breadcrumbs/link/link.tsx
+++ b/src/core/breadcrumbs/link/link.tsx
@@ -2,21 +2,23 @@ import { ElBreadcrumbLink, ElBreadcrumbLinkContent } from './styles'
 
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-export interface BreadcrumbLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /**
-   * The text content to be hyperlinked to the specified URL.
-   */
-  children: ReactNode
-  /**
-   * The URL to navigate to when the link is clicked.
-   */
-  href: string
+export namespace BreadcrumbLink {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /**
+     * The text content to be hyperlinked to the specified URL.
+     */
+    children: ReactNode
+    /**
+     * The URL to navigate to when the link is clicked.
+     */
+    href: string
+  }
 }
 
 /**
  * A breadcrumb link specifically designed for use within breadcrumb navigation.
  */
-export function BreadcrumbLink({ children, ...rest }: BreadcrumbLinkProps) {
+export function BreadcrumbLink({ children, ...rest }: BreadcrumbLink.Props) {
   return (
     <ElBreadcrumbLink {...rest}>
       {/* NOTE: We wrap the children so that our text-overflow behaviour does not also clip the focus outline */}
@@ -24,3 +26,6 @@ export function BreadcrumbLink({ children, ...rest }: BreadcrumbLinkProps) {
     </ElBreadcrumbLink>
   )
 }
+
+// Backward compatibility
+export type BreadcrumbLinkProps = BreadcrumbLink.Props

--- a/src/core/chip-select/chip-select-option.tsx
+++ b/src/core/chip-select/chip-select-option.tsx
@@ -6,13 +6,18 @@ import type { ComponentProps } from 'react'
 
 type AttributesToOmit = 'isExclusive' | 'form' | 'name' | 'size'
 
-export interface ChipSelectOptionProps extends Omit<ComponentProps<typeof ChipSelectChip>, AttributesToOmit> {}
+export namespace ChipSelectOption {
+  export interface Props extends Omit<ComponentProps<typeof ChipSelectChip>, AttributesToOmit> {}
+}
+
+/** @deprecated Use ChipSelectOption.Props instead */
+export type ChipSelectOptionProps = ChipSelectOption.Props
 
 /**
  * A thin wrapper around `ChipSelectChip` that respects the `form`, `name`, `size` and selection mode
  * of the `ChipSelect`.
  */
-export const ChipSelectOption = forwardRef<HTMLInputElement, ChipSelectOptionProps>((props, ref) => {
+export const ChipSelectOption = forwardRef<HTMLInputElement, ChipSelectOption.Props>((props, ref) => {
   const { form, multiple, name, size } = useChipSelectContext()
   return <ChipSelectChip {...props} isExclusive={!multiple} form={form} name={name} ref={ref} size={size} />
 })

--- a/src/core/chip-select/chip-select.tsx
+++ b/src/core/chip-select/chip-select.tsx
@@ -5,32 +5,37 @@ import { ElChipSelect } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface ChipSelectProps extends HTMLAttributes<HTMLDivElement> {
-  /** The chip select items. */
-  children: ReactNode
-  /**
-   * The ID of the form the chip select's options should be associated with. Will be automatically passed
-   * to each option included in the chip select. Without an associated form, or a name, single-selection
-   * behaviour will not be handled out-of-the-box.
-   *
-   * An explicit value is only necessary if the chip select is not a descendant of a form element; if it
-   * is, it will be automatically associated with that ancestral form.
-   */
-  form?: string
-  /** Whether the chip select should wrap or not. */
-  flow?: 'wrap' | 'nowrap'
-  /** Whether the chip select should allow multiple selections or not. */
-  multiple?: boolean
-  /**
-   * The name each option in the chip select should use. Will be automatically passed to each option.
-   * Without a name, or an associated form, single-selection behaviour will not be handled out-of-the-box.
-   */
-  name?: string
-  /** What overflow behaviour the chip select should exhibit. */
-  overflow?: 'auto' | 'visible'
-  /** The size of the chip select's options. */
-  size: 'small' | 'medium' | 'large'
+export namespace ChipSelect {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The chip select items. */
+    children: ReactNode
+    /**
+     * The ID of the form the chip select's options should be associated with. Will be automatically passed
+     * to each option included in the chip select. Without an associated form, or a name, single-selection
+     * behaviour will not be handled out-of-the-box.
+     *
+     * An explicit value is only necessary if the chip select is not a descendant of a form element; if it
+     * is, it will be automatically associated with that ancestral form.
+     */
+    form?: string
+    /** Whether the chip select should wrap or not. */
+    flow?: 'wrap' | 'nowrap'
+    /** Whether the chip select should allow multiple selections or not. */
+    multiple?: boolean
+    /**
+     * The name each option in the chip select should use. Will be automatically passed to each option.
+     * Without a name, or an associated form, single-selection behaviour will not be handled out-of-the-box.
+     */
+    name?: string
+    /** What overflow behaviour the chip select should exhibit. */
+    overflow?: 'auto' | 'visible'
+    /** The size of the chip select's options. */
+    size: 'small' | 'medium' | 'large'
+  }
 }
+
+/** @deprecated Use ChipSelect.Props instead */
+export type ChipSelectProps = ChipSelect.Props
 
 /**
  * The chip select allows the user to select one or more options from a list of items. It supports
@@ -51,7 +56,7 @@ export function ChipSelect({
   overflow = 'visible',
   size,
   ...rest
-}: ChipSelectProps) {
+}: ChipSelect.Props) {
   return (
     <ElChipSelect {...rest} data-flow={flow} data-overflow={overflow}>
       <ChipSelectContextProvider form={form} multiple={multiple} name={name} size={size}>

--- a/src/core/chip-select/chip/chip.tsx
+++ b/src/core/chip-select/chip/chip.tsx
@@ -15,46 +15,51 @@ import type { ChangeEventHandler, MouseEventHandler, InputHTMLAttributes, ReactN
 // - type, because chip select options are always checkboxes
 type AttributesToOmit = 'onClick' | 'size' | 'type'
 
-export interface ChipSelectChipProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
-  /** The accessible name of the chip. Should be considered mandatory when no visual label is provided. */
-  'aria-label'?: string
-  /** The visual label of the chip. */
-  children?: ReactNode
-  /** Whether the chip is disabled. Disabled chips, even if checked, will not be submitted. */
-  disabled?: boolean
-  /**
-   * The icon of the chip. All chips in the same chip select should either have an icon or not.
-   * If there is no visual label provided via `children`, the icon should be considered mandatory.
-   */
-  icon?: ReactNode
-  /**
-   * Whether the chip is exclusive. That is, when it's selected, all other related chips will be
-   * deselected. Exclusive and non-exclusive chips should not be mixed in the same chip select.
-   */
-  isExclusive?: boolean
-  /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
-  maxWidth?: `--size-${string}`
-  /** Name of the form control. Submitted with the form as part of a name/value pair. */
-  name?: string
-  /** Callback called when the chip's checked state changes. */
-  onChange?: ChangeEventHandler<HTMLInputElement>
-  /** Callback called when the chip is clicked. */
-  onClick?: MouseEventHandler<HTMLLabelElement>
-  /** Whether the label of the chip should be truncated if it is too long */
-  overflow?: 'truncate'
-  /** Whether the chip is read-only. */
-  readOnly?: boolean
-  /** The size of the chip. All chips in the same chip select should have the same size. */
-  size: 'small' | 'medium' | 'large'
-  /** The value of the form control. */
-  value: InputHTMLAttributes<HTMLInputElement>['value']
+export namespace ChipSelectChip {
+  export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
+    /** The accessible name of the chip. Should be considered mandatory when no visual label is provided. */
+    'aria-label'?: string
+    /** The visual label of the chip. */
+    children?: ReactNode
+    /** Whether the chip is disabled. Disabled chips, even if checked, will not be submitted. */
+    disabled?: boolean
+    /**
+     * The icon of the chip. All chips in the same chip select should either have an icon or not.
+     * If there is no visual label provided via `children`, the icon should be considered mandatory.
+     */
+    icon?: ReactNode
+    /**
+     * Whether the chip is exclusive. That is, when it's selected, all other related chips will be
+     * deselected. Exclusive and non-exclusive chips should not be mixed in the same chip select.
+     */
+    isExclusive?: boolean
+    /** The maximum width of the chip. If not provided, the chip will be as wide as its content. */
+    maxWidth?: `--size-${string}`
+    /** Name of the form control. Submitted with the form as part of a name/value pair. */
+    name?: string
+    /** Callback called when the chip's checked state changes. */
+    onChange?: ChangeEventHandler<HTMLInputElement>
+    /** Callback called when the chip is clicked. */
+    onClick?: MouseEventHandler<HTMLLabelElement>
+    /** Whether the label of the chip should be truncated if it is too long */
+    overflow?: 'truncate'
+    /** Whether the chip is read-only. */
+    readOnly?: boolean
+    /** The size of the chip. All chips in the same chip select should have the same size. */
+    size: 'small' | 'medium' | 'large'
+    /** The value of the form control. */
+    value: InputHTMLAttributes<HTMLInputElement>['value']
+  }
 }
+
+/** @deprecated Use ChipSelectChip.Props instead */
+export type ChipSelectChipProps = ChipSelectChip.Props
 
 /**
  * An option for a `ChipSelect`. It is a styled native checkbox input, so it's checked state can be
  * controlled (or uncontrolled) like any other native input. Typically used via `ChipSelect.Option`.
  */
-export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChipProps>(
+export const ChipSelectChip = forwardRef<HTMLInputElement, ChipSelectChip.Props>(
   (
     {
       'aria-label': ariaLabel,


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

Past PRs include:
- #766 

### This PR

Applies this namespace pattern for component props to another group of components:
- `AppSwitcher`
- `BottomBar`
- `Breadcrumbs`
- `ChipSelect`