### PR TITLE
chore: apply namespace pattern for component props (part 3)

### DIFF
--- a/src/core/dialog/body/body.tsx
+++ b/src/core/dialog/body/body.tsx
@@ -1,11 +1,13 @@
 import { ElDialogBody } from './styles'
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface DialogBodyProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The content of the dialog's body.
-   */
-  children: ReactNode
+export namespace DialogBody {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The content of the dialog's body.
+     */
+    children: ReactNode
+  }
 }
 
 /**
@@ -13,6 +15,6 @@ interface DialogBodyProps extends HTMLAttributes<HTMLDivElement> {
  * container and grow to the height of its content. Like the dialog's header and footer, the body also
  * adjusts its padding based on the inline-size of the dialog.
  */
-export function DialogBody({ children, ...rest }: DialogBodyProps) {
+export function DialogBody({ children, ...rest }: DialogBody.Props) {
   return <ElDialogBody {...rest}>{children}</ElDialogBody>
 }

--- a/src/core/dialog/dialog.tsx
+++ b/src/core/dialog/dialog.tsx
@@ -8,47 +8,49 @@ import { useId } from 'react'
 
 import type { DialogHTMLAttributes, ReactNode } from 'react'
 
-// NOTE: we omit..
-// - `open` because we do not want React consumers to use it directly as it results in a non-modal experience.
-//     Instead, our React `Dialog` component provides an `isOpen` prop that ensures a modal experience is achieved.
-type AttributesToOmit = 'open'
+export namespace Dialog {
+  // NOTE: we omit..
+  // - `open` because we do not want React consumers to use it directly as it results in a non-modal experience.
+  //     Instead, our React `Dialog` component provides an `isOpen` prop that ensures a modal experience is achieved.
+  type AttributesToOmit = 'open'
 
-interface DialogProps extends Omit<DialogHTMLAttributes<HTMLDialogElement>, AttributesToOmit> {
-  /** The dialog content */
-  children: ReactNode
-  /**
-   * Specifies the types of user actions that can be used to close the dialog. This property distinguishes
-   * two methods by which a dialog can be closed:
-   *
-   *  (1) A platform-specific user action, such as pressing the `Esc` key on desktop platforms, or a "back" or
-   *    "dismiss" gesture on mobile platforms.
-   *
-   *  (2) A developer-specified mechanism such as the dialog close button and a `<form>` submission.
-   *
-   * Possible values are:
-   *
-   *  - `closerequest`: The dialog can be dismissed with a platform-specific user action or a
-   *    developer-specified mechanism. This is what detail dialogs should use.
-   *
-   *  - `none`: The dialog cannot be closed by the user (e.g. via the close button). This is what form dialogs
-   *    should use.
-   *
-   * **Note:** The `closedby` attribute for the HTML `<dialog>` element is experimental. We currently approximate
-   * its behaviour internally, but we are not using the attribute itself.
-   *
-   * **Note 2:** The HTML `<dialog>` element distinguishes a third method, `any`, for closing a dialog element,
-   * but Dialog does not currently support it. See MDN's
-   * [closedBy](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby)
-   * attribute docs for more information.
-   *
-   * **Note 3:** The `closedBy` attribute is not supported in all browsers. We currently approximate its behaviour
-   * internally, but we are not using the attribute itself.
-   */
-  closedBy?: 'closerequest' | 'none'
-  /** Indicates whether the dialog is open or not */
-  isOpen?: boolean
-  /** The size of the dialog. */
-  size: 'small' | 'medium' | 'large' | 'full-screen'
+  export interface Props extends Omit<DialogHTMLAttributes<HTMLDialogElement>, AttributesToOmit> {
+    /** The dialog content */
+    children: ReactNode
+    /**
+     * Specifies the types of user actions that can be used to close the dialog. This property distinguishes
+     * two methods by which a dialog can be closed:
+     *
+     *  (1) A platform-specific user action, such as pressing the `Esc` key on desktop platforms, or a "back" or
+     *    "dismiss" gesture on mobile platforms.
+     *
+     *  (2) A developer-specified mechanism such as the dialog close button and a `<form>` submission.
+     *
+     * Possible values are:
+     *
+     *  - `closerequest`: The dialog can be dismissed with a platform-specific user action or a
+     *    developer-specified mechanism. This is what detail dialogs should use.
+     *
+     *  - `none`: The dialog cannot be closed by the user (e.g. via the close button). This is what form dialogs
+     *    should use.
+     *
+     * **Note:** The `closedby` attribute for the HTML `<dialog>` element is experimental. We currently approximate
+     * its behaviour internally, but we are not using the attribute itself.
+     *
+     * **Note 2:** The HTML `<dialog>` element distinguishes a third method, `any`, for closing a dialog element,
+     * but Dialog does not currently support it. See MDN's
+     * [closedBy](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby)
+     * attribute docs for more information.
+     *
+     * **Note 3:** The `closedBy` attribute is not supported in all browsers. We currently approximate its behaviour
+     * internally, but we are not using the attribute itself.
+     */
+    closedBy?: 'closerequest' | 'none'
+    /** Indicates whether the dialog is open or not */
+    isOpen?: boolean
+    /** The size of the dialog. */
+    size: 'small' | 'medium' | 'large' | 'full-screen'
+  }
 }
 
 /**
@@ -72,7 +74,7 @@ export function Dialog({
   onClose: onCloseProp,
   size,
   ...rest
-}: DialogProps) {
+}: Dialog.Props) {
   // We need to imperatively show or close the dialog element when the `isOpen` prop changes.
   const ref = useDialogController(isOpenProp)
   // We need to track the DOM-held open state of the dialog element to ensure we can show/hide our children.

--- a/src/core/dialog/footer/footer.tsx
+++ b/src/core/dialog/footer/footer.tsx
@@ -2,15 +2,17 @@ import { ElDialogFooter } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface DialogFooterProps extends HTMLAttributes<HTMLDivElement> {
-  /** The footer actions. Typically one or more buttons. */
-  children: ReactNode
+export namespace DialogFooter {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The footer actions. Typically one or more buttons. */
+    children: ReactNode
+  }
 }
 
 /**
  * A footer for dialogs. Typically used to display a set of actions related to the dialog's content (e.g.
  * "Save" and "Cancel" buttons when the dialog contains a form).
  */
-export function DialogFooter({ children, ...rest }: DialogFooterProps) {
+export function DialogFooter({ children, ...rest }: DialogFooter.Props) {
   return <ElDialogFooter {...rest}>{children}</ElDialogFooter>
 }

--- a/src/core/dialog/header/header.tsx
+++ b/src/core/dialog/header/header.tsx
@@ -3,22 +3,24 @@ import { DialogHeaderCloseButton } from './close-button'
 import { ElDialogHeader, ElDialogHeaderAction, ElDialogHeaderContentContainer, ElDialogHeaderTitle } from './styles'
 import type { ComponentProps, ReactNode } from 'react'
 
-interface DialogHeaderProps extends Omit<ComponentProps<typeof ElDialogHeader>, 'title'> {
-  /** Optional close action for the dialog. Should not be used when the dialog contains a form. */
-  action?: ReactNode
-  /**
-   * The accessible label for the dialog. This should always be provided when the dialog has no visible
-   * title (i.e. `children`).
-   */
-  'aria-label'?: string
-  /** The title of the dialog. */
-  children?: ReactNode
+export namespace DialogHeader {
+  export interface Props extends Omit<ComponentProps<typeof ElDialogHeader>, 'title'> {
+    /** Optional close action for the dialog. Should not be used when the dialog contains a form. */
+    action?: ReactNode
+    /**
+     * The accessible label for the dialog. This should always be provided when the dialog has no visible
+     * title (i.e. `children`).
+     */
+    'aria-label'?: string
+    /** The title of the dialog. */
+    children?: ReactNode
+  }
 }
 
 /**
  * A header for dialogs. Contains the dialog's title, as well as an optional action (close button).
  */
-export function DialogHeader({ action, children, 'aria-label': ariaLabel, ...rest }: DialogHeaderProps) {
+export function DialogHeader({ action, children, 'aria-label': ariaLabel, ...rest }: DialogHeader.Props) {
   const { titleId } = useDialogContext() ?? {}
   return (
     // NOTE: If we don't have a visible title, we should have an aria-label on this root element.

--- a/src/core/drawer/body/body.tsx
+++ b/src/core/drawer/body/body.tsx
@@ -1,11 +1,13 @@
 import { ElDrawerBody } from './styles'
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface DrawerBodyProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The content of the drawer's body.
-   */
-  children: ReactNode
+export namespace DrawerBody {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The content of the drawer's body.
+     */
+    children: ReactNode
+  }
 }
 
 /**
@@ -13,6 +15,6 @@ interface DrawerBodyProps extends HTMLAttributes<HTMLDivElement> {
  * container and grow to the height of its content. Like the drawer's header and footer, the body also
  * adjusts its padding based on the inline-size of the drawer.
  */
-export function DrawerBody({ children, ...rest }: DrawerBodyProps) {
+export function DrawerBody({ children, ...rest }: DrawerBody.Props) {
   return <ElDrawerBody {...rest}>{children}</ElDrawerBody>
 }

--- a/src/core/drawer/drawer.tsx
+++ b/src/core/drawer/drawer.tsx
@@ -16,40 +16,42 @@ import type { DialogHTMLAttributes, ReactNode } from 'react'
 //     Instead, our React `Drawer` component provides an `isOpen` prop that ensures a modal experience is achieved.
 type AttributesToOmit = 'open'
 
-interface DrawerProps extends Omit<DialogHTMLAttributes<HTMLDialogElement>, AttributesToOmit> {
-  /** The drawer content */
-  children: ReactNode
-  /**
-   * Specifies the types of user actions that can be used to close the drawer. This property distinguishes
-   * two methods by which a drawer can be closed:
-   *
-   *  (1) A platform-specific user action, such as pressing the `Esc` key on desktop platforms, or a "back" or
-   *    "dismiss" gesture on mobile platforms.
-   *
-   *  (2) A developer-specified mechanism such as the drawer close button and a `<form>` submission.
-   *
-   * Possible values are:
-   *
-   *  - `closerequest`: The drawer can be dismissed with a platform-specific user action or a
-   *    developer-specified mechanism. This is what detail drawers should use.
-   *
-   *  - `none`: The drawer cannot be closed by the user (e.g. via the close button). This is what form drawers
-   *    should use.
-   *
-   * **Note:** The `closedby` attribute for the HTML `<dialog>` element is experimental. We currently approximate
-   * its behaviour internally, but we are not using the attribute itself.
-   *
-   * **Note 2:** The HTML `<dialog>` element distinguishes a third method, `any`, for closing a dialog element,
-   * but Drawer does not currently support it. See MDN's
-   * [closedBy](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby)
-   * attribute docs for more information.
-   *
-   * **Note 3:** The `closedBy` attribute is not supported in all browsers. We currently approximate its behaviour
-   * internally, but we are not using the attribute itself.
-   */
-  closedBy?: 'closerequest' | 'none'
-  /** Indicates whether the Drawer is open or not */
-  isOpen?: boolean
+export namespace Drawer {
+  export interface Props extends Omit<DialogHTMLAttributes<HTMLDialogElement>, AttributesToOmit> {
+    /** The drawer content */
+    children: ReactNode
+    /**
+     * Specifies the types of user actions that can be used to close the drawer. This property distinguishes
+     * two methods by which a drawer can be closed:
+     *
+     *  (1) A platform-specific user action, such as pressing the `Esc` key on desktop platforms, or a "back" or
+     *    "dismiss" gesture on mobile platforms.
+     *
+     *  (2) A developer-specified mechanism such as the drawer close button and a `<form>` submission.
+     *
+     * Possible values are:
+     *
+     *  - `closerequest`: The drawer can be dismissed with a platform-specific user action or a
+     *    developer-specified mechanism. This is what detail drawers should use.
+     *
+     *  - `none`: The drawer cannot be closed by the user (e.g. via the close button). This is what form drawers
+     *    should use.
+     *
+     * **Note:** The `closedby` attribute for the HTML `<dialog>` element is experimental. We currently approximate
+     * its behaviour internally, but we are not using the attribute itself.
+     *
+     * **Note 2:** The HTML `<dialog>` element distinguishes a third method, `any`, for closing a dialog element,
+     * but Drawer does not currently support it. See MDN's
+     * [closedBy](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby)
+     * attribute docs for more information.
+     *
+     * **Note 3:** The `closedBy` attribute is not supported in all browsers. We currently approximate its behaviour
+     * internally, but we are not using the attribute itself.
+     */
+    closedBy?: 'closerequest' | 'none'
+    /** Indicates whether the Drawer is open or not */
+    isOpen?: boolean
+  }
 }
 
 /**
@@ -71,7 +73,7 @@ export function Drawer({
   onCancel: onCancelProp,
   onClose: onCloseProp,
   ...rest
-}: DrawerProps) {
+}: Drawer.Props) {
   // We need to imperatively show or close the dialog element when the `isOpen` prop changes.
   const ref = useDialogController(isOpenProp)
   // We need to track the DOM-held open state of the dialog element to ensure we can show/hide our children.

--- a/src/core/drawer/footer/footer.tsx
+++ b/src/core/drawer/footer/footer.tsx
@@ -2,15 +2,17 @@ import { ElDrawerFooter } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface DrawerFooterProps extends HTMLAttributes<HTMLDivElement> {
-  /** The footer actions. Typically one or more buttons. */
-  children: ReactNode
+export namespace DrawerFooter {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The footer actions. Typically one or more buttons. */
+    children: ReactNode
+  }
 }
 
 /**
  * A footer for drawers. Typically used to display a set of actions related to the drawer's content (e.g.
  * "Save" and "Cancel" buttons when the drawer contains a form).
  */
-export function DrawerFooter({ children, ...rest }: DrawerFooterProps) {
+export function DrawerFooter({ children, ...rest }: DrawerFooter.Props) {
   return <ElDrawerFooter {...rest}>{children}</ElDrawerFooter>
 }

--- a/src/core/drawer/header/header.tsx
+++ b/src/core/drawer/header/header.tsx
@@ -12,24 +12,26 @@ import {
 } from './styles'
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface DrawerHeaderProps extends HTMLAttributes<HTMLDivElement> {
-  /** Optional close action for the drawer. Should not be used when the drawer contains a form. */
-  action?: ReactNode
-  /** Optional text to display above the title. */
-  overline?: ReactNode
-  /** Optional supplementary information. Typically a `SupplementaryInfo` component. */
-  supplementaryInfo?: ReactNode
-  /** Optional tabs. Typically a `Tabs` component. Note that tabs should not be used when the drawer has a footer. */
-  tabs?: ReactNode
-  /** The title of the drawer. */
-  children: ReactNode
+export namespace DrawerHeader {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** Optional close action for the drawer. Should not be used when the drawer contains a form. */
+    action?: ReactNode
+    /** Optional text to display above the title. */
+    overline?: ReactNode
+    /** Optional supplementary information. Typically a `SupplementaryInfo` component. */
+    supplementaryInfo?: ReactNode
+    /** Optional tabs. Typically a `Tabs` component. Note that tabs should not be used when the drawer has a footer. */
+    tabs?: ReactNode
+    /** The title of the drawer. */
+    children: ReactNode
+  }
 }
 
 /**
  * A header for drawers. Contains the drawer's title, as well as an optional action (close button), category,
  * supplementary info and/or tabs.
  */
-export function DrawerHeader({ action, overline, children, supplementaryInfo, tabs, ...rest }: DrawerHeaderProps) {
+export function DrawerHeader({ action, overline, children, supplementaryInfo, tabs, ...rest }: DrawerHeader.Props) {
   const { titleId } = useDrawerContext() ?? {}
   return (
     <ElDrawerHeader {...rest}>

--- a/src/core/drawer/index.ts
+++ b/src/core/drawer/index.ts
@@ -9,3 +9,15 @@ export * from './use-cancel-close-requests'
 export * from './use-dialog-controller'
 export * from './use-dialog-observer'
 export * from './use-with-stop-propagation'
+
+// Import specific components to access their namespaces for backward compatibility
+import { Drawer } from './drawer'
+import { DrawerBody } from './body'
+import { DrawerHeader } from './header'
+import { DrawerFooter } from './footer'
+
+// Backward compatibility exports
+export type DrawerProps = Drawer.Props
+export type DrawerBodyProps = DrawerBody.Props
+export type DrawerHeaderProps = DrawerHeader.Props
+export type DrawerFooterProps = DrawerFooter.Props

--- a/src/core/features/common-items/bathrooms.tsx
+++ b/src/core/features/common-items/bathrooms.tsx
@@ -1,14 +1,19 @@
 import { BathIcon } from '#src/icons/bath'
 import { FeaturesItem } from '../item'
 
-interface FeaturesBathroomsItemProps {
-  /** The number of bathrooms in the property. Can be a decimal. */
-  value: number
+export namespace FeaturesBathroomsItem {
+  export interface Props {
+    /** The number of bathrooms in the property. Can be a decimal. */
+    value: number
+  }
 }
 
 /**
  * A feature item that represents the number of bathrooms in a property.
  */
-export function FeaturesBathroomsItem({ value }: FeaturesBathroomsItemProps) {
+export function FeaturesBathroomsItem({ value }: FeaturesBathroomsItem.Props) {
   return <FeaturesItem icon={<BathIcon />} label="Bathrooms" value={value} />
 }
+
+/** @deprecated Use FeaturesBathroomsItem.Props instead */
+export type FeaturesBathroomsItemProps = FeaturesBathroomsItem.Props

--- a/src/core/features/common-items/bedrooms.tsx
+++ b/src/core/features/common-items/bedrooms.tsx
@@ -1,13 +1,18 @@
 import { BedIcon } from '#src/icons/bed'
 import { FeaturesItem } from '../item'
 
-interface FeaturesBedroomsItemProps {
-  value: number
+export namespace FeaturesBedroomsItem {
+  export interface Props {
+    value: number
+  }
 }
 
 /**
  * A feature item that represents the number of bedrooms in a property.
  */
-export function FeaturesBedroomsItem({ value }: FeaturesBedroomsItemProps) {
+export function FeaturesBedroomsItem({ value }: FeaturesBedroomsItem.Props) {
   return <FeaturesItem icon={<BedIcon />} label="Bedrooms" value={value} />
 }
+
+/** @deprecated Use FeaturesBedroomsItem.Props instead */
+export type FeaturesBedroomsItemProps = FeaturesBedroomsItem.Props

--- a/src/core/features/common-items/car-spaces.tsx
+++ b/src/core/features/common-items/car-spaces.tsx
@@ -1,14 +1,19 @@
 import { CarIcon } from '#src/icons/car'
 import { FeaturesItem } from '../item'
 
-interface FeaturesCarSpacesItemProps {
-  /** The number of car spaces in the property. */
-  value: number
+export namespace FeaturesCarSpacesItem {
+  export interface Props {
+    /** The number of car spaces in the property. */
+    value: number
+  }
 }
 
 /**
  * A feature item that represents the number of car spaces in a property.
  */
-export function FeaturesCarSpacesItem({ value }: FeaturesCarSpacesItemProps) {
+export function FeaturesCarSpacesItem({ value }: FeaturesCarSpacesItem.Props) {
   return <FeaturesItem icon={<CarIcon />} label="Car spaces" value={value} />
 }
+
+/** @deprecated Use FeaturesCarSpacesItem.Props instead */
+export type FeaturesCarSpacesItemProps = FeaturesCarSpacesItem.Props

--- a/src/core/features/common-items/land-size.tsx
+++ b/src/core/features/common-items/land-size.tsx
@@ -3,15 +3,20 @@ import { FeaturesItem } from '../item'
 
 import type { ReactNode } from 'react'
 
-interface FeaturesLandSizeItemProps {
-  /** The land size of the property. */
-  value: ReactNode
+export namespace FeaturesLandSizeItem {
+  export interface Props {
+    /** The land size of the property. */
+    value: ReactNode
+  }
 }
 
 /**
  * A feature item that represents the land size of a property. Care should be taken to ensure any abbreviated
  * area units are accessible (e.g. by using an `<abbr>` element with a `title` attribute).
  */
-export function FeaturesLandSizeItem({ value }: FeaturesLandSizeItemProps) {
+export function FeaturesLandSizeItem({ value }: FeaturesLandSizeItem.Props) {
   return <FeaturesItem icon={<LandSizeIcon />} label="Land size" value={value} />
 }
+
+/** @deprecated Use FeaturesLandSizeItem.Props instead */
+export type FeaturesLandSizeItemProps = FeaturesLandSizeItem.Props

--- a/src/core/features/features.tsx
+++ b/src/core/features/features.tsx
@@ -9,13 +9,15 @@ import {
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface FeaturesProps extends HTMLAttributes<HTMLDListElement> {
-  /** One or more feature items. Typically, bedrooms, bathrooms, car spaces, and land size. */
-  children: ReactNode
-  /** The size of the features text. */
-  size: '2xs' | 'xs' | 'sm' | 'base'
-  /** Whether to prevent wrapping of feature items. */
-  wrap?: 'wrap' | 'nowrap'
+export namespace Features {
+  export interface Props extends HTMLAttributes<HTMLDListElement> {
+    /** One or more feature items. Typically, bedrooms, bathrooms, car spaces, and land size. */
+    children: ReactNode
+    /** The size of the features text. */
+    size: '2xs' | 'xs' | 'sm' | 'base'
+    /** Whether to prevent wrapping of feature items. */
+    wrap?: 'wrap' | 'nowrap'
+  }
 }
 
 /**
@@ -25,7 +27,7 @@ export interface FeaturesProps extends HTMLAttributes<HTMLDListElement> {
  * Typically, each item will be one of the following: `Features.Bedrooms`, `Features.Bathrooms`, `Features.CarSpaces`,
  * and `Features.LandSize`, though custom items can be facilitated by using `Features.Item` directly.
  */
-export function Features({ size, wrap, ...rest }: FeaturesProps) {
+export function Features({ size, wrap, ...rest }: Features.Props) {
   return <ElFeatures {...rest} data-size={size} data-wrap={wrap} />
 }
 
@@ -35,3 +37,6 @@ Features.CarSpaces = FeaturesCarSpacesItem
 Features.LandSize = FeaturesLandSizeItem
 
 Features.Item = FeaturesItem
+
+/** @deprecated Use Features.Props instead */
+export type FeaturesProps = Features.Props

--- a/src/core/features/item/item.tsx
+++ b/src/core/features/item/item.tsx
@@ -4,10 +4,12 @@ import { useId } from 'react'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface FeaturesItemProps extends HTMLAttributes<HTMLDivElement> {
-  icon: ReactNode
-  label: string
-  value: ReactNode
+export namespace FeaturesItem {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    icon: ReactNode
+    label: string
+    value: ReactNode
+  }
 }
 
 /**
@@ -15,7 +17,7 @@ interface FeaturesItemProps extends HTMLAttributes<HTMLDivElement> {
  * using pre-configured items like `Features.Bedrooms`, `Features.Bathrooms`, `Features.CarSpaces`, and
  * `Features.LandSize`.
  */
-export function FeaturesItem({ icon, id, label, value, ...rest }: FeaturesItemProps) {
+export function FeaturesItem({ icon, id, label, value, ...rest }: FeaturesItem.Props) {
   const tooltipId = useId()
   const triggerId = id ?? useId()
 
@@ -29,3 +31,6 @@ export function FeaturesItem({ icon, id, label, value, ...rest }: FeaturesItemPr
     </ElFeaturesItem>
   )
 }
+
+/** @deprecated Use FeaturesItem.Props instead */
+export type FeaturesItemProps = FeaturesItem.Props

--- a/src/core/filter-bar/applied-filters/applied-filters.tsx
+++ b/src/core/filter-bar/applied-filters/applied-filters.tsx
@@ -2,18 +2,23 @@ import { ElFilterBarAppliedFilters, ElFilterBarAppliedFiltersActionContainer } f
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface FilterBarAppliedFiltersProps extends HTMLAttributes<HTMLDivElement> {
-  /** Optional action element. Typically a "Save filters" button. */
-  action?: ReactNode
-  /** A chip group displaying the active filters. */
-  children: ReactNode
+export namespace FilterBarAppliedFilters {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** Optional action element. Typically a "Save filters" button. */
+    action?: ReactNode
+    /** A chip group displaying the active filters. */
+    children: ReactNode
+  }
 }
+
+/** @deprecated Use FilterBarAppliedFilters.Props instead */
+export type FilterBarAppliedFiltersProps = FilterBarAppliedFilters.Props
 
 /**
  * Simple container for applied filters chips and an optional action. Typically used via
  * `FilterBar.AppliedFilters`.
  */
-export function FilterBarAppliedFilters({ action, children, ...rest }: FilterBarAppliedFiltersProps) {
+export function FilterBarAppliedFilters({ action, children, ...rest }: FilterBarAppliedFilters.Props) {
   return (
     <ElFilterBarAppliedFilters {...rest}>
       {children}

--- a/src/core/filter-bar/filter-bar.tsx
+++ b/src/core/filter-bar/filter-bar.tsx
@@ -10,19 +10,24 @@ import { FilterBarRightContent } from './right-content'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface FilterBarProps extends HTMLAttributes<HTMLDivElement> {
-  /** The applied filters. Typically used with `FilterBar.AppliedFilters`. */
-  appliedFilters?: ReactNode
-  /** Content for the left side of the filter bar. Typically used with `FilterBar.LeftContent`. */
-  leftContent?: ReactNode
-  /** Content for the right side of the filter bar. Typically used with `FilterBar.RightContent`. */
-  rightContent?: ReactNode
+export namespace FilterBar {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The applied filters. Typically used with `FilterBar.AppliedFilters`. */
+    appliedFilters?: ReactNode
+    /** Content for the left side of the filter bar. Typically used with `FilterBar.LeftContent`. */
+    leftContent?: ReactNode
+    /** Content for the right side of the filter bar. Typically used with `FilterBar.RightContent`. */
+    rightContent?: ReactNode
+  }
 }
+
+/** @deprecated Use FilterBar.Props instead */
+export type FilterBarProps = FilterBar.Props
 
 /**
  * A filter bar is used with tables or lists to lets users narrow the result set by selecting from given options.
  */
-export function FilterBar({ appliedFilters, leftContent, rightContent, ...rest }: FilterBarProps) {
+export function FilterBar({ appliedFilters, leftContent, rightContent, ...rest }: FilterBar.Props) {
   return (
     // NOTE: We apply role="search" explicitly because React Testing Library does not (yet)
     // support it implicitly for the <search> element.

--- a/src/core/filter-bar/left-content/left-content.tsx
+++ b/src/core/filter-bar/left-content/left-content.tsx
@@ -1,13 +1,18 @@
 import { ElFilterBarLeftContent } from './styles'
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface FilterBarLeftContentProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode
+export namespace FilterBarLeftContent {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    children: ReactNode
+  }
 }
+
+/** @deprecated Use FilterBarLeftContent.Props instead */
+export type FilterBarLeftContentProps = FilterBarLeftContent.Props
 
 /**
  * The left content of a filter bar. Will typically contain a search input and/or some actions.
  */
-export function FilterBarLeftContent(props: FilterBarLeftContentProps) {
+export function FilterBarLeftContent(props: FilterBarLeftContent.Props) {
   return <ElFilterBarLeftContent {...props} />
 }

--- a/src/core/filter-bar/right-content/right-content.tsx
+++ b/src/core/filter-bar/right-content/right-content.tsx
@@ -2,13 +2,18 @@ import { ElFilterBarRightContent } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface FilterBarRightContentProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode
+export namespace FilterBarRightContent {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    children: ReactNode
+  }
 }
+
+/** @deprecated Use FilterBarRightContent.Props instead */
+export type FilterBarRightContentProps = FilterBarRightContent.Props
 
 /**
  * The rigth content of a filter bar. Will typically contain controls like chip selects, buttons, or switches.
  */
-export function FilterBarRightContent(props: FilterBarRightContentProps) {
+export function FilterBarRightContent(props: FilterBarRightContent.Props) {
   return <ElFilterBarRightContent {...props} />
 }

--- a/src/core/folder-tabs/count-label/count-label.tsx
+++ b/src/core/folder-tabs/count-label/count-label.tsx
@@ -1,11 +1,13 @@
 import { ElFolderTabCountContainer, ElFolderTabCountLabel, ElFolderTabCountText } from './styles'
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface FolderTabCountLabelProps extends HTMLAttributes<HTMLSpanElement> {
-  /** The label text. */
-  children: ReactNode
-  /** The featured numerical count. */
-  count: ReactNode
+export namespace FolderTabCountLabel {
+  export interface Props extends HTMLAttributes<HTMLSpanElement> {
+    /** The label text. */
+    children: ReactNode
+    /** The featured numerical count. */
+    count: ReactNode
+  }
 }
 
 /**
@@ -13,7 +15,7 @@ interface FolderTabCountLabelProps extends HTMLAttributes<HTMLSpanElement> {
  * This is used to label tabs that need to indicate the number of associated items it contains, such as
  * the number of transactions ready for processing.
  */
-export function FolderTabCountLabel({ children, count, ...rest }: FolderTabCountLabelProps) {
+export function FolderTabCountLabel({ children, count, ...rest }: FolderTabCountLabel.Props) {
   return (
     <ElFolderTabCountContainer {...rest}>
       <ElFolderTabCountText>{count}</ElFolderTabCountText>

--- a/src/core/folder-tabs/folder-tabs.tsx
+++ b/src/core/folder-tabs/folder-tabs.tsx
@@ -4,16 +4,18 @@ import { FolderTabCountLabel } from './count-label'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface FolderTabsProps extends HTMLAttributes<HTMLElement> {
-  /** The tab items for primary navigation. Typically a collection of `FolderTabs.Item` components. */
-  children: ReactNode
+export namespace FolderTabs {
+  export interface Props extends HTMLAttributes<HTMLElement> {
+    /** The tab items for primary navigation. Typically a collection of `FolderTabs.Item` components. */
+    children: ReactNode
+  }
 }
 
 /**
  * A navigation container for primary tabs. Typically used with `FolderTabs.Item`
  * and `FolderTabs.CountLabel`.
  */
-export function FolderTabs({ children, ...rest }: FolderTabsProps) {
+export function FolderTabs({ children, ...rest }: FolderTabs.Props) {
   return (
     <ElFolderTabs {...rest}>
       <ElFolderTabsGroup role="group">{children}</ElFolderTabsGroup>

--- a/src/core/folder-tabs/tab/tab.tsx
+++ b/src/core/folder-tabs/tab/tab.tsx
@@ -3,20 +3,22 @@ import LeftWave from './left-wave.svg?react'
 import RightWave from './right-wave.svg?react'
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-interface FolderTabProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** Whether this tab represents the current page or not. */
-  'aria-current': 'page' | false
-  /** The tab's label text. Typically plain text or a `FolderTabs.CountLabel` element. */
-  children: ReactNode
-  /** The page this tab should navigate to. */
-  href: string
+export namespace FolderTab {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** Whether this tab represents the current page or not. */
+    'aria-current': 'page' | false
+    /** The tab's label text. Typically plain text or a `FolderTabs.CountLabel` element. */
+    children: ReactNode
+    /** The page this tab should navigate to. */
+    href: string
+  }
 }
 
 /**
  * Folder tabs let users switch between related sections of content within the same screen.
  * Typically used via `FolderTabs.Item`.
  */
-export function FolderTab({ children, ...rest }: FolderTabProps) {
+export function FolderTab({ children, ...rest }: FolderTab.Props) {
   return (
     <ElFolderTab {...rest}>
       <LeftWave aria-hidden className={elFolderTabWave} />


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

Past PRs include:
- #766 
- #767 

### This PR

Applies this namespace pattern for component props to another group of components:
- `Dialog`
- `Drawer`
- `Features`
- `FilterBar`
- `FolderTabs`