### PR TITLE
chore: apply namespace pattern for component props (part 6)

### DIFF
--- a/src/core/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/breadcrumbs/breadcrumbs.tsx
@@ -36,5 +36,5 @@ export function Breadcrumbs({ children, overflow, ...rest }: Breadcrumbs.Props) 
 Breadcrumbs.Item = BreadcrumbItem
 Breadcrumbs.Link = BreadcrumbLink
 
-// Backward compatibility
+/** @deprecated use Breadcrumbs.Props instead */
 export type BreadcrumbsProps = Breadcrumbs.Props

--- a/src/core/breadcrumbs/item/item.tsx
+++ b/src/core/breadcrumbs/item/item.tsx
@@ -27,5 +27,5 @@ export function BreadcrumbItem({ children, ...rest }: BreadcrumbItem.Props) {
   )
 }
 
-// Backward compatibility
+/** @deprecated use BreadcrumbItem.Props instead */
 export type BreadcrumbItemProps = BreadcrumbItem.Props

--- a/src/core/breadcrumbs/link/link.tsx
+++ b/src/core/breadcrumbs/link/link.tsx
@@ -27,5 +27,5 @@ export function BreadcrumbLink({ children, ...rest }: BreadcrumbLink.Props) {
   )
 }
 
-// Backward compatibility
+/** @deprecated use BreadcrumbLink.Props instead */
 export type BreadcrumbLinkProps = BreadcrumbLink.Props

--- a/src/core/drawer/index.ts
+++ b/src/core/drawer/index.ts
@@ -16,8 +16,11 @@ import { DrawerBody } from './body'
 import { DrawerHeader } from './header'
 import { DrawerFooter } from './footer'
 
-// Backward compatibility exports
+/** @deprecated use Drawer.Props instead */
 export type DrawerProps = Drawer.Props
+/** @deprecated use DrawerBody.Props instead */
 export type DrawerBodyProps = DrawerBody.Props
+/** @deprecated use DrawerHeader.Props instead */
 export type DrawerHeaderProps = DrawerHeader.Props
+/** @deprecated use DrawerFooter.Props instead */
 export type DrawerFooterProps = DrawerFooter.Props

--- a/src/core/input/checkbox/checkbox.tsx
+++ b/src/core/input/checkbox/checkbox.tsx
@@ -14,7 +14,7 @@ export namespace InputCheckbox {
   export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {}
 }
 
-// Backward compatibility
+/** @deprecated use InputCheckbox.Props instead */
 export type CheckboxInputProps = InputCheckbox.Props
 
 /**

--- a/src/core/input/input.tsx
+++ b/src/core/input/input.tsx
@@ -29,7 +29,7 @@ export namespace Input {
   }
 }
 
-// Backward compatibility
+/** @deprecated use Input.Props instead */
 export type InputProps = Input.Props
 
 /**

--- a/src/core/link/link.tsx
+++ b/src/core/link/link.tsx
@@ -28,7 +28,7 @@ export namespace Link {
   }
 }
 
-// Backward compatibility export
+/** @deprecated use Link.Props instead */
 export type LinkProps = Link.Props
 
 /**

--- a/src/core/tag-group/tag-group-item.tsx
+++ b/src/core/tag-group/tag-group-item.tsx
@@ -3,12 +3,14 @@ import { Tag } from '../tag/tag'
 
 import type { ComponentProps } from 'react'
 
-type TagGroupItemProps = ComponentProps<typeof Tag>
+export namespace TagGroupItem {
+  export interface Props extends ComponentProps<typeof Tag> {}
+}
 
 /**
  * A thin wrapper around a tag to ensure it is rendered as a list item inside the tag group.
  */
