### PR TITLE
chore: apply namespace pattern for component props (part 4)

### DIFF
--- a/src/core/input/checkbox/checkbox.tsx
+++ b/src/core/input/checkbox/checkbox.tsx
@@ -10,12 +10,17 @@ import type { InputHTMLAttributes } from 'react'
 // - type, because this should always be a checkbox-type input.
 type AttributesToOmit = 'type'
 
-export interface CheckboxInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {}
+export namespace InputCheckbox {
+  export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {}
+}
+
+// Backward compatibility
+export type CheckboxInputProps = InputCheckbox.Props
 
 /**
  * A basic `<input type="checkbox">` component. Used internally by `Input`; not intended for direct use.
  */
-export const InputCheckbox = forwardRef<HTMLInputElement, CheckboxInputProps>(({ className, style, ...rest }, ref) => {
+export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckbox.Props>(({ className, style, ...rest }, ref) => {
   return (
     // Consumer-supplied class names and inline styles are applied to the root "container" element,
     // not the input. This is because we don't want consumers to _easily_ override the input's styles

--- a/src/core/input/input.tsx
+++ b/src/core/input/input.tsx
@@ -3,34 +3,39 @@ import { forwardRef } from 'react'
 
 import type { InputHTMLAttributes } from 'react'
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
-  /** Used to name the form control when there is no other visual or accessible name. */
-  'aria-label'?: string
-  /** Indicates whether the checkbox or radio is checked. */
-  checked?: boolean
-  /** Whether the form control is disabled. */
-  disabled?: boolean
-  /** Name of the form control. Submitted with the form as part of a name/value pair. */
-  name?: string
-  /**
-   * Whether the input's value is editable. Does not apply to `hidden`, `range`, `color`,
-   * `checkbox`, or `radio` inputs.
-   */
-  readOnly?: boolean
-  /**
-   * Whether a value is required or must be checked for the form to be submittable.
-   */
-  required?: boolean
-  /** Type of form control. */
-  type: 'checkbox'
-  /** The value of the form control. */
-  value?: InputHTMLAttributes<HTMLInputElement>['value']
+export namespace Input {
+  export interface Props extends InputHTMLAttributes<HTMLInputElement> {
+    /** Used to name the form control when there is no other visual or accessible name. */
+    'aria-label'?: string
+    /** Indicates whether the checkbox or radio is checked. */
+    checked?: boolean
+    /** Whether the form control is disabled. */
+    disabled?: boolean
+    /** Name of the form control. Submitted with the form as part of a name/value pair. */
+    name?: string
+    /**
+     * Whether the input's value is editable. Does not apply to `hidden`, `range`, `color`,
+     * `checkbox`, or `radio` inputs.
+     */
+    readOnly?: boolean
+    /**
+     * Whether a value is required or must be checked for the form to be submittable.
+     */
+    required?: boolean
+    /** Type of form control. */
+    type: 'checkbox'
+    /** The value of the form control. */
+    value?: InputHTMLAttributes<HTMLInputElement>['value']
+  }
 }
+
+// Backward compatibility
+export type InputProps = Input.Props
 
 /**
  * A thin, low-level wrapper around the native HTML `<input>` element. Like its native counterpart,
  * labels and custom validation messages are BYO.
  */
-export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+export const Input = forwardRef<HTMLInputElement, Input.Props>((props, ref) => {
   return <InputCheckbox {...props} ref={ref} />
 })

--- a/src/core/label-text/label-text.tsx
+++ b/src/core/label-text/label-text.tsx
@@ -1,13 +1,24 @@
 import React, { FC, LabelHTMLAttributes } from 'react'
 import { ElLabelRequiredMark, ElLabelText } from './styles'
 
-export interface LabelTextProps extends LabelHTMLAttributes<HTMLSpanElement> {
-  variant?: 'soft' | 'strong'
-  size?: 'small' | 'medium'
-  isRequired?: boolean
+export namespace LabelText {
+  export interface Props extends LabelHTMLAttributes<HTMLSpanElement> {
+    variant?: 'soft' | 'strong'
+    size?: 'small' | 'medium'
+    isRequired?: boolean
+  }
 }
 
-export const LabelText: FC<LabelTextProps> = ({ children, isRequired, size = 'medium', variant = 'soft', ...rest }) => {
+/** @deprecated Use LabelText.Props instead */
+export type LabelTextProps = LabelText.Props
+
+export const LabelText: FC<LabelText.Props> = ({
+  children,
+  isRequired,
+  size = 'medium',
+  variant = 'soft',
+  ...rest
+}) => {
   return (
     <ElLabelText {...rest} data-size={size} data-variant={variant}>
       {children}

--- a/src/core/link/link.tsx
+++ b/src/core/link/link.tsx
@@ -3,33 +3,38 @@ import { ElLink } from './styles'
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 import type { LinkVariant, LinkSize } from './styles'
 
-export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /**
-   * The text content to be hyperlinked to the specified URL.
-   */
-  children: ReactNode
-  /**
-   * The URL to navigate to when the link is clicked.
-   */
-  href: string
-  /**
-   * Whether the link should be displayed without an underline
-   */
-  isQuiet?: boolean
-  /**
-   * The size of the link text
-   */
-  size?: LinkSize
-  /**
-   * The visual style variant of the link
-   */
-  variant?: LinkVariant
+export namespace Link {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /**
+     * The text content to be hyperlinked to the specified URL.
+     */
+    children: ReactNode
+    /**
+     * The URL to navigate to when the link is clicked.
+     */
+    href: string
+    /**
+     * Whether the link should be displayed without an underline
+     */
+    isQuiet?: boolean
+    /**
+     * The size of the link text
+     */
+    size?: LinkSize
+    /**
+     * The visual style variant of the link
+     */
+    variant?: LinkVariant
+  }
 }
+
+// Backward compatibility export
+export type LinkProps = Link.Props
 
 /**
  * A simple, inline link component that can be used to navigate users to some other page.
  */
-export function Link({ children, isQuiet = false, size = 'base', variant = 'primary', ...rest }: LinkProps) {
+export function Link({ children, isQuiet = false, size = 'base', variant = 'primary', ...rest }: Link.Props) {
   return (
     <ElLink data-variant={variant} data-size={size} data-is-quiet={isQuiet} {...rest}>
       {children}

--- a/src/core/menu/group/group.tsx
+++ b/src/core/menu/group/group.tsx
@@ -3,23 +3,25 @@ import { useId } from 'react'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface MenuGroupProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Optional label for the menu group. Considered mandatory when there is no visual label defined
-   * by `label`.
-   */
-  'aria-label'?: string
-  /** A collection of menu items, typically `MenuGroup.Item` or `MenuGroup.AnchorItem` components */
-  children: ReactNode
-  /** Optional label for the menu group */
-  label?: ReactNode
+export namespace MenuGroup {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * Optional label for the menu group. Considered mandatory when there is no visual label defined
+     * by `label`.
+     */
+    'aria-label'?: string
+    /** A collection of menu items, typically `MenuGroup.Item` or `MenuGroup.AnchorItem` components */
+    children: ReactNode
+    /** Optional label for the menu group */
+    label?: ReactNode
+  }
 }
 
 /**
  * A menu group component that provides semantic grouping of menu items with an optional title.
  * Does not render items within a list structure, as not all menu items have to exist within a group.
  */
-export function MenuGroup({ 'aria-label': ariaLabel, children, label, role = 'group', ...rest }: MenuGroupProps) {
+export function MenuGroup({ 'aria-label': ariaLabel, children, label, role = 'group', ...rest }: MenuGroup.Props) {
   const labelId = useId()
   return (
     <ElMenuGroup {...rest} aria-label={ariaLabel} aria-labelledby={ariaLabel ? undefined : labelId} role={role}>

--- a/src/core/menu/item/anchor-item.tsx
+++ b/src/core/menu/item/anchor-item.tsx
@@ -1,13 +1,15 @@
 import { MenuItemBase } from './item-base'
 
 import type { AnchorHTMLAttributes } from 'react'
-import type { CommonMenuItemBaseProps } from './item-base'
+import type { MenuItemBase as MenuItemBaseNamespace } from './item-base'
 
-export interface MenuAnchorItemProps extends CommonMenuItemBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** Whether the menu item represents the current page */
-  'aria-current'?: 'page' | false
-  /** The URL to which this menu anchor item navigates */
-  href: string
+export namespace AnchorMenuItem {
+  export interface Props extends MenuItemBaseNamespace.CommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** Whether the menu item represents the current page */
+    'aria-current'?: 'page' | false
+    /** The URL to which this menu anchor item navigates */
+    href: string
+  }
 }
 
 /**
@@ -16,6 +18,9 @@ export interface MenuAnchorItemProps extends CommonMenuItemBaseProps, AnchorHTML
  * Use `Menu.AnchorItem` when you need menu item styling but want to navigate to a URL.
  * Use `Menu.Item` when the action needs to occur on click.
  */
-export function AnchorMenuItem(props: MenuAnchorItemProps) {
+export function AnchorMenuItem(props: AnchorMenuItem.Props) {
   return <MenuItemBase as="a" {...props} />
 }
+
+/** @deprecated Use AnchorMenuItem.Props instead */
+export type MenuAnchorItemProps = AnchorMenuItem.Props

--- a/src/core/menu/item/item-base.tsx
+++ b/src/core/menu/item/item-base.tsx
@@ -12,38 +12,40 @@ import { useCallback, useId } from 'react'
 
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
 
-export interface CommonMenuItemBaseProps {
-  /**
-   * Whether the menu item is disabled. This can be used to make the menu item appear disabled to users, but still be
-   * focusable. ARIA disabled menu items, whether they are button or anchor DOM elements, will ignore click events.
-   * Using `aria-disabled` is preferred when the menu item should still be focusable while it's disabled; for example,
-   * to allow a tooltip to be displayed that explains why the menu item is disabled.
-   */
-  'aria-disabled'?: boolean | 'true' | 'false'
-  /** Badge to display next to the primary text */
-  badge?: ReactNode
-  /** The menu item's primary label */
-  children?: ReactNode
-  /** Icon to display on the left side */
-  iconLeft?: ReactNode
-  /** Icon to display on the right side */
-  iconRight?: ReactNode
-  /** Secondary description text */
-  supplementaryInfo?: ReactNode
-}
+export namespace MenuItemBase {
+  export interface CommonProps {
+    /**
+     * Whether the menu item is disabled. This can be used to make the menu item appear disabled to users, but still be
+     * focusable. ARIA disabled menu items, whether they are button or anchor DOM elements, will ignore click events.
+     * Using `aria-disabled` is preferred when the menu item should still be focusable while it's disabled; for example,
+     * to allow a tooltip to be displayed that explains why the menu item is disabled.
+     */
+    'aria-disabled'?: boolean | 'true' | 'false'
+    /** Badge to display next to the primary text */
+    badge?: ReactNode
+    /** The menu item's primary label */
+    children?: ReactNode
+    /** Icon to display on the left side */
+    iconLeft?: ReactNode
+    /** Icon to display on the right side */
+    iconRight?: ReactNode
+    /** Secondary description text */
+    supplementaryInfo?: ReactNode
+  }
 
-export interface MenuItemAsButtonProps extends CommonMenuItemBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
-  'aria-checked'?: boolean
-  as: 'button'
-}
+  export interface AsButtonProps extends CommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
+    'aria-checked'?: boolean
+    as: 'button'
+  }
 
-export interface MenuItemAsAnchorProps extends CommonMenuItemBaseProps, AnchorHTMLAttributes<HTMLAnchorElement> {
-  'aria-current'?: 'page' | false
-  as: 'a'
-  href: string
-}
+  export interface AsAnchorProps extends CommonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+    'aria-current'?: 'page' | false
+    as: 'a'
+    href: string
+  }
 
-export type MenuItemBaseProps = MenuItemAsButtonProps | MenuItemAsAnchorProps
+  export type Props = AsButtonProps | AsAnchorProps
+}
 
 /**
  * A polymorphic menu item foundation that can render as either a button or anchor element.
@@ -62,7 +64,7 @@ export function MenuItemBase({
   role = 'menuitem',
   supplementaryInfo,
   ...rest
-}: MenuItemBaseProps) {
+}: MenuItemBase.Props) {
   const labelId = useId()
   const badgeId = useId()
   const supplementaryInfoId = useId()
@@ -115,3 +117,15 @@ export function MenuItemBase({
     </Element>
   )
 }
+
+/** @deprecated Use MenuItemBase.CommonProps instead */
+export type CommonMenuItemBaseProps = MenuItemBase.CommonProps
+
+/** @deprecated Use MenuItemBase.AsButtonProps instead */
+export type MenuItemAsButtonProps = MenuItemBase.AsButtonProps
+
+/** @deprecated Use MenuItemBase.AsAnchorProps instead */
+export type MenuItemAsAnchorProps = MenuItemBase.AsAnchorProps
+
+/** @deprecated Use MenuItemBase.Props instead */
+export type MenuItemBaseProps = MenuItemBase.Props

--- a/src/core/menu/item/item.tsx
+++ b/src/core/menu/item/item.tsx
@@ -1,16 +1,18 @@
 import { MenuItemBase } from './item-base'
 
 import type { ButtonHTMLAttributes } from 'react'
-import type { CommonMenuItemBaseProps } from './item-base'
+import type { MenuItemBase as MenuItemBaseNamespace } from './item-base'
 
-export interface MenuItemProps extends CommonMenuItemBaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Whether the menu item is selected/active */
-  'aria-checked'?: boolean
-  /**
-   * Whether the menu item is disabled or not. Unlike `aria-disabled`, menu items disabled with this prop will not be
-   * focusable or interactive. Typically, disabled menu items should be focusable, so `aria-disabled` is preferred.
-   */
-  disabled?: boolean
+export namespace MenuItem {
+  export interface Props extends MenuItemBaseNamespace.CommonProps, ButtonHTMLAttributes<HTMLButtonElement> {
+    /** Whether the menu item is selected/active */
+    'aria-checked'?: boolean
+    /**
+     * Whether the menu item is disabled or not. Unlike `aria-disabled`, menu items disabled with this prop will not be
+     * focusable or interactive. Typically, disabled menu items should be focusable, so `aria-disabled` is preferred.
+     */
+    disabled?: boolean
+  }
 }
 
 /**
@@ -19,6 +21,9 @@ export interface MenuItemProps extends CommonMenuItemBaseProps, ButtonHTMLAttrib
  * Use `Menu.Item` when the action needs to occur on click.
  * Use `Menu.AnchorItem` when you need menu item styling but want to navigate to a URL.
  */
-export function MenuItem(props: MenuItemProps) {
+export function MenuItem(props: MenuItem.Props) {
   return <MenuItemBase as="button" {...props} />
 }
+
+/** @deprecated Use MenuItem.Props instead */
+export type MenuItemProps = MenuItem.Props

--- a/src/core/menu/menu.tsx
+++ b/src/core/menu/menu.tsx
@@ -13,19 +13,21 @@ import type { HTMLAttributes } from 'react'
 // - role, because the Menu's role should always be "menu".
 type AttributesToOmit = 'role'
 
-export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
-  /** The element that labels this menu. This should be the element that controls the menu. */
-  'aria-labelledby': string
-  /** The ID of the menu. */
-  id: string
-  /** The gap between the popover and the anchor. */
-  gap?: `--spacing-${string}`
-  /** The maximum height of the menu. By default, the menu will be as tall as its content requires. */
-  maxHeight?: `--size-${string}`
-  /** The maximum width of the menu. By default, the menu will be as wide as its widest item. */
-  maxWidth?: `--size-${string}`
-  /** Where the popover should be placed relative to its anchor. */
-  placement?: 'top-start' | 'top' | 'top-end' | 'bottom-start' | 'bottom' | 'bottom-end'
+export namespace Menu {
+  export interface Props extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
+    /** The element that labels this menu. This should be the element that controls the menu. */
+    'aria-labelledby': string
+    /** The ID of the menu. */
+    id: string
+    /** The gap between the popover and the anchor. */
+    gap?: `--spacing-${string}`
+    /** The maximum height of the menu. By default, the menu will be as tall as its content requires. */
+    maxHeight?: `--size-${string}`
+    /** The maximum width of the menu. By default, the menu will be as wide as its widest item. */
+    maxWidth?: `--size-${string}`
+    /** Where the popover should be placed relative to its anchor. */
+    placement?: 'top-start' | 'top' | 'top-end' | 'bottom-start' | 'bottom' | 'bottom-end'
+  }
 }
 
 /**
@@ -44,7 +46,7 @@ export function Menu({
   onKeyDown,
   placement = 'top-start',
   ...rest
-}: MenuProps) {
+}: Menu.Props) {
   const handleClick = useCloseMenuOnClick(onClick)
   const handleKeyboardNavigation = useMenuKeyboardNavigation(onKeyDown)
 
@@ -77,3 +79,6 @@ Menu.Item = MenuItem
 
 Menu.getClosestMenuElement = Popover.getClosestPopoverElement
 Menu.getTriggerProps = Popover.getTriggerProps
+
+/** @deprecated Use Menu.Props instead */
+export type MenuProps = Menu.Props

--- a/src/core/page-header/index.ts
+++ b/src/core/page-header/index.ts
@@ -1,5 +1,6 @@
 export * from './page-header'
 export * from './styles'
+export * from './leading-element'
 export * from './subtitle'
 export * from './supplementary-info'
 export * from './title'

--- a/src/core/page-header/leading-element/leading-element.tsx
+++ b/src/core/page-header/leading-element/leading-element.tsx
@@ -2,16 +2,18 @@ import { ElPageHeaderLeadingElement } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface PageHeaderLeadingElementProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The actual leading element to display. Will typically be an image or product icon.
-   */
-  children: ReactNode
-  /**
-   * The type of leading element being displayed. This impacts the amount of space available to the element
-   * on different screen/container sizes.
-   */
-  type: 'icon' | 'image'
+export namespace PageHeaderLeadingElement {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The actual leading element to display. Will typically be an image or product icon.
+     */
+    children: ReactNode
+    /**
+     * The type of leading element being displayed. This impacts the amount of space available to the element
+     * on different screen/container sizes.
+     */
+    type: 'icon' | 'image'
+  }
 }
 
 /**
@@ -19,7 +21,7 @@ interface PageHeaderLeadingElementProps extends HTMLAttributes<HTMLDivElement> {
  * Typically used via `PageHeader.LeadingElement`. This component does not render the leading element itself, rather
  * it provides a correctly sized container, based on the `type` prop, for the leading element.
  */
-export function PageHeaderLeadingElement({ children, type, ...rest }: PageHeaderLeadingElementProps) {
+export function PageHeaderLeadingElement({ children, type, ...rest }: PageHeaderLeadingElement.Props) {
   return (
     <ElPageHeaderLeadingElement {...rest} data-type={type}>
       {children}

--- a/src/core/page-header/page-header.tsx
+++ b/src/core/page-header/page-header.tsx
@@ -13,27 +13,29 @@ import { PageHeaderTitle } from './title'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-// NOTE: We omit...
-// - `children`, because the page title's "children" are spread across multiple props.
-// - `title`, because we want to use that prop name for the page header title.
-type AttributesToOmit = 'children' | 'title'
+export namespace PageHeader {
+  // NOTE: We omit...
+  // - `children`, because the page title's "children" are spread across multiple props.
+  // - `title`, because we want to use that prop name for the page header title.
+  type AttributesToOmit = 'children' | 'title'
 
-interface PageHeaderProps extends Omit<HTMLAttributes<HTMLElement>, AttributesToOmit> {
-  /**
-   * The background colour of the page header. When no value is provided (the default), the background will be
-   * transparent.
-   */
-  backgroundColour?: 'white' | 'neutral-lightest'
-  /** The breadcrumbs for the current page. */
-  breadcrumbs?: ReactNode
-  /** The leading element, like an image or product icon. */
-  leadingElement?: ReactNode
-  /** The page subtitle. */
-  subtitle?: ReactNode
-  /** The supplementary info. */
-  supplementaryInfo?: ReactNode
-  /** The page title. */
-  title: ReactNode
+  export interface Props extends Omit<HTMLAttributes<HTMLElement>, AttributesToOmit> {
+    /**
+     * The background colour of the page header. When no value is provided (the default), the background will be
+     * transparent.
+     */
+    backgroundColour?: 'white' | 'neutral-lightest'
+    /** The breadcrumbs for the current page. */
+    breadcrumbs?: ReactNode
+    /** The leading element, like an image or product icon. */
+    leadingElement?: ReactNode
+    /** The page subtitle. */
+    subtitle?: ReactNode
+    /** The supplementary info. */
+    supplementaryInfo?: ReactNode
+    /** The page title. */
+    title: ReactNode
+  }
 }
 
 /**
@@ -47,7 +49,7 @@ export function PageHeader({
   subtitle,
   leadingElement,
   supplementaryInfo,
-}: PageHeaderProps) {
+}: PageHeader.Props) {
   return (
     <ElPageHeader
       style={{

--- a/src/core/page-header/subtitle/subtitle.tsx
+++ b/src/core/page-header/subtitle/subtitle.tsx
@@ -2,18 +2,20 @@ import { ElPageHeaderSubtitle, ElPageHeaderSubtitleText, ElPageHeaderSubtitleAdd
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface PageHeaderSubtitleProps extends HTMLAttributes<HTMLDivElement> {
-  /** The main title text to display */
-  children: ReactNode
-  /** Optional information to display alongside the title. Typically a tag group, badge, or icon. */
-  additionalInfo?: ReactNode
+export namespace PageHeaderSubtitle {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The main title text to display */
+    children: ReactNode
+    /** Optional information to display alongside the title. Typically a tag group, badge, or icon. */
+    additionalInfo?: ReactNode
+  }
 }
 
 /**
  * A subtitle component for page headers. Displays the main page's subtitle with optional, additional information.
  * Typically used via `PageHeader.Subtitle`.
  */
-export function PageHeaderSubtitle({ additionalInfo, children, ...rest }: PageHeaderSubtitleProps) {
+export function PageHeaderSubtitle({ additionalInfo, children, ...rest }: PageHeaderSubtitle.Props) {
   return (
     <ElPageHeaderSubtitle {...rest}>
       <ElPageHeaderSubtitleText>{children}</ElPageHeaderSubtitleText>

--- a/src/core/page-header/supplementary-info/supplementary-info.tsx
+++ b/src/core/page-header/supplementary-info/supplementary-info.tsx
@@ -2,18 +2,20 @@ import { ElPageHeaderSupplementaryInfo } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface PageHeaderSupplementaryInfoProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The supplementary info to display. Will typically be some combination of `SupplementaryInfo`, `Features` and
-   * `CompactSelectNative`.
-   */
-  children: ReactNode
+export namespace PageHeaderSupplementaryInfo {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The supplementary info to display. Will typically be some combination of `SupplementaryInfo`, `Features` and
+     * `CompactSelectNative`.
+     */
+    children: ReactNode
+  }
 }
 
 /**
  * Allows for supplementary info to be displayed in the page header. Used to display supplementary info, features and,
  * sometimes, compact selects. Typically used via `PageHeader.SupplementaryInfo`.
  */
-export function PageHeaderSupplementaryInfo({ children, ...rest }: PageHeaderSupplementaryInfoProps) {
+export function PageHeaderSupplementaryInfo({ children, ...rest }: PageHeaderSupplementaryInfo.Props) {
   return <ElPageHeaderSupplementaryInfo {...rest}>{children}</ElPageHeaderSupplementaryInfo>
 }

--- a/src/core/page-header/title/title.tsx
+++ b/src/core/page-header/title/title.tsx
@@ -8,20 +8,22 @@ import {
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface PageHeaderTitleProps extends HTMLAttributes<HTMLDivElement> {
-  /** The main title text to display */
-  children: ReactNode
-  /** Optional action buttons or elements (e.g., buttons, more menu) */
-  actions?: ReactNode
-  /** Optional information to display alongside the title. Typically a tag group, badge, or icon. */
-  additionalInfo?: ReactNode
+export namespace PageHeaderTitle {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The main title text to display */
+    children: ReactNode
+    /** Optional action buttons or elements (e.g., buttons, more menu) */
+    actions?: ReactNode
+    /** Optional information to display alongside the title. Typically a tag group, badge, or icon. */
+    additionalInfo?: ReactNode
+  }
 }
 
 /**
  * A title component for page headers. Displays the main page title with optional, additional information and actions.
  * Typically used via `PageHeader.Title`.
  */
-export function PageHeaderTitle({ actions, additionalInfo, children, ...rest }: PageHeaderTitleProps) {
+export function PageHeaderTitle({ actions, additionalInfo, children, ...rest }: PageHeaderTitle.Props) {
   return (
     <ElPageHeaderTitle {...rest}>
       <ElPageHeaderTitleContent>

--- a/src/core/pagination/info/info.tsx
+++ b/src/core/pagination/info/info.tsx
@@ -6,16 +6,21 @@ import type { HTMLAttributes } from 'react'
 // - children, because we control the pagination info content, not the consumer
 type AttributesToOmit = 'children'
 
-interface PaginationInfoProps extends Omit<HTMLAttributes<HTMLSpanElement>, AttributesToOmit> {
-  /** The current page number */
-  pageCount: number
-  /** The total number of pages */
-  pageNumber: number
+export namespace PaginationInfo {
+  export interface Props extends Omit<HTMLAttributes<HTMLSpanElement>, AttributesToOmit> {
+    /** The current page number */
+    pageCount: number
+    /** The total number of pages */
+    pageNumber: number
+  }
 }
 
 /**
  * A simple component for displaying the current page out of the total number of pages present.
  */
-export function PaginationInfo({ pageNumber, pageCount, ...rest }: PaginationInfoProps) {
+export function PaginationInfo({ pageNumber, pageCount, ...rest }: PaginationInfo.Props) {
   return <ElPaginationInfo {...rest}>{`${pageNumber} of ${pageCount}`}</ElPaginationInfo>
 }
+
+/** @deprecated Use PaginationInfo.Props instead */
+export type PaginationInfoProps = PaginationInfo.Props

--- a/src/core/pagination/link/link-base.tsx
+++ b/src/core/pagination/link/link-base.tsx
@@ -8,29 +8,39 @@ import type { ButtonHTMLAttributes, HTMLAttributes } from 'react'
 // - children, because the previous page and next page buttons are icon-only buttons.
 type AttributesToOmit = 'children'
 
-export interface CommonPaginationLinkProps {
-  variant: 'next-page' | 'previous-page'
+export namespace PaginationLinkBase {
+  export interface CommonProps {
+    variant: 'next-page' | 'previous-page'
+  }
+
+  export interface AsAnchorProps extends CommonProps, Omit<HTMLAttributes<HTMLAnchorElement>, AttributesToOmit> {
+    as: 'a'
+    href: string
+  }
+
+  export interface AsButtonProps extends CommonProps, Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+    as: 'button'
+  }
+
+  export type Props = AsAnchorProps | AsButtonProps
 }
 
-export interface PaginationLinkBaseAsAnchorProps
-  extends CommonPaginationLinkProps,
-    Omit<HTMLAttributes<HTMLAnchorElement>, AttributesToOmit> {
-  as: 'a'
-  href: string
-}
+/** @deprecated Use PaginationLinkBase.CommonProps instead */
+export type CommonPaginationLinkProps = PaginationLinkBase.CommonProps
 
-export interface PaginationLinkBaseAsButtonProps
-  extends CommonPaginationLinkProps,
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
-  as: 'button'
-}
+/** @deprecated Use PaginationLinkBase.AsAnchorProps instead */
+export type PaginationLinkBaseAsAnchorProps = PaginationLinkBase.AsAnchorProps
 
-export type PaginationLinkBaseProps = PaginationLinkBaseAsAnchorProps | PaginationLinkBaseAsButtonProps
+/** @deprecated Use PaginationLinkBase.AsButtonProps instead */
+export type PaginationLinkBaseAsButtonProps = PaginationLinkBase.AsButtonProps
+
+/** @deprecated Use PaginationLinkBase.Props instead */
+export type PaginationLinkBaseProps = PaginationLinkBase.Props
 
 /**
  *
  */
-export function PaginationLinkBase({ variant, ...rest }: PaginationLinkBaseProps) {
+export function PaginationLinkBase({ variant, ...rest }: PaginationLinkBase.Props) {
   const icon = variant === 'next-page' ? <ChevronRightIcon /> : <ChevronLeftIcon />
   return <ButtonBase {...rest} iconLeft={icon} size="small" variant="tertiary" />
 }

--- a/src/core/pagination/link/link-button.tsx
+++ b/src/core/pagination/link/link-button.tsx
@@ -1,30 +1,35 @@
 import { PaginationLinkBase } from './link-base'
 
 import type { ButtonHTMLAttributes } from 'react'
-import type { CommonPaginationLinkProps } from './link-base'
+import type { PaginationLinkBase as PaginationLinkBaseType } from './link-base'
 
 // NOTE: we omit...
 // - children, because the previous page and next page buttons are icon-only buttons.
 type AttributesToOmit = 'children'
 
-interface PaginationLinkButtonProps
-  extends CommonPaginationLinkProps,
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
-  /**
-   * Whether the button is disabled. This can be used to make the button appear disabled to users,
-   * but still be focusable. This will typically be used when there is no next or previous page.
-   */
-  'aria-disabled'?: boolean | 'true' | 'false'
-  /**
-   * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will
-   * not be focusable or interactive.
-   */
-  disabled?: boolean
+export namespace PaginationLinkButton {
+  export interface Props
+    extends PaginationLinkBaseType.CommonProps,
+      Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+    /**
+     * Whether the button is disabled. This can be used to make the button appear disabled to users,
+     * but still be focusable. This will typically be used when there is no next or previous page.
+     */
+    'aria-disabled'?: boolean | 'true' | 'false'
+    /**
+     * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will
+     * not be focusable or interactive.
+     */
+    disabled?: boolean
+  }
 }
 
 /**
  *
  */
-export function PaginationLinkButton({ type = 'button', ...rest }: PaginationLinkButtonProps) {
+export function PaginationLinkButton({ type = 'button', ...rest }: PaginationLinkButton.Props) {
   return <PaginationLinkBase {...rest} as="button" type={type} />
 }
+
+/** @deprecated Use PaginationLinkButton.Props instead */
+export type PaginationLinkButtonProps = PaginationLinkButton.Props

--- a/src/core/pagination/link/link.tsx
+++ b/src/core/pagination/link/link.tsx
@@ -1,27 +1,32 @@
 import { PaginationLinkBase } from './link-base'
 
-import type { CommonPaginationLinkProps } from './link-base'
+import type { PaginationLinkBase as PaginationLinkBaseType } from './link-base'
 import type { HTMLAttributes } from 'react'
 
 // NOTE: we omit...
 // - children, because the previous page and next page buttons are icon-only buttons.
 type AttributesToOmit = 'children'
 
-interface PaginationLinkProps
-  extends CommonPaginationLinkProps,
-    Omit<HTMLAttributes<HTMLAnchorElement>, AttributesToOmit> {
-  /**
-   * Whether the button is disabled. This can be used to make the button appear disabled to users,
-   * but still be focusable. This will typically be used when there is no next or previous page.
-   */
-  'aria-disabled'?: boolean
-  /** The URL of the next or previous page to navigate to. */
-  href: string
+export namespace PaginationLink {
+  export interface Props
+    extends PaginationLinkBaseType.CommonProps,
+      Omit<HTMLAttributes<HTMLAnchorElement>, AttributesToOmit> {
+    /**
+     * Whether the button is disabled. This can be used to make the button appear disabled to users,
+     * but still be focusable. This will typically be used when there is no next or previous page.
+     */
+    'aria-disabled'?: boolean
+    /** The URL of the next or previous page to navigate to. */
+    href: string
+  }
 }
 
 /**
  *
  */
-export function PaginationLink(props: PaginationLinkProps) {
+export function PaginationLink(props: PaginationLink.Props) {
   return <PaginationLinkBase {...props} as="a" />
 }
+
+/** @deprecated Use PaginationLink.Props instead */
+export type PaginationLinkProps = PaginationLink.Props

--- a/src/core/pagination/pagination.tsx
+++ b/src/core/pagination/pagination.tsx
@@ -6,37 +6,39 @@ import { useCallback } from 'react'
 
 import type { ReactNode } from 'react'
 
-export interface PaginationProps {
-  /**
-   * The action to go to the next page. Typically a `Pagination.Link`
-   * or `Pagination.LinkButton`.
-   */
-  leftAction?: ReactNode
-  /**
-   * Optional callback useful when relying on the deprecated, built-in button controls
-   * @deprecated use `leftAction` and `rightAction`
-   */
-  onPageChange?: (page: number) => void
-  /**
-   * The total number of pages.
-   */
-  pageCount: number
-  /**
-   * The current page number. Expects a 1-based value.
-   */
-  pageNumber: number
-  /**
-   * The action to go to the previous page. Typically a `Pagination.Link`
-   * or `Pagination.LinkButton`.
-   */
-  rightAction?: ReactNode
+export namespace Pagination {
+  export interface Props {
+    /**
+     * The action to go to the next page. Typically a `Pagination.Link`
+     * or `Pagination.LinkButton`.
+     */
+    leftAction?: ReactNode
+    /**
+     * Optional callback useful when relying on the deprecated, built-in button controls
+     * @deprecated use `leftAction` and `rightAction`
+     */
+    onPageChange?: (page: number) => void
+    /**
+     * The total number of pages.
+     */
+    pageCount: number
+    /**
+     * The current page number. Expects a 1-based value.
+     */
+    pageNumber: number
+    /**
+     * The action to go to the previous page. Typically a `Pagination.Link`
+     * or `Pagination.LinkButton`.
+     */
+    rightAction?: ReactNode
+  }
 }
 
 /**
  * The pagination component is used to navigate between pages. It displays the current page and the total
  * number of pages available.
  */
-export function Pagination({ leftAction, onPageChange, pageCount, pageNumber, rightAction }: PaginationProps) {
+export function Pagination({ leftAction, onPageChange, pageCount, pageNumber, rightAction }: Pagination.Props) {
   const deprecatedHandleOnNextPageClick = useCallback(() => {
     onPageChange?.(pageNumber + 1)
   }, [pageNumber])
@@ -85,3 +87,6 @@ Pagination.Link = PaginationLink
 Pagination.LinkButton = PaginationLinkButton
 
 Pagination.getLinkProps = getLinkProps
+
+/** @deprecated Use Pagination.Props instead */
+export type PaginationProps = Pagination.Props


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

Past PRs include:
- #766 
- #767 
- #768 

### This PR

Applies this namespace pattern for component props to another group of components:
- `Input`
- `LabelText`
- `Link`
- `Menu`
- `PageHeader`
- `Pagination`