-export function TagGroupItem(props: TagGroupItemProps) {
+export function TagGroupItem(props: TagGroupItem.Props) {
   return (
     <ElTagGroupListItem>
       <Tag {...props} />

--- a/src/core/tag-group/tag-group.tsx
+++ b/src/core/tag-group/tag-group.tsx
@@ -3,19 +3,21 @@ import { TagGroupItem } from './tag-group-item'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TagGroupProps extends HTMLAttributes<HTMLUListElement> {
-  /** The tag group items. */
-  children: ReactNode
-  /** Whether the tag group should wrap or not. */
-  flow?: 'wrap' | 'nowrap'
-  /** What overflow behaviour the tag group should exhibit. */
-  overflow?: 'auto' | 'visible'
+export namespace TagGroup {
+  export interface Props extends HTMLAttributes<HTMLUListElement> {
+    /** The tag group items. */
+    children: ReactNode
+    /** Whether the tag group should wrap or not. */
+    flow?: 'wrap' | 'nowrap'
+    /** What overflow behaviour the tag group should exhibit. */
+    overflow?: 'auto' | 'visible'
+  }
 }
 
 /**
  * Groups multiple tags together. A tag group should have at least one tag.
  */
-export function TagGroup({ children, flow = 'wrap', overflow = 'visible', ...rest }: TagGroupProps) {
+export function TagGroup({ children, flow = 'wrap', overflow = 'visible', ...rest }: TagGroup.Props) {
   return (
     <ElTagGroupList {...rest} data-flow={flow} data-overflow={overflow}>
       {children}

--- a/src/core/tag/tag.tsx
+++ b/src/core/tag/tag.tsx
@@ -2,14 +2,19 @@ import { ElTag } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
-  /** The content of the tag. */
-  children: ReactNode
+export namespace Tag {
+  export interface Props extends HTMLAttributes<HTMLSpanElement> {
+    /** The content of the tag. */
+    children: ReactNode
+  }
 }
+
+/** @deprecated Use Tag.Props instead */
+export type TagProps = Tag.Props
 
 /**
  * The tag component is used to label, categorise or organise items using keywords.
  */
-export function Tag({ children, ...rest }: TagProps) {
+export function Tag({ children, ...rest }: Tag.Props) {
   return <ElTag {...rest}>{children}</ElTag>
 }

--- a/src/core/text/text.tsx
+++ b/src/core/text/text.tsx
@@ -4,61 +4,63 @@ import { elText } from './styles'
 import type { FontStyle, FontSize, FontWeight, TextColour } from './types'
 import type { HTMLAttributes, QuoteHTMLAttributes, TimeHTMLAttributes } from 'react'
 
-interface BaseTextProps {
-  colour?: TextColour
-  /**
-   * Defines the font style the text should use. Defaults to `inherit` when not provided.
-   * When both `font` and `size`/`weight` are provided, `font` takes precedence.
-   */
-  font?: FontStyle
-  overflow?: 'truncate'
-  /** @deprecated Use `font` prop instead */
-  size?: FontSize
-  /** @deprecated Use `font` prop instead */
-  weight?: FontWeight
-}
+export namespace Text {
+  interface BaseProps {
+    colour?: TextColour
+    /**
+     * Defines the font style the text should use. Defaults to `inherit` when not provided.
+     * When both `font` and `size`/`weight` are provided, `font` takes precedence.
+     */
+    font?: FontStyle
+    overflow?: 'truncate'
+    /** @deprecated Use `font` prop instead */
+    size?: FontSize
+    /** @deprecated Use `font` prop instead */
+    weight?: FontWeight
+  }
 
-interface TextAsAbbrProps extends BaseTextProps, HTMLAttributes<HTMLElement> {
-  as: 'abbr'
-}
+  interface AsAbbrProps extends BaseProps, HTMLAttributes<HTMLElement> {
+    as: 'abbr'
+  }
 
-interface TextAsEmProps extends BaseTextProps, HTMLAttributes<HTMLElement> {
-  as: 'em'
-}
+  interface AsEmProps extends BaseProps, HTMLAttributes<HTMLElement> {
+    as: 'em'
+  }
 
-interface TextAsMarkProps extends BaseTextProps, HTMLAttributes<HTMLElement> {
-  as: 'mark'
-}
+  interface AsMarkProps extends BaseProps, HTMLAttributes<HTMLElement> {
+    as: 'mark'
+  }
 
-interface TextAsQuoteProps extends BaseTextProps, QuoteHTMLAttributes<HTMLQuoteElement> {
-  as: 'q'
-}
+  interface AsQuoteProps extends BaseProps, QuoteHTMLAttributes<HTMLQuoteElement> {
+    as: 'q'
+  }
 
-interface TextAsStrikethroughProps extends BaseTextProps, HTMLAttributes<HTMLElement> {
-  as: 's'
-}
+  interface AsStrikethroughProps extends BaseProps, HTMLAttributes<HTMLElement> {
+    as: 's'
+  }
 
-interface TextAsSpanProps extends BaseTextProps, HTMLAttributes<HTMLSpanElement> {
-  as?: 'span'
-}
+  interface AsSpanProps extends BaseProps, HTMLAttributes<HTMLSpanElement> {
+    as?: 'span'
+  }
 
-interface TextAsStrongProps extends BaseTextProps, HTMLAttributes<HTMLElement> {
-  as: 'strong'
-}
+  interface AsStrongProps extends BaseProps, HTMLAttributes<HTMLElement> {
+    as: 'strong'
+  }
 
-interface TextAsTimeProps extends BaseTextProps, TimeHTMLAttributes<HTMLTimeElement> {
-  as: 'time'
-}
+  interface AsTimeProps extends BaseProps, TimeHTMLAttributes<HTMLTimeElement> {
+    as: 'time'
+  }
 
-type TextProps =
-  | TextAsAbbrProps
-  | TextAsEmProps
-  | TextAsMarkProps
-  | TextAsQuoteProps
-  | TextAsStrikethroughProps
-  | TextAsSpanProps
-  | TextAsStrongProps
-  | TextAsTimeProps
+  export type Props =
+    | AsAbbrProps
+    | AsEmProps
+    | AsMarkProps
+    | AsQuoteProps
+    | AsStrikethroughProps
+    | AsSpanProps
+    | AsStrongProps
+    | AsTimeProps
+}
 
 /**
  * A simple component that can be used to display text in a particular size, weight and colour. If
@@ -82,7 +84,7 @@ export function Text({
   size: deprecatedSizeProp,
   weight: deprecatedWeightProp,
   ...rest
-}: TextProps) {
+}: Text.Props) {
   // We use the deprecated props if neither font, size nor weight are specified, OR if no font is specified
   // but at least one of size or weight are.
   const useDeprecatedProps =

--- a/src/core/textarea/textarea.atoms.tsx
+++ b/src/core/textarea/textarea.atoms.tsx
@@ -16,34 +16,39 @@ import useResizeTextAreaEffect from './use-resize-textarea-effect'
 
 interface BaseTextAreaProps extends Omit<ElTextAreaProps, 'data-field-sizing'> {}
 
-export interface ContentFieldSizingTextAreaProps extends BaseTextAreaProps {
-  /**
-   * Allows the text area to automatically size itself based on its content, within the specified
-   * minimum and maximum number of rows.
-   */
-  fieldSizing: ContentFieldSizing
-  /**
-   * The maximum number of rows to which the text area should be sized. Provides the upper bound
-   * for the text area to grow to, except where an explicit value for `rows` is defined.
-   *
-   * @default Infinity
-   */
-  maxRows?: number
-  /**
-   * The minimum number of rows to which the text area should be sized. Provides the lower bound
-   * for the text area to shrink to, except where an explicit value for `rows` is defined. The
-   * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows)
-   * highlight that the default number of rows is 2.
-   *
-   * @default 3
-   */
-  minRows?: number
+export namespace ContentFieldSizingTextArea {
+  export interface Props extends BaseTextAreaProps {
+    /**
+     * Allows the text area to automatically size itself based on its content, within the specified
+     * minimum and maximum number of rows.
+     */
+    fieldSizing: ContentFieldSizing
+    /**
+     * The maximum number of rows to which the text area should be sized. Provides the upper bound
+     * for the text area to grow to, except where an explicit value for `rows` is defined.
+     *
+     * @default Infinity
+     */
+    maxRows?: number
+    /**
+     * The minimum number of rows to which the text area should be sized. Provides the lower bound
+     * for the text area to shrink to, except where an explicit value for `rows` is defined. The
+     * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows)
+     * highlight that the default number of rows is 2.
+     *
+     * @default 3
+     */
+    minRows?: number
+  }
 }
+
+/** @deprecated Use ContentFieldSizingTextArea.Props instead */
+export type ContentFieldSizingTextAreaProps = ContentFieldSizingTextArea.Props
 
 /**
  * An text area that automatically resizes based on its content between a minimum and maximum number of rows.
  */
-export const ContentFieldSizingTextArea = forwardRef<HTMLTextAreaElement, ContentFieldSizingTextAreaProps>(
+export const ContentFieldSizingTextArea = forwardRef<HTMLTextAreaElement, ContentFieldSizingTextArea.Props>(
   (
     {
       className,
@@ -115,23 +120,28 @@ export const ContentFieldSizingTextArea = forwardRef<HTMLTextAreaElement, Conten
   },
 )
 
-export interface FixedFieldSizingTextAreaProps extends BaseTextAreaProps {
-  /**
-   * Ensures the text area has a fixed size based on the specified number of rows.
-   */
-  fieldSizing: FixedFieldSizing
-  /**
-   * The exact number of rows to which the text area should be sized.
-   *
-   * @default 3
-   */
-  rows?: number
+export namespace FixedFieldSizingTextArea {
+  export interface Props extends BaseTextAreaProps {
+    /**
+     * Ensures the text area has a fixed size based on the specified number of rows.
+     */
+    fieldSizing: FixedFieldSizing
+    /**
+     * The exact number of rows to which the text area should be sized.
+     *
+     * @default 3
+     */
+    rows?: number
+  }
 }
+
+/** @deprecated Use FixedFieldSizingTextArea.Props instead */
+export type FixedFieldSizingTextAreaProps = FixedFieldSizingTextArea.Props
 
 /**
  * A fixed-sized text area.
  */
-export const FixedFieldSizingTextArea = forwardRef<HTMLTextAreaElement, FixedFieldSizingTextAreaProps>(
+export const FixedFieldSizingTextArea = forwardRef<HTMLTextAreaElement, FixedFieldSizingTextArea.Props>(
   ({ className, defaultValue, fieldSizing, hasError, rows = 3, onChange, value, ...rest }, ref) => {
     return (
       <ElTextArea
@@ -148,25 +158,30 @@ export const FixedFieldSizingTextArea = forwardRef<HTMLTextAreaElement, FixedFie
   },
 )
 
-export interface ManualFieldSizingTextAreaProps extends BaseTextAreaProps {
-  /**
-   * Allows the text area to be manually sized by users.
-   * @deprecated `manual` is deprecated. Please use `content` or `fixed` field sizing instead.
-   */
-  fieldSizing: ManualFieldSizing
-  /**
-   * The exact number of rows to which the text area should be _initially_ sized.
-   *
-   * @default 3
-   */
-  initialRows?: number
+export namespace ManualFieldSizingTextArea {
+  export interface Props extends BaseTextAreaProps {
+    /**
+     * Allows the text area to be manually sized by users.
+     * @deprecated `manual` is deprecated. Please use `content` or `fixed` field sizing instead.
+     */
+    fieldSizing: ManualFieldSizing
+    /**
+     * The exact number of rows to which the text area should be _initially_ sized.
+     *
+     * @default 3
+     */
+    initialRows?: number
+  }
 }
+
+/** @deprecated Use ManualFieldSizingTextArea.Props instead */
+export type ManualFieldSizingTextAreaProps = ManualFieldSizingTextArea.Props
 
 /**
  * A manually-resizable text area. Should not be used.
  * @deprecated Will be removed in future major version. Use `content` or `fixed` field sizing instead.
  */
-export const ManualFieldSizingTextArea = forwardRef<HTMLTextAreaElement, ManualFieldSizingTextAreaProps>(
+export const ManualFieldSizingTextArea = forwardRef<HTMLTextAreaElement, ManualFieldSizingTextArea.Props>(
   ({ className, defaultValue, fieldSizing, hasError, initialRows = 3, onChange, value, ...rest }, ref) => {
     return (
       <ElTextArea

--- a/src/core/textarea/textarea.tsx
+++ b/src/core/textarea/textarea.tsx
@@ -1,16 +1,15 @@
 import { ContentFieldSizingTextArea, FixedFieldSizingTextArea, ManualFieldSizingTextArea } from './textarea.atoms'
 import { forwardRef } from 'react'
 
-import type {
-  ContentFieldSizingTextAreaProps,
-  FixedFieldSizingTextAreaProps,
-  ManualFieldSizingTextAreaProps,
-} from './textarea.atoms'
+export namespace TextArea {
+  export type Props =
+    | ContentFieldSizingTextArea.Props
+    | FixedFieldSizingTextArea.Props
+    | ManualFieldSizingTextArea.Props
+}
 
-export type TextAreaProps =
-  | ContentFieldSizingTextAreaProps
-  | FixedFieldSizingTextAreaProps
-  | ManualFieldSizingTextAreaProps
+/** @deprecated Use TextArea.Props instead */
+export type TextAreaProps = TextArea.Props
 
 /**
  * An (almost) standard HTML/JSX `<textarea>` for use in forms.
@@ -20,7 +19,7 @@ export type TextAreaProps =
  * support the [field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing) property, we
  * fallback to a JS-based resizing solution that is only available to React-based consumers.
  */
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(({ fieldSizing, ...rest }, ref) => {
+export const TextArea = forwardRef<HTMLTextAreaElement, TextArea.Props>(({ fieldSizing, ...rest }, ref) => {
   if (fieldSizing === 'manual') {
     return <ManualFieldSizingTextArea fieldSizing={fieldSizing} {...rest} ref={ref} />
   } else if (fieldSizing === 'fixed') {

--- a/src/core/theme-provider/theme-provider.tsx
+++ b/src/core/theme-provider/theme-provider.tsx
@@ -3,9 +3,11 @@ import { useTheme } from './use-theme'
 import type { ReactNode } from 'react'
 import type { Theme } from '#src/tokens'
 
-interface ThemeProviderProps {
-  children: ReactNode
-  theme: Theme
+export namespace ThemeProvider {
+  export interface Props {
+    children: ReactNode
+    theme: Theme
+  }
 }
 
 /**
@@ -21,7 +23,7 @@ interface ThemeProviderProps {
  * It is also possible to use the `useTheme` hook directly if you'd prefer to interact with a hook-based API, or to
  * manually set the `data-theme` attribute on the document's root element in HTML document.
  */
-export function ThemeProvider({ children, theme }: ThemeProviderProps) {
+export function ThemeProvider({ children, theme }: ThemeProvider.Props) {
   useTheme(theme)
   return children
 }

--- a/src/core/tooltip/tooltip.tsx
+++ b/src/core/tooltip/tooltip.tsx
@@ -10,23 +10,25 @@ import type { PopoverPlacement } from '#src/utils/popover'
 // - role, because the Tooltip's role should always be "menu".
 type AttributesToOmit = 'role'
 
-export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
-  /** The ID of the tooltip. */
-  id: string
-  /** The maximum width of the menu. By default, the menu will be as wide as its widest item. */
-  maxWidth?: `--size-${string}`
-  /** Where the popover should be placed relative to its anchor. */
-  placement?: PopoverPlacement
-  /**
-   * The ID of the element described by this tooltip. When this element receives focus or is
-   * hovered by the mouse, the tooltip will be displayed.
-   */
-  triggerId: string
-  /**
-   * The ID of element to measure for truncation. If supplied, the tooltip will only display
-   * if this element's content has been truncated.
-   */
-  truncationTargetId?: string
+export namespace Tooltip {
+  export interface Props extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
+    /** The ID of the tooltip. */
+    id: string
+    /** The maximum width of the menu. By default, the menu will be as wide as its widest item. */
+    maxWidth?: `--size-${string}`
+    /** Where the popover should be placed relative to its anchor. */
+    placement?: PopoverPlacement
+    /**
+     * The ID of the element described by this tooltip. When this element receives focus or is
+     * hovered by the mouse, the tooltip will be displayed.
+     */
+    triggerId: string
+    /**
+     * The ID of element to measure for truncation. If supplied, the tooltip will only display
+     * if this element's content has been truncated.
+     */
+    truncationTargetId?: string
+  }
 }
 
 /**
@@ -47,7 +49,7 @@ export function Tooltip({
   triggerId,
   truncationTargetId,
   ...rest
-}: TooltipProps) {
+}: Tooltip.Props) {
   useTooltipController({ tooltipId: id, triggerId, truncationTargetId })
 
   return (
@@ -71,3 +73,6 @@ export function Tooltip({
 }
 
 Tooltip.getTriggerProps = getTooltipTriggerProps
+
+/** @deprecated use Tooltip.Props instead */
+export type TooltipProps = Tooltip.Props


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

Past PRs include:
- #766 
- #767 
- #768 
- #769 
- #770 

### This PR

Applies this namespace pattern for component props to another group of components:
- `Tag`
- `TagGroup`
- `Text`
- `Textarea`
- `Tooltip`