### PR TITLE
chore: apply namespace pattern for component props (part 7)

### DIFF
--- a/src/core/side-bar/__tests__/use-side-bar-controller.test.tsx
+++ b/src/core/side-bar/__tests__/use-side-bar-controller.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { useSideBarController } from '../use-side-bar-controller'
 
-import type { SideBarState } from '../use-side-bar'
+import type { useSideBar } from '../use-side-bar'
 
 test('only observes changes when the side bar is expanded', () => {
   const observeSpy = vi.spyOn(MutationObserver.prototype, 'observe')
@@ -49,7 +49,7 @@ test('handles null ref gracefully', () => {
 interface TestComponentProps {
   activeGroup?: 'none' | 'menu-group-1'
   currentPage?: 'none' | 'menu-item-1'
-  sideBarState?: SideBarState
+  sideBarState?: useSideBar.State
 }
 
 function TestComponent({ activeGroup = 'none', currentPage = 'none', sideBarState = 'expanded' }: TestComponentProps) {

--- a/src/core/side-bar/collapse-button/collapse-button.tsx
+++ b/src/core/side-bar/collapse-button/collapse-button.tsx
@@ -12,7 +12,14 @@ import type { ComponentProps, MouseEventHandler } from 'react'
 // - `children` because the button text is always "Collapse" or "Expand" based on the state of the SideBar.
 type AttributesToOmit = 'aria-expanded' | 'aria-controls' | 'children'
 
-interface SideBarCollapseButtonProps extends Omit<ComponentProps<typeof ElSideBarCollapseButton>, AttributesToOmit> {}
+export namespace SideBarCollapseButton {
+  export interface Props extends Omit<ComponentProps<typeof ElSideBarCollapseButton>, AttributesToOmit> {}
+}
+
+/**
+ * @deprecated Use `SideBarCollapseButton.Props` instead
+ */
+export type SideBarCollapseButtonProps = SideBarCollapseButton.Props
 
 /**
  * A button used to collapse or expand the `SideBar`. Should be placed within the `SideBar` footer. To help communicate
@@ -22,7 +29,7 @@ interface SideBarCollapseButtonProps extends Omit<ComponentProps<typeof ElSideBa
  * When the side bar is collapsed, the button's accessible name will be "Expand" (though this will not be visible), and
  * when the side bar is expanded, the button's accessible name will be "Collapse".
  */
-export function SideBarCollapseButton({ id, onClick, ...props }: SideBarCollapseButtonProps) {
+export function SideBarCollapseButton({ id, onClick, ...props }: SideBarCollapseButton.Props) {
   const sideBar = useSideBarContext()
   const tooltipId = useId()
   const triggerId = id ?? useId()

--- a/src/core/side-bar/menu-group/__tests__/use-menu-group-controller.test.tsx
+++ b/src/core/side-bar/menu-group/__tests__/use-menu-group-controller.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { useSideBarMenuGroupController } from '../use-menu-group-controller'
 
 import type { DetailsHTMLAttributes } from 'react'
-import type { SideBarState } from '../../use-side-bar'
+import type { useSideBar } from '../../use-side-bar'
 
 test('`<details>` is opened when the `SideBar` is expanded and a descendant represents the current page', () => {
   const { rerender } = render(
@@ -121,7 +121,7 @@ test('`<details>` is closed when it is no longer active', async () => {
 })
 
 interface DetailsProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
-  sideBarState: SideBarState
+  sideBarState: useSideBar.State
 }
 
 /** Simple integration of the subject under test (useSideBarMenuGroupController) and a `<details>` element */

--- a/src/core/side-bar/menu-group/menu-group-summary.tsx
+++ b/src/core/side-bar/menu-group/menu-group-summary.tsx
@@ -14,16 +14,23 @@ import { useSideBarMenuGroupLabelIdContext } from './menu-group-label-id-context
 
 import type { HTMLAttributes, MouseEventHandler, ReactNode } from 'react'
 
-interface SideBarMenuGroupSummaryProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * The label for the menu group.
-   */
-  children: ReactNode
-  /**
-   * The icon to display next to the label.
-   */
-  icon: ReactNode
+export namespace SideBarMenuGroupSummary {
+  export interface Props extends HTMLAttributes<HTMLElement> {
+    /**
+     * The label for the menu group.
+     */
+    children: ReactNode
+    /**
+     * The icon to display next to the label.
+     */
+    icon: ReactNode
+  }
 }
+
+/**
+ * @deprecated Use `SideBarMenuGroupSummary.Props` instead
+ */
+export type SideBarMenuGroupSummaryProps = SideBarMenuGroupSummary.Props
 
 /**
  * A summary element for the `SideBar.MenuGroup`. It is explicitly designed for use within a `<details>` element,
@@ -39,7 +46,7 @@ export function SideBarMenuGroupSummary({
   id,
   onClick,
   ...props
-}: SideBarMenuGroupSummaryProps) {
+}: SideBarMenuGroupSummary.Props) {
   const tooltipId = useSideBarMenuGroupLabelIdContext()
   const triggerId = id ?? useId()
   const truncationTargetId = useId()

--- a/src/core/side-bar/menu-group/menu-group.tsx
+++ b/src/core/side-bar/menu-group/menu-group.tsx
@@ -8,37 +8,44 @@ import { useSideBarMenuGroupController } from './use-menu-group-controller'
 
 import type { DetailsHTMLAttributes, ReactNode } from 'react'
 
-export interface SideBarMenuGroupProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
-  /**
-   * Typically a single `SideBar.Submenu` component that contains any number of submenu items
-   */
-  children: ReactNode
-  /**
-   * Allows consumers to "force" the menu group to be active in scenarios where it does not have a submenu item
-   * that represents the current page. Typically, this should not be necessary, but it can be a useful escape hatch
-   * when dealing with pages that, from an Information Architecture (IA) perspective, are part of a menu group,
-   * but where no submenu items can be uniquely marked as representing current page.
-   *
-   * Being active means the menu group will be open (except when the `SideBar` is collapsed). However, being `open`
-   * does not mean the menu group is active.
-   */
-  isActive?: boolean
-  /**
-   * Indicates whether the menu group's contents---that is, the submenu of items---are currently visible.
-   *
-   * Typically, the open state of menu groups can remain uncontrolled. If this state is controlled, it is important
-   * for consumers to listen for
-   * [toggle](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#events) events fired after
-   * the underlying `<details>` element's `open` state changes. This is because the `SideBar` will, at times,
-   * imperatively control child `<details>` elements.
-   */
-  open?: boolean
-  /**
-   * The summary/main item for the menu group. Will typically be a `SideBar.MenuGroupSummary`. If a custom element is
-   * rendered, it should be a `<summary>` element.
-   */
-  summary: ReactNode
+export namespace SideBarMenuGroup {
+  export interface Props extends DetailsHTMLAttributes<HTMLDetailsElement> {
+    /**
+     * Typically a single `SideBar.Submenu` component that contains any number of submenu items
+     */
+    children: ReactNode
+    /**
+     * Allows consumers to "force" the menu group to be active in scenarios where it does not have a submenu item
+     * that represents the current page. Typically, this should not be necessary, but it can be a useful escape hatch
+     * when dealing with pages that, from an Information Architecture (IA) perspective, are part of a menu group,
+     * but where no submenu items can be uniquely marked as representing current page.
+     *
+     * Being active means the menu group will be open (except when the `SideBar` is collapsed). However, being `open`
+     * does not mean the menu group is active.
+     */
+    isActive?: boolean
+    /**
+     * Indicates whether the menu group's contents---that is, the submenu of items---are currently visible.
+     *
+     * Typically, the open state of menu groups can remain uncontrolled. If this state is controlled, it is important
+     * for consumers to listen for
+     * [toggle](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#events) events fired after
+     * the underlying `<details>` element's `open` state changes. This is because the `SideBar` will, at times,
+     * imperatively control child `<details>` elements.
+     */
+    open?: boolean
+    /**
+     * The summary/main item for the menu group. Will typically be a `SideBar.MenuGroupSummary`. If a custom element is
+     * rendered, it should be a `<summary>` element.
+     */
+    summary: ReactNode
+  }
 }
+
+/**
+ * @deprecated Use `SideBarMenuGroup.Props` instead
+ */
+export type SideBarMenuGroupProps = SideBarMenuGroup.Props
 
 /**
  * A menu group that can contain a submenu of items for use in a `SideBar`. The group leverages a `<details>`
@@ -58,7 +65,7 @@ export function SideBarMenuGroup({
   isActive,
   summary,
   ...rest
-}: SideBarMenuGroupProps) {
+}: SideBarMenuGroup.Props) {
   const labelId = ariaLabelledBy ?? useId()
   const sideBar = useSideBarContext()
   const ref = useSideBarMenuGroupController(sideBar.state)

--- a/src/core/side-bar/menu-group/use-menu-group-controller.ts
+++ b/src/core/side-bar/menu-group/use-menu-group-controller.ts
@@ -2,13 +2,13 @@ import { useLayoutEffect, useRef } from 'react'
 import { shouldBeOpen } from './should-be-open'
 
 import type { RefObject } from 'react'
-import type { SideBarState } from '../use-side-bar'
+import type { useSideBar } from '../use-side-bar'
 
 /**
  * Controls the open state of a `SideBar.MenuGroup` when the `SideBar` is expanded or collapsed or when a descendant
  * comes to represent, or stops representing, the current page.
  */
-export function useSideBarMenuGroupController(sideBarState: SideBarState): RefObject<HTMLDetailsElement> {
+export function useSideBarMenuGroupController(sideBarState: useSideBar.State): RefObject<HTMLDetailsElement> {
   const ref = useRef<HTMLDetailsElement>(null)
 
   useLayoutEffect(

--- a/src/core/side-bar/menu-item/menu-item.tsx
+++ b/src/core/side-bar/menu-item/menu-item.tsx
@@ -5,19 +5,26 @@ import { useId } from 'react'
 
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-interface SideBarMenuItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /**
-   * When the item represents the current page, `aria-current="page"` should be supplied to communicate to visual and
-   * accessible users that the item is currently "selected".
-   */
-  'aria-current': 'page' | false
-  /** The label of the menu item */
-  children: ReactNode
-  /** The URL to navigate to when this item is activated. */
-  href: string
-  /** The icon to display next to the label. */
-  icon: ReactNode
+export namespace SideBarMenuItem {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /**
+     * When the item represents the current page, `aria-current="page"` should be supplied to communicate to visual and
+     * accessible users that the item is currently "selected".
+     */
+    'aria-current': 'page' | false
+    /** The label of the menu item */
+    children: ReactNode
+    /** The URL to navigate to when this item is activated. */
+    href: string
+    /** The icon to display next to the label. */
+    icon: ReactNode
+  }
 }
+
+/**
+ * @deprecated Use `SideBarMenuItem.Props` instead
+ */
+export type SideBarMenuItemProps = SideBarMenuItem.Props
 
 /**
  * Standard menu item for use in a `SideBar`. Is always an anchor element because side bar navigation
@@ -46,7 +53,7 @@ export function SideBarMenuItem({
   icon,
   id,
   ...rest
-}: SideBarMenuItemProps) {
+}: SideBarMenuItem.Props) {
   const tooltipId = useId()
   const triggerId = id ?? useId()
   const truncationTargetId = useId()

--- a/src/core/side-bar/menu-list/menu-list-group.tsx
+++ b/src/core/side-bar/menu-list/menu-list-group.tsx
@@ -3,7 +3,14 @@ import { ElSideBarMenuListItem } from './styles'
 
 import type { ComponentProps } from 'react'
 
-interface SideBarMenuListGroupProps extends ComponentProps<typeof SideBarMenuGroup> {}
+export namespace SideBarMenuListGroup {
+  export interface Props extends ComponentProps<typeof SideBarMenuGroup> {}
+}
+
+/**
+ * @deprecated Use `SideBarMenuListGroup.Props` instead
+ */
+export type SideBarMenuListGroupProps = SideBarMenuListGroup.Props
 
 /**
  * A thin wrapper around `SideBarMenuGroup` that ensures it is contained within a list item (`<li>`) for
@@ -11,7 +18,7 @@ interface SideBarMenuListGroupProps extends ComponentProps<typeof SideBarMenuGro
  *
  * All props are passed through to `SideBarMenuGroup`.
  */
-export function SideBarMenuListGroup({ children, ...props }: SideBarMenuListGroupProps) {
+export function SideBarMenuListGroup({ children, ...props }: SideBarMenuListGroup.Props) {
   return (
     <ElSideBarMenuListItem>
       <SideBarMenuGroup {...props}>{children}</SideBarMenuGroup>

--- a/src/core/side-bar/menu-list/menu-list-item.tsx
+++ b/src/core/side-bar/menu-list/menu-list-item.tsx
@@ -3,7 +3,14 @@ import { ElSideBarMenuListItem } from './styles'
 
 import type { ComponentProps } from 'react'
 
-interface SideBarMenuListItemProps extends ComponentProps<typeof BaseSideBarMenuItem> {}
+export namespace SideBarMenuListItem {
+  export interface Props extends ComponentProps<typeof BaseSideBarMenuItem> {}
+}
+
+/**
+ * @deprecated Use `SideBarMenuListItem.Props` instead
+ */
+export type SideBarMenuListItemProps = SideBarMenuListItem.Props
 
 /**
  * A thin wrapper around `SideBarMenuItem` that ensures it is contained within a list item (`<li>`) for
@@ -11,7 +18,7 @@ interface SideBarMenuListItemProps extends ComponentProps<typeof BaseSideBarMenu
  *
  * All props are passed through to `SideBarMenuItem`.
  */
-export function SideBarMenuListItem({ children, ...props }: SideBarMenuListItemProps) {
+export function SideBarMenuListItem({ children, ...props }: SideBarMenuListItem.Props) {
   return (
     <ElSideBarMenuListItem>
       <BaseSideBarMenuItem {...props}>{children}</BaseSideBarMenuItem>

--- a/src/core/side-bar/menu-list/menu-list.tsx
+++ b/src/core/side-bar/menu-list/menu-list.tsx
@@ -5,13 +5,20 @@ import { SideBarMenuListGroup } from './menu-list-group'
 import type { ComponentProps } from 'react'
 import { SideBarSubmenu } from '../submenu'
 
-interface SideBarMenuListProps extends ComponentProps<typeof ElSideBarMenuList> {}
+export namespace SideBarMenuList {
+  export interface Props extends ComponentProps<typeof ElSideBarMenuList> {}
+}
+
+/**
+ * @deprecated Use `SideBarMenuList.Props` instead
+ */
+export type SideBarMenuListProps = SideBarMenuList.Props
 
 /**
  * Main menu list for the `SideBar`. Typically provided a collection of `SideBar.MenuItem` and `SideBar.MenuGroup`
  * components as children.
  */
-export function SideBarMenuList({ children, ...rest }: SideBarMenuListProps) {
+export function SideBarMenuList({ children, ...rest }: SideBarMenuList.Props) {
   return <ElSideBarMenuList {...rest}>{children}</ElSideBarMenuList>
 }
 

--- a/src/core/side-bar/side-bar-context.tsx
+++ b/src/core/side-bar/side-bar-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useMemo } from 'react'
-import type { UseSideBarResult } from './use-side-bar'
+import type { useSideBar } from './use-side-bar'
 
-interface SideBarContextValue extends UseSideBarResult {
+interface SideBarContextValue extends useSideBar.Result {
   id: string
 }
 

--- a/src/core/side-bar/side-bar.tsx
+++ b/src/core/side-bar/side-bar.tsx
@@ -10,21 +10,28 @@ import { useSideBarKeyboardNavigation } from './use-keyboard-navigation'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface SideBarProps extends Omit<ComponentProps<typeof ElSideBar>, 'data-state'> {
-  /**
-   * The side bar's menu items. Typically a `SideBar.MenuList` with `SideBar.MenuItem` and
-   * `SideBar.MenuGroup` components.
-   */
-  children: ReactNode
-  /**
-   * The side bar's footer. Should typically be a `SideBar.CollapseButton` component.
-   */
-  footer: ReactNode
-  /**
-   * The width of the side bar.
-   */
-  width?: `--size-${string}`
+export namespace SideBar {
+  export interface Props extends Omit<ComponentProps<typeof ElSideBar>, 'data-state'> {
+    /**
+     * The side bar's menu items. Typically a `SideBar.MenuList` with `SideBar.MenuItem` and
+     * `SideBar.MenuGroup` components.
+     */
+    children: ReactNode
+    /**
+     * The side bar's footer. Should typically be a `SideBar.CollapseButton` component.
+     */
+    footer: ReactNode
+    /**
+     * The width of the side bar.
+     */
+    width?: `--size-${string}`
+  }
 }
+
+/**
+ * @deprecated Use `SideBar.Props` instead
+ */
+export type SideBarProps = SideBar.Props
 
 /**
  * Collapsible navigation component for products with too many navigation items to fit in the TopBar's main nav.
@@ -36,7 +43,7 @@ export function SideBar({
   id,
   width = '--size-64',
   ...props
-}: SideBarProps) {
+}: SideBar.Props) {
   const sideBarId = id ?? useId()
   const sideBar = useSideBar(() => determineSideBarStateFromViewport())
   const handleKeyboardNavigation = useSideBarKeyboardNavigation()

--- a/src/core/side-bar/submenu-item/submenu-item.tsx
+++ b/src/core/side-bar/submenu-item/submenu-item.tsx
@@ -2,21 +2,28 @@ import { elSideBarSubmenuItem, ElSideBarSubmenuItemLabel } from './styles'
 import { cx } from '@linaria/core'
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-interface SideBarSubmenuItemProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-current'> {
-  /**
-   * When the item represents the current page, `aria-current="page"` should be supplied to communicate to visual and
-   * accessible users that the item is currently "selected".
-   */
-  'aria-current': 'page' | false
-  /**
-   * The label of the menu item.
-   */
-  children: ReactNode
-  /**
-   * The URL to navigate to when this item is activated.
-   */
-  href: string
+export namespace SideBarSubmenuItem {
+  export interface Props extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-current'> {
+    /**
+     * When the item represents the current page, `aria-current="page"` should be supplied to communicate to visual and
+     * accessible users that the item is currently "selected".
+     */
+    'aria-current': 'page' | false
+    /**
+     * The label of the menu item.
+     */
+    children: ReactNode
+    /**
+     * The URL to navigate to when this item is activated.
+     */
+    href: string
+  }
 }
+
+/**
+ * @deprecated Use `SideBarSubmenuItem.Props` instead
+ */
+export type SideBarSubmenuItemProps = SideBarSubmenuItem.Props
 
 /**
  * A simple menu item for use in submenus within a `SideBar`. Is always an anchor element because side bar navigation
@@ -43,7 +50,7 @@ export function SideBarSubmenuItem({
   children,
   className,
   ...rest
-}: SideBarSubmenuItemProps) {
+}: SideBarSubmenuItem.Props) {
   return (
     <a {...rest} aria-current={ariaCurrent} className={cx(elSideBarSubmenuItem, className)}>
       <ElSideBarSubmenuItemLabel>{children}</ElSideBarSubmenuItemLabel>

--- a/src/core/side-bar/submenu/submenu-list-item.tsx
+++ b/src/core/side-bar/submenu/submenu-list-item.tsx
@@ -3,7 +3,14 @@ import { SideBarSubmenuItem as SideBarSubmenuItem } from '../submenu-item'
 
 import type { ComponentProps } from 'react'
 
-interface SideBarSubmenuListItemProps extends ComponentProps<typeof SideBarSubmenuItem> {}
+export namespace SideBarSubmenuListItem {
+  export interface Props extends ComponentProps<typeof SideBarSubmenuItem> {}
+}
+
+/**
+ * @deprecated Use `SideBarSubmenuListItem.Props` instead
+ */
+export type SideBarSubmenuListItemProps = SideBarSubmenuListItem.Props
 
 /**
  * A thin wrapper around `SideBarSubmenuItem` that ensures it is contained within a list item (`<li>`) for
@@ -11,7 +18,7 @@ interface SideBarSubmenuListItemProps extends ComponentProps<typeof SideBarSubme
  *
  * All props are passed through to `SideBarSubmenuItem`.
  */
-export function SideBarSubmenuListItem({ children, ...props }: SideBarSubmenuListItemProps) {
+export function SideBarSubmenuListItem({ children, ...props }: SideBarSubmenuListItem.Props) {
   return (
     <ElSideBarSubmenuListItem>
       <SideBarSubmenuItem {...props}>{children}</SideBarSubmenuItem>

--- a/src/core/side-bar/submenu/submenu.tsx
+++ b/src/core/side-bar/submenu/submenu.tsx
@@ -3,17 +3,24 @@ import { ElSideBarSubmenuList } from './styles'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface SideBarSubmenuProps extends ComponentProps<typeof ElSideBarSubmenuList> {
-  /** A collection of items, typically `SideBar.SubmenuItem` components */
-  children: ReactNode
+export namespace SideBarSubmenu {
+  export interface Props extends ComponentProps<typeof ElSideBarSubmenuList> {
+    /** A collection of items, typically `SideBar.SubmenuItem` components */
+    children: ReactNode
+  }
 }
+
+/**
+ * @deprecated Use `SideBarSubmenu.Props` instead
+ */
+export type SideBarSubmenuProps = SideBarSubmenu.Props
 
 /**
  * A simple submenu for use in a `SideBar`. Typically used via `SideBar.Submenu` as the child of a
  * `SideBar.MenuGroup`. The submenu itself will typically container a collection of `SideBar.SubmenuItem`'s
  * as children. Only one items, if any, in the submenu should represent the current page at any given time.
  */
-export function SideBarSubmenu({ children, ...rest }: SideBarSubmenuProps) {
+export function SideBarSubmenu({ children, ...rest }: SideBarSubmenu.Props) {
   return <ElSideBarSubmenuList {...rest}>{children}</ElSideBarSubmenuList>
 }
 

--- a/src/core/side-bar/use-side-bar-controller.ts
+++ b/src/core/side-bar/use-side-bar-controller.ts
@@ -1,13 +1,13 @@
 import { shouldBeOpen } from './menu-group'
 import { useEffect, useRef } from 'react'
 
-import type { SideBarState } from './use-side-bar'
+import type { useSideBar } from './use-side-bar'
 
 /**
  * A simple effect that observes changes to which item represents the current page (or active group) and
  * ensures all menu groups are closed.
  */
-export function useSideBarController(sideBarState: SideBarState) {
+export function useSideBarController(sideBarState: useSideBar.State) {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(

--- a/src/core/side-bar/use-side-bar-match-media-effect.ts
+++ b/src/core/side-bar/use-side-bar-match-media-effect.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import type { UseSideBarResult } from './use-side-bar'
+import type { useSideBar } from './use-side-bar'
 
 // Media query to detect "wide-screen" widths (1440px and above).
 const mediaQuery = globalThis.matchMedia('(min-width: 1440px)')
@@ -8,7 +8,7 @@ const mediaQuery = globalThis.matchMedia('(min-width: 1440px)')
  * A simple effect that listens for changes in the match media query (min wide-screen width) and updates
  * the side bar's state accordingly.
  */
-export function useSideBarMatchMediaEffect({ setState }: UseSideBarResult) {
+export function useSideBarMatchMediaEffect({ setState }: useSideBar.Result) {
   useEffect(
     function expandOrCollapseWhenMediaQueryChanges() {
       setState(determineSideBarStateFromViewport())

--- a/src/core/side-bar/use-side-bar.tsx
+++ b/src/core/side-bar/use-side-bar.tsx
@@ -1,18 +1,30 @@
 import { useCallback, useMemo, useState } from 'react'
 
-export type SideBarState = 'collapsed' | 'expanded'
+export namespace useSideBar {
+  export type State = 'collapsed' | 'expanded'
 
-export interface UseSideBarResult {
-  expand: () => void
-  state: SideBarState
-  setState: (state: SideBarState) => void
-  toggle: () => void
+  export interface Result {
+    expand: () => void
+    state: State
+    setState: (state: State) => void
+    toggle: () => void
+  }
 }
+
+/**
+ * @deprecated Use `UseSideBar.State` instead
+ */
+export type SideBarState = useSideBar.State
+
+/**
+ * @deprecated Use `UseSideBar.Result` instead
+ */
+export interface UseSideBarResult extends useSideBar.Result {}
 
 /**
  * Manages the collapsed/expanded state of the side bar and provides setters for changing that state.
  */
-export function useSideBar(initialState: SideBarState | (() => SideBarState) = 'expanded'): UseSideBarResult {
+export function useSideBar(initialState: useSideBar.State | (() => useSideBar.State) = 'expanded'): useSideBar.Result {
   const [state, setState] = useState(initialState)
 
   const expand = useCallback(() => setState('expanded'), [])
@@ -24,5 +36,5 @@ export function useSideBar(initialState: SideBarState | (() => SideBarState) = '
     [],
   )
 
-  return useMemo<UseSideBarResult>(() => ({ expand, state, setState, toggle }), [expand, state, setState, toggle])
+  return useMemo(() => ({ expand, state, setState, toggle }), [expand, state, setState, toggle])
 }

--- a/src/core/table/body-cell/body-cell.tsx
+++ b/src/core/table/body-cell/body-cell.tsx
@@ -3,38 +3,40 @@ import { elTableBodyCell } from './styles'
 
 import type { HTMLAttributes, ReactNode, TdHTMLAttributes, ThHTMLAttributes } from 'react'
 
-interface TableBodyCellCommonProps {
-  /**
-   * Remove default padding. Useful for cells that contain an interactive element whose hit area
-   * should fill the entire cell.
-   */
-  hasNoPadding?: boolean
-  /** The alignment of the cell's content. */
-  justifySelf?: 'start' | 'center' | 'end'
-}
+export namespace TableBodyCell {
+  interface CommonProps {
+    /**
+     * Remove default padding. Useful for cells that contain an interactive element whose hit area
+     * should fill the entire cell.
+     */
+    hasNoPadding?: boolean
+    /** The alignment of the cell's content. */
+    justifySelf?: 'start' | 'center' | 'end'
+  }
 
-interface TableBodyCellAsTdProps extends TableBodyCellCommonProps, TdHTMLAttributes<HTMLTableCellElement> {
-  as?: 'td'
-  /** The cell content. */
-  children: ReactNode
-}
+  interface AsTdProps extends CommonProps, TdHTMLAttributes<HTMLTableCellElement> {
+    as?: 'td'
+    /** The cell content. */
+    children: ReactNode
+  }
 
-interface TableBodyCellAsThProps
-  extends TableBodyCellCommonProps,
-    // NOTE: we omit scope because it should always be "row"
-    Omit<ThHTMLAttributes<HTMLTableCellElement>, 'scope'> {
-  as: 'th'
-  /** The cell content. */
-  children: ReactNode
-}
+  interface AsThProps
+    extends CommonProps,
+      // NOTE: we omit scope because it should always be "row"
+      Omit<ThHTMLAttributes<HTMLTableCellElement>, 'scope'> {
+    as: 'th'
+    /** The cell content. */
+    children: ReactNode
+  }
 
-interface TableBodyCellAsDivProps extends TableBodyCellCommonProps, HTMLAttributes<HTMLDivElement> {
-  as: 'div'
-  /** The cell content. */
-  children: ReactNode
-}
+  interface AsDivProps extends CommonProps, HTMLAttributes<HTMLDivElement> {
+    as: 'div'
+    /** The cell content. */
+    children: ReactNode
+  }
 
-type TableBodyCellProps = TableBodyCellAsTdProps | TableBodyCellAsThProps | TableBodyCellAsDivProps
+  export type Props = AsTdProps | AsThProps | AsDivProps
+}
 
 /**
  * A basic cell for a table's body. Does little more than render its children in a `<td>`,
@@ -47,7 +49,7 @@ export function TableBodyCell({
   hasNoPadding,
   justifySelf,
   ...rest
-}: TableBodyCellProps) {
+}: TableBodyCell.Props) {
   const thElementScope = Element === 'th' ? { scope: 'row' } : undefined
   return (
     <Element
@@ -61,3 +63,6 @@ export function TableBodyCell({
     </Element>
   )
 }
+
+// Backward compatibility
+export type TableBodyCellProps = TableBodyCell.Props

--- a/src/core/table/body-row/body-row.tsx
+++ b/src/core/table/body-row/body-row.tsx
@@ -3,37 +3,35 @@ import { elTableBodyRow } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TableBodyRowAsTrProps extends HTMLAttributes<HTMLTableRowElement> {
-  as?: 'tr'
-  /** The cell content. */
-  children: ReactNode
-}
+export namespace TableBodyRow {
+  interface AsTrProps extends HTMLAttributes<HTMLTableRowElement> {
+    as?: 'tr'
+    /** The row's cells. */
+    children: ReactNode
+  }
 
-interface TableBodyRowAsDivProps extends HTMLAttributes<HTMLDivElement> {
-  as: 'div'
-  /** The row content. */
-  children: ReactNode
-}
+  interface AsDivProps extends HTMLAttributes<HTMLDivElement> {
+    as: 'div'
+    /** The row's cells. */
+    children: ReactNode
+  }
 
-type TableBodyRowProps = TableBodyRowAsTrProps | TableBodyRowAsDivProps
+  export type Props = AsTrProps | AsDivProps
+}
 
 /**
- * A basic row for a table's body. Does little more than render it's children in a `<tr>` or `<div>`.
- * Cells within a row may contain interactive elements such as buttons, links or menus. Cells are
- * aligned to the table's CSS grid layout via
+ * A table's body row. Does little more than render its children in a `<tr>` or `<div>` element.
+ * Descendants will flow to new columns while rows will align to the table's grid using
  * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
- *
- * The row itself should never be interactive. When a row must *appear* to be clickable to users,
- * [Table.PrimaryAction](./?path=/docs/core-table-primaryaction--docs) should be used in the row's header
- * cell; it's "hit area" will cover the entire row to give users the experience of being interactive
- * without violating accessibility guidelines or producing an invalid DOM hierarchy.
- *
  * Typically used via `Table.BodyRow`.
  */
-export function TableBodyRow({ as: Element = 'tr', children, className, ...rest }: TableBodyRowProps) {
+export function TableBodyRow({ as: Element = 'tr', children, className, ...rest }: TableBodyRow.Props) {
   return (
     <Element {...rest} className={cx(elTableBodyRow, className)}>
       {children}
     </Element>
   )
 }
+
+// Backward compatibility
+export type TableBodyRowProps = TableBodyRow.Props

--- a/src/core/table/body/body.tsx
+++ b/src/core/table/body/body.tsx
@@ -3,19 +3,21 @@ import { elTableBody } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TableBodyAsTbodyProps extends HTMLAttributes<HTMLTableSectionElement> {
-  as?: 'tbody'
-  /** The table's rows. */
-  children: ReactNode
-}
+export namespace TableBody {
+  interface AsTbodyProps extends HTMLAttributes<HTMLTableSectionElement> {
+    as?: 'tbody'
+    /** The table's rows. */
+    children: ReactNode
+  }
 
-interface TableBodyAsDivProps extends HTMLAttributes<HTMLDivElement> {
-  as: 'div'
-  /** The table's rows. */
-  children: ReactNode
-}
+  interface AsDivProps extends HTMLAttributes<HTMLDivElement> {
+    as: 'div'
+    /** The table's rows. */
+    children: ReactNode
+  }
 
-type TableBodyProps = TableBodyAsTbodyProps | TableBodyAsDivProps
+  export type Props = AsTbodyProps | AsDivProps
+}
 
 /**
  * A table's body. Does little more than render its children in a `<tbody>` or `<div>` element.
@@ -23,10 +25,13 @@ type TableBodyProps = TableBodyAsTbodyProps | TableBodyAsDivProps
  * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
  * Typically used via `Table.Body`.
  */
-export function TableBody({ as: Element = 'tbody', children, className, ...rest }: TableBodyProps) {
+export function TableBody({ as: Element = 'tbody', children, className, ...rest }: TableBody.Props) {
   return (
     <Element {...rest} className={cx(elTableBody, className)}>
       {children}
     </Element>
   )
 }
+
+// Backward compatibility
+export type TableBodyProps = TableBody.Props

--- a/src/core/table/checkbox/checkbox.tsx
+++ b/src/core/table/checkbox/checkbox.tsx
@@ -1,40 +1,50 @@
 import { cx } from '@linaria/core'
+import { forwardRef } from 'react'
+import { Input } from '../../input'
 import { elTableCellCheckbox } from './styles'
-import { Input } from '#src/core/input'
 
-import { forwardRef, type InputHTMLAttributes } from 'react'
+import type { InputHTMLAttributes } from 'react'
 
 // NOTE: we omit...
-// - type, because this component will always be a checkbox input
-type AttributesToOmit = 'type'
+// - defaultChecked, because we control state via checked
+// - type, because we internally control the input type
+type AttributesToOmit = 'defaultChecked' | 'type'
 
-export interface TableCellCheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
-  /** The accessible name for the checkbox. */
-  'aria-label': string
-  /** Indicates whether the checkbox or radio is checked. */
-  checked?: boolean
-  /** Whether the checkbox is disabled. Typically, row selection checkboxes should avoid being disabled. */
-  disabled?: boolean
-  /** The form this checkbox is associated with. */
-  form?: string
-  /**
-   * Name of the checkbox. Submitted as part of a name/value pair. Will typically be the same name as
-   * all other checkboxes in the same column of the table.
-   */
-  name?: string
-  /**
-   * The value that should be submitted with a form when the checkbox is checked. For row checkboxes, this
-   * will typically be the ID of the entity represented by the row this checkbox is a descendant of.
-   */
-  value?: InputHTMLAttributes<HTMLInputElement>['value']
+export namespace TableCellCheckbox {
+  export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, AttributesToOmit> {
+    /** The accessible name for the checkbox. */
+    'aria-label': string
+    /** Indicates whether the checkbox or radio is checked. */
+    checked?: boolean
+    /** Whether the checkbox is disabled. Typically, row selection checkboxes should avoid being disabled. */
+    disabled?: boolean
+    /** The form this checkbox is associated with. */
+    form?: string
+    /**
+     * Name of the checkbox. Submitted as part of a name/value pair. Will typically be the same name as
+     * other row selection checkboxes in the table.
+     */
+    name?: string
+    /** Callback fired when the checkbox state changes. */
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    /** The accessible name for the checkbox when used in a table header for selecting all rows. */
+    title?: string
+    /** The value of the checkbox. Submitted as part of a name/value pair. */
+    value?: string
+  }
 }
 
 /**
- * A thin wrapper around [Input's checkbox implementation](./?path=/docs/core-input--docs) that is geared
- * for use in tables built with [Table](./?path=/docs/core-table--docs).
+ * A checkbox meant to be used inside of table cells. Displays an HTML checkbox input. Typically used
+ * via `Table.Checkbox`.
  */
-export const TableCellCheckbox = forwardRef<HTMLInputElement, TableCellCheckboxProps>(({ className, ...rest }, ref) => {
-  return <Input {...rest} className={cx(elTableCellCheckbox, className)} ref={ref} type="checkbox" />
-})
+export const TableCellCheckbox = forwardRef<HTMLInputElement, TableCellCheckbox.Props>(
+  ({ className, ...rest }, ref) => {
+    return <Input {...rest} className={cx(elTableCellCheckbox, className)} ref={ref} type="checkbox" />
+  },
+)
 
 TableCellCheckbox.displayName = 'TableCellCheckbox'
+
+// Backward compatibility
+export type TableCellCheckboxProps = TableCellCheckbox.Props

--- a/src/core/table/double-line-layout/double-line-layout.tsx
+++ b/src/core/table/double-line-layout/double-line-layout.tsx
@@ -7,16 +7,18 @@ import {
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TableCellDoubleLineLayoutProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The primary data being displayed in the table cell. Typically used with alphanumeric
-   * information like addresses, dates, times, and names.
-   */
-  children: ReactNode
-  /** The media item to display. Typically an image or avatar. */
-  mediaItem?: ReactNode
-  /** The trailing icon displayed after the content. */
-  supplementaryData?: ReactNode
+export namespace TableCellDoubleLineLayout {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The primary data being displayed in the table cell. Typically used with alphanumeric
+     * information like addresses, dates, times, and names.
+     */
+    children: ReactNode
+    /** The media item to display. Typically an image or avatar. */
+    mediaItem?: ReactNode
+    /** The trailing icon displayed after the content. */
+    supplementaryData?: ReactNode
+  }
 }
 
 /**
@@ -28,7 +30,7 @@ export function TableCellDoubleLineLayout({
   mediaItem,
   supplementaryData,
   ...rest
-}: TableCellDoubleLineLayoutProps) {
+}: TableCellDoubleLineLayout.Props) {
   return (
     <ElTableCellDoubleLineLayout {...rest}>
       {mediaItem && <ElTableCellDoubleLineLayoutMediaItem>{mediaItem}</ElTableCellDoubleLineLayoutMediaItem>}
@@ -39,3 +41,6 @@ export function TableCellDoubleLineLayout({
     </ElTableCellDoubleLineLayout>
   )
 }
+
+// Backward compatibility
+export type TableCellDoubleLineLayoutProps = TableCellDoubleLineLayout.Props

--- a/src/core/table/head/head.tsx
+++ b/src/core/table/head/head.tsx
@@ -3,19 +3,21 @@ import { elTableHead } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TableHeadAsTheadProps extends HTMLAttributes<HTMLTableSectionElement> {
-  as?: 'thead'
-  /** The table's rows. */
-  children: ReactNode
-}
+export namespace TableHead {
+  interface AsTheadProps extends HTMLAttributes<HTMLTableSectionElement> {
+    as?: 'thead'
+    /** The table's header rows. */
+    children: ReactNode
+  }
 
-interface TableHeadAsDivProps extends HTMLAttributes<HTMLDivElement> {
-  as: 'div'
-  /** The table's rows. */
-  children: ReactNode
-}
+  interface AsDivProps extends HTMLAttributes<HTMLDivElement> {
+    as: 'div'
+    /** The table's header rows. */
+    children: ReactNode
+  }
 
-type TableHeadProps = TableHeadAsTheadProps | TableHeadAsDivProps
+  export type Props = AsTheadProps | AsDivProps
+}
 
 /**
  * A table's head. Does little more than render its children in a `<thead>` or `<div>` element.
@@ -23,10 +25,13 @@ type TableHeadProps = TableHeadAsTheadProps | TableHeadAsDivProps
  * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
  * Typically used via `Table.Head`.
  */
-export function TableHead({ as: Element = 'thead', children, className, ...rest }: TableHeadProps) {
+export function TableHead({ as: Element = 'thead', children, className, ...rest }: TableHead.Props) {
   return (
     <Element {...rest} className={cx(elTableHead, className)}>
       {children}
     </Element>
   )
 }
+
+// Backward compatibility
+export type TableHeadProps = TableHead.Props

--- a/src/core/table/header-cell/header-cell.tsx
+++ b/src/core/table/header-cell/header-cell.tsx
@@ -3,34 +3,36 @@ import { elTableHeaderCell } from './styles'
 
 import type { HTMLAttributes, ReactNode, ThHTMLAttributes } from 'react'
 
-interface TableHeaderCellCommonProps {
-  /** The cell content. */
-  children?: ReactNode
-  /**
-   * Remove default padding. Useful for cells that contain an interactive element whose hit area
-   * should fill the entire cell.
-   */
-  hasNoPadding?: boolean
-  /** The alignment of the cell's content. */
-  justifySelf?: 'start' | 'center' | 'end'
-}
+export namespace TableHeaderCell {
+  interface CommonProps {
+    /** The cell content. */
+    children?: ReactNode
+    /**
+     * Remove default padding. Useful for cells that contain an interactive element whose hit area
+     * should fill the entire cell.
+     */
+    hasNoPadding?: boolean
+    /** The alignment of the cell's content. */
+    justifySelf?: 'start' | 'center' | 'end'
+  }
 
-interface TableHeaderCellAsThProps
-  extends TableHeaderCellCommonProps,
-    // NOTE: we omit scope because it should always be "col"
-    Omit<ThHTMLAttributes<HTMLTableCellElement>, 'scope'> {
-  /** The sort direction currently applied to the column. */
-  'aria-sort'?: 'ascending' | 'descending'
-  as?: 'th'
-}
+  interface AsThProps
+    extends CommonProps,
+      // NOTE: we omit scope because it should always be "col"
+      Omit<ThHTMLAttributes<HTMLTableCellElement>, 'scope'> {
+    /** The sort direction currently applied to the column. */
+    'aria-sort'?: 'ascending' | 'descending'
+    as?: 'th'
+  }
 
-interface TableHeaderCellAsDivProps extends TableHeaderCellCommonProps, HTMLAttributes<HTMLDivElement> {
-  /** The sort direction currently applied to the column. */
-  'aria-sort'?: 'ascending' | 'descending'
-  as: 'div'
-}
+  interface AsDivProps extends CommonProps, HTMLAttributes<HTMLDivElement> {
+    /** The sort direction currently applied to the column. */
+    'aria-sort'?: 'ascending' | 'descending'
+    as: 'div'
+  }
 
-type TableHeaderCellProps = TableHeaderCellAsThProps | TableHeaderCellAsDivProps
+  export type Props = AsThProps | AsDivProps
+}
 
 /**
  * A basic header cell for a table's head. Does little more than render its children in a `<th>`, or
@@ -43,7 +45,7 @@ export function TableHeaderCell({
   hasNoPadding,
   justifySelf,
   ...rest
-}: TableHeaderCellProps) {
+}: TableHeaderCell.Props) {
   // If there's no children (i.e. it's an empty cell), we need to render as a <td>, not a <th>, but this
   // only relevant if we're rendering as a <th> element in the first-place.
   const Element = !children && ElementProp === 'th' ? 'td' : ElementProp
@@ -60,3 +62,6 @@ export function TableHeaderCell({
     </Element>
   )
 }
+
+// Backward compatibility
+export type TableHeaderCellProps = TableHeaderCell.Props

--- a/src/core/table/header-row/header-row.tsx
+++ b/src/core/table/header-row/header-row.tsx
@@ -3,31 +3,35 @@ import { elTableHeaderRow } from './styles'
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TableHeaderRowAsTrProps extends HTMLAttributes<HTMLTableRowElement> {
-  as?: 'tr'
-  /** The row content. */
-  children: ReactNode
-}
+export namespace TableHeaderRow {
+  interface AsTrProps extends HTMLAttributes<HTMLTableRowElement> {
+    as?: 'tr'
+    /** The row's cells. */
+    children: ReactNode
+  }
 
-interface TableHeaderRowAsDivProps extends HTMLAttributes<HTMLDivElement> {
-  as: 'div'
-  /** The row content. */
-  children: ReactNode
-}
+  interface AsDivProps extends HTMLAttributes<HTMLDivElement> {
+    as: 'div'
+    /** The row's cells. */
+    children: ReactNode
+  }
 
-type TableHeaderRowProps = TableHeaderRowAsTrProps | TableHeaderRowAsDivProps
+  export type Props = AsTrProps | AsDivProps
+}
 
 /**
- * A basic row for a table's head. Does little more than render it's children in a `<tr>` or `<div>`.
- * Cells within a row may contain static text or buttons that sort the table column. Cells are
- * aligned to the table's CSS grid layout via
- * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid). Typically
- * used via `Table.HeadingRow`.
+ * A table's header row. Does little more than render its children in a `<tr>` or `<div>` element.
+ * Descendants will flow to new columns while rows will align to the table's grid using
+ * [subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
+ * Typically used via `Table.HeaderRow`.
  */
-export function TableHeaderRow({ as: Element = 'tr', children, className, ...rest }: TableHeaderRowProps) {
+export function TableHeaderRow({ as: Element = 'tr', children, className, ...rest }: TableHeaderRow.Props) {
   return (
     <Element {...rest} className={cx(elTableHeaderRow, className)}>
       {children}
     </Element>
   )
 }
+
+// Backward compatibility
+export type TableHeaderRowProps = TableHeaderRow.Props

--- a/src/core/table/more-actions/more-actions-button.tsx
+++ b/src/core/table/more-actions/more-actions-button.tsx
@@ -10,24 +10,26 @@ import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
 // - type, because the more actions button should never act as a submit button
 type AttributesToOmit = 'children' | 'type'
 
-interface TableRowMoreActionsButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
-  /**
-   * Whether the button is disabled. This can be used to make the button appear disabled to users, but
-   * still be focusable. When ARIA disabled, the button will ignore click events. Using `aria-disabled`
-   * is preferred when the button should still be focusable while it's disabled; for example, to allow
-   * a tooltip to be displayed that explains why the button is disabled.
-   */
-  'aria-disabled'?: boolean
-  /**
-   * The accessible name for this button. Take care to ensure it is descriptive of the table row
-   * to which it's related.
-   */
-  'aria-label': string
-  /**
-   * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will
-   * not be focusable or interactive.
-   */
-  disabled?: boolean
+export namespace TableRowMoreActionsButton {
+  export interface Props extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+    /**
+     * Whether the button is disabled. This can be used to make the button appear disabled to users, but
+     * still be focusable. When ARIA disabled, the button will ignore click events. Using `aria-disabled`
+     * is preferred when the button should still be focusable while it's disabled; for example, to allow
+     * a tooltip to be displayed that explains why the button is disabled.
+     */
+    'aria-disabled'?: boolean
+    /**
+     * The accessible name for this button. Take care to ensure it is descriptive of the table row
+     * to which it's related.
+     */
+    'aria-label': string
+    /**
+     * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will
+     * not be focusable or interactive.
+     */
+    disabled?: boolean
+  }
 }
 
 /**
@@ -41,7 +43,7 @@ export function TableRowMoreActionsButton({
   disabled,
   onClick,
   ...rest
-}: TableRowMoreActionsButtonProps) {
+}: TableRowMoreActionsButton.Props) {
   const handleClick = useCallback<MouseEventHandler<HTMLElement>>(
     (event) => {
       const element = event.currentTarget
@@ -74,3 +76,6 @@ export function TableRowMoreActionsButton({
     </button>
   )
 }
+
+// Backward compatibility
+export type TableRowMoreActionsButtonProps = TableRowMoreActionsButton.Props

--- a/src/core/table/more-actions/more-actions.tsx
+++ b/src/core/table/more-actions/more-actions.tsx
@@ -4,32 +4,34 @@ import { useId } from 'react'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface TableRowMoreActionsProps extends ComponentProps<typeof TableRowMoreActionsButton> {
-  /**
-   * Whether the button is disabled. This can be used to make the button appear disabled to users, but
-   * still be focusable. When ARIA disabled, the button will ignore click events. Using `aria-disabled`
-   * is preferred when the button should still be focusable while it's disabled; for example, to allow
-   * a tooltip to be displayed that explains why the button is disabled.
-   */
-  'aria-disabled'?: boolean
-  /**
-   * The accessible name for this button. Take care to ensure it is descriptive of the table row
-   * to which it's related.
-   */
-  'aria-label': string
-  /** The secondary actions for the table row. */
-  children: ReactNode
-  /**
-   * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will
-   * not be focusable or interactive.
-   */
-  disabled?: boolean
+export namespace TableRowMoreActions {
+  export interface Props extends ComponentProps<typeof TableRowMoreActionsButton> {
+    /**
+     * Whether the button is disabled. This can be used to make the button appear disabled to users, but
+     * still be focusable. When ARIA disabled, the button will ignore click events. Using `aria-disabled`
+     * is preferred when the button should still be focusable while it's disabled; for example, to allow
+     * a tooltip to be displayed that explains why the button is disabled.
+     */
+    'aria-disabled'?: boolean
+    /**
+     * The accessible name for this button. Take care to ensure it is descriptive of the table row
+     * to which it's related.
+     */
+    'aria-label': string
+    /** The secondary actions for the table row. */
+    children: ReactNode
+    /**
+     * Whether the button is disabled or not. Unlike `aria-disabled`, buttons disabled with this prop will
+     * not be focusable or interactive.
+     */
+    disabled?: boolean
+  }
 }
 
 /**
  * A "more actions" button and menu for use in table rows.
  */
-export function TableRowMoreActions({ children, id, ...rest }: TableRowMoreActionsProps) {
+export function TableRowMoreActions({ children, id, ...rest }: TableRowMoreActions.Props) {
   const triggerId = id ?? useId()
   const menuId = useId()
   return (
@@ -44,3 +46,6 @@ export function TableRowMoreActions({ children, id, ...rest }: TableRowMoreActio
     </>
   )
 }
+
+// Backward compatibility
+export type TableRowMoreActionsProps = TableRowMoreActions.Props

--- a/src/core/table/primary-action/primary-action-button.tsx
+++ b/src/core/table/primary-action/primary-action-button.tsx
@@ -3,20 +3,26 @@ import { elTableRowPrimaryAction } from './styles'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-// NOTE: We omit...
-// - disabled, because the row's primary action should never be disabled.
-type AttributesToOmit = 'disabled'
+// NOTE: we omit...
+// - type, because we internally control the button type
+type AttributesToOmit = 'type'
 
-export interface TableRowPrimaryActionButtonProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
-  /** The content of the primary action */
-  children: ReactNode
+export namespace TableRowPrimaryActionButton {
+  export interface Props extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+    /** The content of the primary action */
+    children: ReactNode
+  }
 }
 
 /**
- * A simple primary action component for table rows. Comes in two varieties: `Table.PrimaryActionButton`,
- * which renders as a button, and `Table.PrimaryAction`, which renders as an anchor.
+ * A primary action button for table rows. Renders as a button (`<button>`) element that spans the entire
+ * row, allowing users to interact by clicking anywhere on the row. The visual appearance is
+ * designed to integrate seamlessly with table layouts while providing clear interactive feedback.
+ * Typically used via `Table.PrimaryActionButton`.
  */
-export function TableRowPrimaryActionButton({ className, ...rest }: TableRowPrimaryActionButtonProps) {
+export function TableRowPrimaryActionButton({ className, ...rest }: TableRowPrimaryActionButton.Props) {
   return <button {...rest} className={cx(elTableRowPrimaryAction, className)} />
 }
+
+// Backward compatibility
+export type TableRowPrimaryActionButtonProps = TableRowPrimaryActionButton.Props

--- a/src/core/table/primary-action/primary-action.tsx
+++ b/src/core/table/primary-action/primary-action.tsx
@@ -3,22 +3,24 @@ import { elTableRowPrimaryAction } from './styles'
 
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-export interface TableRowPrimaryActionProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** The content of the primary action */
-  children: ReactNode
-  /** The URL to which this primary action navigates */
-  href: string
+export namespace TableRowPrimaryAction {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** The content of the primary action */
+    children: ReactNode
+    /** The URL to which this primary action navigates */
+    href: string
+  }
 }
 
 /**
- * A simple primary action component for table rows that allows an anchor or button, typically placed
- * within a row's header cell, to act as the row's primary action. The key feature of the primary
- * action is that its "hit area" will expand to fill the bounding box of the closest, relative-positioned
- * ancestor. By default, this will be the table row.
- *
- * Comes in two varieties: `Table.PrimaryAction`, which renders as an anchor, and
- * `Table.PrimaryActionButton`, which renders as a button.
+ * A primary action for table rows. Renders as an anchor (`<a>`) element that spans the entire
+ * row, allowing users to navigate by clicking anywhere on the row. The visual appearance is
+ * designed to integrate seamlessly with table layouts while providing clear interactive feedback.
+ * Typically used via `Table.PrimaryAction`.
  */
-export function TableRowPrimaryAction({ className, ...rest }: TableRowPrimaryActionProps) {
+export function TableRowPrimaryAction({ className, ...rest }: TableRowPrimaryAction.Props) {
   return <a {...rest} className={cx(elTableRowPrimaryAction, className)} />
 }
+
+// Backward compatibility
+export type TableRowPrimaryActionProps = TableRowPrimaryAction.Props

--- a/src/core/table/primary-data/primary-data.tsx
+++ b/src/core/table/primary-data/primary-data.tsx
@@ -6,16 +6,18 @@ import {
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface TableCellPrimaryDataProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The primary data being displayed in the table cell. Typically used with alphanumeric
-   * information like addresses, dates, times, and names.
-   */
-  children: ReactNode
-  /** The leading icon displayed before the content. */
-  iconLeft?: ReactNode
-  /** The trailing icon displayed after the content. */
-  iconRight?: ReactNode
+export namespace TableCellPrimaryData {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The primary data being displayed in the table cell. Typically used with alphanumeric
+     * information like addresses, dates, times, and names.
+     */
+    children: ReactNode
+    /** The leading icon displayed before the content. */
+    iconLeft?: ReactNode
+    /** The trailing icon displayed after the content. */
+    iconRight?: ReactNode
+  }
 }
 
 /**
@@ -24,7 +26,7 @@ interface TableCellPrimaryDataProps extends HTMLAttributes<HTMLDivElement> {
  * cell's primary data. It ensures the icons remain visible even when there is insufficient
  * space for the content. Typically used via `Table.PrimaryData`.
  */
-export function TableCellPrimaryData({ children, iconLeft, iconRight, ...rest }: TableCellPrimaryDataProps) {
+export function TableCellPrimaryData({ children, iconLeft, iconRight, ...rest }: TableCellPrimaryData.Props) {
   return (
     <ElTableCellPrimaryData {...rest}>
       {iconLeft && (
@@ -44,3 +46,6 @@ export function TableCellPrimaryData({ children, iconLeft, iconRight, ...rest }:
     </ElTableCellPrimaryData>
   )
 }
+
+// Backward compatibility
+export type TableCellPrimaryDataProps = TableCellPrimaryData.Props

--- a/src/core/table/sort-button/sort-button.tsx
+++ b/src/core/table/sort-button/sort-button.tsx
@@ -9,20 +9,22 @@ import type { SortDirection } from './sort-direction'
 // - disabled, because the sort button should never be disabled
 type AttributesToOmit = 'disabled'
 
-interface TableCellSortButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
-  /** The sort button's label. */
-  children: ReactNode
-  /** The name of the "field" in the table's data sorted by this button. */
-  name: string
-  /** The current sort direction for this column, if any. */
-  value: SortDirection
+export namespace TableCellSortButton {
+  export interface Props extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, AttributesToOmit> {
+    /** The sort button's label. */
+    children: ReactNode
+    /** The name of the "field" in the table's data sorted by this button. */
+    name: string
+    /** The current sort direction for this column, if any. */
+    value: SortDirection
+  }
 }
 
 /**
  * A simple button for table column headers that allows users to sort the column in ascending
  * or descending order. Typically used via `Table.SortButton`.
  */
-export function TableCellSortButton({ children, className, name, value, ...rest }: TableCellSortButtonProps) {
+export function TableCellSortButton({ children, className, name, value, ...rest }: TableCellSortButton.Props) {
   return (
     <button {...rest} className={cx(elTableCellSortButton, className)} name={name} value={value}>
       {children}
@@ -30,3 +32,6 @@ export function TableCellSortButton({ children, className, name, value, ...rest 
     </button>
   )
 }
+
+// Backward compatibility
+export type TableCellSortButtonProps = TableCellSortButton.Props

--- a/src/core/table/table.tsx
+++ b/src/core/table/table.tsx
@@ -17,35 +17,37 @@ import { TableToolbar } from './toolbar'
 
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
 
-interface CommonTablePros {
-  /**
-   * Defines the number of columns and their explicit sizing. Columns are defined using the
-   * [grid-template-columns)(https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
-   * syntax.
-   */
-  columns: string
-  /**
-   * Defines how column content is positioned along the inline axis. By default, content is packed
-   * against the starting edge of the column.
-   */
-  justifyItems?: 'start' | 'center' | 'end'
-}
+export namespace Table {
+  interface CommonProps {
+    /**
+     * Defines the number of columns and their explicit sizing. Columns are defined using the
+     * [grid-template-columns)(https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
+     * syntax.
+     */
+    columns: string
+    /**
+     * Defines how column content is positioned along the inline axis. By default, content is packed
+     * against the starting edge of the column.
+     */
+    justifyItems?: 'start' | 'center' | 'end'
+  }
 
-// NOTE: We do not use TableHTMLAttributes because the table-specific attributes it provides are
-// deprecated (see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table#attributes).
-interface TableAsTableProps extends CommonTablePros, HTMLAttributes<HTMLTableElement> {
-  as?: 'table'
-  /** The table's content. */
-  children: ReactNode
-}
+  // NOTE: We do not use TableHTMLAttributes because the table-specific attributes it provides are
+  // deprecated (see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table#attributes).
+  interface AsTableProps extends CommonProps, HTMLAttributes<HTMLTableElement> {
+    as?: 'table'
+    /** The table's content. */
+    children: ReactNode
+  }
 
-interface TableAsDivProps extends CommonTablePros, HTMLAttributes<HTMLDivElement> {
-  as: 'div'
-  /** The table's content. */
-  children: ReactNode
-}
+  interface AsDivProps extends CommonProps, HTMLAttributes<HTMLDivElement> {
+    as: 'div'
+    /** The table's content. */
+    children: ReactNode
+  }
 
-type TableProps = TableAsTableProps | TableAsDivProps
+  export type Props = AsTableProps | AsDivProps
+}
 
 /**
  * A classic table. Renders its children in a `<table>` or `<div>` element based on the specified columns.
@@ -76,7 +78,7 @@ export function Table({
   justifyItems = 'start',
   style,
   ...rest
-}: TableProps) {
+}: Table.Props) {
   return (
     <Element
       {...rest}
@@ -106,3 +108,6 @@ Table.SortButton = TableCellSortButton
 Table.Checkbox = TableCellCheckbox
 
 Table.Toolbar = TableToolbar
+
+// Backward compatibility
+export type TableProps = Table.Props

--- a/src/core/table/toolbar/toolbar.tsx
+++ b/src/core/table/toolbar/toolbar.tsx
@@ -6,14 +6,16 @@ import type { HTMLAttributes, ReactNode } from 'react'
 // - children, because we internally control the child content
 type AttributesToOmit = 'children'
 
-interface TableToolbarProps extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
-  /** Typically used to show the total number of items or the number of selected rows. */
-  leftContent?: ReactNode
-  /**
-   * Typically used to display table controls, like page size, or actions available for
-   * the selected rows.
-   */
-  rightContent?: ReactNode
+export namespace TableToolbar {
+  export interface Props extends Omit<HTMLAttributes<HTMLDivElement>, AttributesToOmit> {
+    /** Typically used to show the total number of items or the number of selected rows. */
+    leftContent?: ReactNode
+    /**
+     * Typically used to display table controls, like page size, or actions available for
+     * the selected rows.
+     */
+    rightContent?: ReactNode
+  }
 }
 
 /**
@@ -21,7 +23,7 @@ interface TableToolbarProps extends Omit<HTMLAttributes<HTMLDivElement>, Attribu
  * in the table and/or some controls related to the items. At least one of `leftContent` or `rightContent`
  * must be provided.
  */
-export function TableToolbar({ leftContent, rightContent, ...rest }: TableToolbarProps) {
+export function TableToolbar({ leftContent, rightContent, ...rest }: TableToolbar.Props) {
   return (
     <ElTableToolbar {...rest}>
       {leftContent && <ElTableToolbarLeftContent>{leftContent}</ElTableToolbarLeftContent>}
@@ -29,3 +31,6 @@ export function TableToolbar({ leftContent, rightContent, ...rest }: TableToolba
     </ElTableToolbar>
   )
 }
+
+// Backward compatibility
+export type TableToolbarProps = TableToolbar.Props

--- a/src/core/top-bar/avatar-button/avatar-button.tsx
+++ b/src/core/top-bar/avatar-button/avatar-button.tsx
@@ -4,12 +4,17 @@ import { elTopBarAvatarButton } from './styles'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-export interface AvatarButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** The accessible name of the button. */
-  'aria-label'?: string
-  /** The avatar's text. Typically the initials of the current user. */
-  children: ReactNode
+export namespace TopBarAvatarButton {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    /** The accessible name of the button. */
+    'aria-label'?: string
+    /** The avatar's text. Typically the initials of the current user. */
+    children: ReactNode
+  }
 }
+
+/** @deprecated Use TopBarAvatarButton.Props instead */
+export type AvatarButtonProps = TopBarAvatarButton.Props
 
 /**
  * A simple avatar button that should open a menu with items that relate to the current user. These menu items will
@@ -23,7 +28,7 @@ export function TopBarAvatarButton({
   children,
   className,
   ...rest
-}: AvatarButtonProps) {
+}: TopBarAvatarButton.Props) {
   return (
     <button {...rest} aria-label={ariaLabel} className={cx(elTopBarAvatarButton, className)}>
       <Avatar size="small" shape="circle" colour="purple">

--- a/src/core/top-bar/avatar-menu/avatar-menu.tsx
+++ b/src/core/top-bar/avatar-menu/avatar-menu.tsx
@@ -4,19 +4,24 @@ import { useId } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-export interface AvatarMenuProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** The menu items. */
-  children: ReactNode
-  /** The avatar's text. Typically the initials of the current user. */
-  initials: ReactNode
-  maxWidth?: `--size-${string}`
-  maxHeight?: `--size-${string}`
+export namespace TopBarAvatarMenu {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    /** The menu items. */
+    children: ReactNode
+    /** The avatar's text. Typically the initials of the current user. */
+    initials: ReactNode
+    maxWidth?: `--size-${string}`
+    maxHeight?: `--size-${string}`
+  }
 }
+
+/** @deprecated Use TopBarAvatarMenu.Props instead */
+export type AvatarMenuProps = TopBarAvatarMenu.Props
 
 /**
  * A combination of a `TopBar.AvatarButton` and `Menu`.
  */
-export function TopBarAvatarMenu({ children, id, initials, maxWidth, maxHeight, ...rest }: AvatarMenuProps) {
+export function TopBarAvatarMenu({ children, id, initials, maxWidth, maxHeight, ...rest }: TopBarAvatarMenu.Props) {
   const triggerId = id ?? useId()
   const menuId = useId()
   return (

--- a/src/core/top-bar/brand-logo/app-logo.tsx
+++ b/src/core/top-bar/brand-logo/app-logo.tsx
@@ -38,14 +38,16 @@ export const supportedAppNames = [
 
 export type SupportedAppName = (typeof supportedAppNames)[number]
 
-interface AppLogoProps {
-  appName: SupportedAppName
+export namespace AppLogo {
+  export interface Props {
+    appName: SupportedAppName
+  }
 }
 
 /**
  * A simple component for displaying product's logo. Each logo will have an accessible name that matches the app name.
  */
-export function AppLogo({ appName }: AppLogoProps) {
+export function AppLogo({ appName }: AppLogo.Props) {
   switch (appName) {
     case 'Reapit':
       return <Reapit aria-label={appName} />

--- a/src/core/top-bar/brand-logo/brand-logo.tsx
+++ b/src/core/top-bar/brand-logo/brand-logo.tsx
@@ -4,18 +4,20 @@ import { AppLogo } from './app-logo'
 import type { SupportedAppName } from './app-logo'
 import type { AnchorHTMLAttributes } from 'react'
 
-interface BrandLogoProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** The name of the app for which to display the logo */
-  appName: SupportedAppName
-  /** The URL to navigate to when the logo is clicked. Defaults to the root path. */
-  href?: string
+export namespace BrandLogo {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** The name of the app for which to display the logo */
+    appName: SupportedAppName
+    /** The URL to navigate to when the logo is clicked. Defaults to the root path. */
+    href?: string
+  }
 }
 
 /**
  * A simple component for displaying a product logo in the Reapit brand. Will typically be used
  * via `TopBar.BrandLogo`.
  */
-export function BrandLogo({ appName, href = '/', ...rest }: BrandLogoProps) {
+export function BrandLogo({ appName, href = '/', ...rest }: BrandLogo.Props) {
   return (
     <ElBrandLogo {...rest} aria-label={`Go to ${appName}`} href={href}>
       <AppLogo appName={appName} />

--- a/src/core/top-bar/main-nav/main-nav-list-item.tsx
+++ b/src/core/top-bar/main-nav/main-nav-list-item.tsx
@@ -3,7 +3,9 @@ import { TopBarNavItem } from '../nav-item'
 
 import type { ComponentProps } from 'react'
 
-interface TopBarMainNavItemListProps extends ComponentProps<typeof TopBarNavItem> {}
+export namespace TopBarMainNavListItem {
+  export interface Props extends ComponentProps<typeof TopBarNavItem> {}
+}
 
 /**
  * A thin wrapper around `TopBarNavItem` that ensures it is contained within a list item (`<li>`) for
@@ -11,7 +13,7 @@ interface TopBarMainNavItemListProps extends ComponentProps<typeof TopBarNavItem
  *
  * All props are passed through to `TopBarNavItem`.
  */
-export function TopBarMainNavListItem(props: TopBarMainNavItemListProps) {
+export function TopBarMainNavListItem(props: TopBarMainNavListItem.Props) {
   return (
     <ElTopBarMainNavListItem>
       <TopBarNavItem {...props} />

--- a/src/core/top-bar/main-nav/main-nav-menu-list-item.tsx
+++ b/src/core/top-bar/main-nav/main-nav-menu-list-item.tsx
@@ -5,18 +5,20 @@ import { useId } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface TopBarMainNavMenuListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode
-  label: string
-  maxWidth?: `--size-${string}`
-  maxHeight?: `--size-${string}`
+export namespace TopBarMainNavMenuListItem {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    children: ReactNode
+    label: string
+    maxWidth?: `--size-${string}`
+    maxHeight?: `--size-${string}`
+  }
 }
 
 /**
  * A combination of a `TopBar.NavDropdownButton` and `Menu` that is contained within a list item (`<li>`) for
  * correct semantics and accessibility when used with `TopBar.MainNav`.
  */
-export function TopBarMainNavMenuListItem({ children, id, label, ...rest }: TopBarMainNavMenuListItemProps) {
+export function TopBarMainNavMenuListItem({ children, id, label, ...rest }: TopBarMainNavMenuListItem.Props) {
   const triggerId = id ?? useId()
   const menuId = useId()
   return (

--- a/src/core/top-bar/main-nav/main-nav.tsx
+++ b/src/core/top-bar/main-nav/main-nav.tsx
@@ -4,16 +4,18 @@ import { TopBarMainNavMenuListItem } from './main-nav-menu-list-item'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface TopBarMainNavProps extends ComponentProps<typeof ElTopBarMainNav> {
-  /**
-   * The accessible name for the main navigation.
-   * @default 'Main navigation'
-   */
-  'aria-label'?: string
-  /**
-   * The main navigation items for the product. Typically a collection of `TopBar.NavItem` and `TopBar.NavMenuItem`.
-   */
-  children: ReactNode
+export namespace TopBarMainNav {
+  export interface Props extends ComponentProps<typeof ElTopBarMainNav> {
+    /**
+     * The accessible name for the main navigation.
+     * @default 'Main navigation'
+     */
+    'aria-label'?: string
+    /**
+     * The main navigation items for the product. Typically a collection of `TopBar.NavItem` and `TopBar.NavMenuItem`.
+     */
+    children: ReactNode
+  }
 }
 
 /**
@@ -21,7 +23,7 @@ interface TopBarMainNavProps extends ComponentProps<typeof ElTopBarMainNav> {
  * collection of `TopBar.NavItem` and `TopBar.NavMenuItem` children. Only one item, if any, in the top bar
  * should represent the current page at any given time.
  */
-export function TopBarMainNav({ 'aria-label': ariaLabel = 'Main navigation', children, ...rest }: TopBarMainNavProps) {
+export function TopBarMainNav({ 'aria-label': ariaLabel = 'Main navigation', children, ...rest }: TopBarMainNav.Props) {
   return (
     <ElTopBarMainNav {...rest} aria-label={ariaLabel}>
       <ElTopBarMainNavList>{children}</ElTopBarMainNavList>

--- a/src/core/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
+++ b/src/core/top-bar/nav-dropdown-button/nav-dropdown-button.tsx
@@ -4,12 +4,17 @@ import { elTopBarNavDropdownButton, ElTopBarNavDropdownButtonIcon, ElTopBarNavDr
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-export interface TopBarNavDropdownButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  /**
-   * The label of the dropdown button.
-   */
-  children: ReactNode
+export namespace TopBarNavDropdownButton {
+  export interface Props extends HTMLAttributes<HTMLButtonElement> {
+    /**
+     * The label of the dropdown button.
+     */
+    children: ReactNode
+  }
 }
+
+/** @deprecated Use TopBarNavDropdownButton.Props instead */
+export type TopBarNavDropdownButtonProps = TopBarNavDropdownButton.Props
 
 /**
  * A simple dropdown button for use in the Top Bar's main navigation region. It can be used as an overflow menu when
@@ -22,7 +27,7 @@ export interface TopBarNavDropdownButtonProps extends HTMLAttributes<HTMLButtonE
  * is correctly wrapped by a list item (`<li>`) to ensure good semantics and accessibility when used with
  * `TopBar.MainNav`.
  */
-export function TopBarNavDropdownButton({ children, className, ...rest }: TopBarNavDropdownButtonProps) {
+export function TopBarNavDropdownButton({ children, className, ...rest }: TopBarNavDropdownButton.Props) {
   return (
     <button {...rest} className={cx(elTopBarNavDropdownButton, className)}>
       <ElTopBarNavDropdownButtonLabel>{children}</ElTopBarNavDropdownButtonLabel>

--- a/src/core/top-bar/nav-icon-item/nav-icon-item-base.tsx
+++ b/src/core/top-bar/nav-icon-item/nav-icon-item-base.tsx
@@ -4,26 +4,33 @@ import { Tooltip } from '#src/core/tooltip'
 
 import { HTMLAttributes, useId, type AnchorHTMLAttributes, type ButtonHTMLAttributes, type ReactNode } from 'react'
 
-interface TopBarNavIconItemCommonProps {
-  hasBadge?: boolean
-  icon: ReactNode
+export namespace TopBarNavIconItemBase {
+  interface CommonProps {
+    hasBadge?: boolean
+    icon: ReactNode
+  }
+
+  export interface AsAnchorProps extends CommonProps, Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> {
+    'aria-label': string
+    as: 'a'
+  }
+
+  export interface AsButtonProps extends CommonProps, Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+    'aria-label': string
+    as: 'button'
+  }
+
+  export type Props = AsAnchorProps | AsButtonProps
 }
 
-export interface TopBarNavIconItemAsAnchorProps
-  extends TopBarNavIconItemCommonProps,
-    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> {
-  'aria-label': string
-  as: 'a'
-}
+/** @deprecated Use TopBarNavIconItemBase.AsAnchorProps instead */
+export type TopBarNavIconItemAsAnchorProps = TopBarNavIconItemBase.AsAnchorProps
 
-export interface TopBarNavIconItemAsButtonProps
-  extends TopBarNavIconItemCommonProps,
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
-  'aria-label': string
-  as: 'button'
-}
+/** @deprecated Use TopBarNavIconItemBase.AsButtonProps instead */
+export type TopBarNavIconItemAsButtonProps = TopBarNavIconItemBase.AsButtonProps
 
-export type TopBarNavIconItemBaseProps = TopBarNavIconItemAsAnchorProps | TopBarNavIconItemAsButtonProps
+/** @deprecated Use TopBarNavIconItemBase.Props instead */
+export type TopBarNavIconItemBaseProps = TopBarNavIconItemBase.Props
 
 /**
  * A simple polymorphic icon-only nav item that can render as a button or link. It is used internally by the
@@ -37,7 +44,7 @@ export function TopBarNavIconItemBase({
   id,
   hasBadge,
   ...rest
-}: TopBarNavIconItemBaseProps) {
+}: TopBarNavIconItemBase.Props) {
   const triggerId = id ?? useId()
   const tooltipId = useId()
 

--- a/src/core/top-bar/nav-icon-item/nav-icon-item-button.tsx
+++ b/src/core/top-bar/nav-icon-item/nav-icon-item-button.tsx
@@ -2,16 +2,21 @@ import { TopBarNavIconItemBase } from './nav-icon-item-base'
 
 import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react'
 
-export interface TopBarNavIconItemButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
-  /** The accessible name of the nav icon item. */
-  'aria-label': string
-  /** Optional badge to be displayed on the nav item */
-  hasBadge?: boolean
-  /** The nav item's icon. */
-  icon: ReactNode
-  /** The click handler for the nav item. */
-  onClick?: MouseEventHandler<HTMLButtonElement>
+export namespace TopBarNavIconItemButton {
+  export interface Props extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+    /** The accessible name of the nav icon item. */
+    'aria-label': string
+    /** Optional badge to be displayed on the nav item */
+    hasBadge?: boolean
+    /** The nav item's icon. */
+    icon: ReactNode
+    /** The click handler for the nav item. */
+    onClick?: MouseEventHandler<HTMLButtonElement>
+  }
 }
+
+/** @deprecated Use TopBarNavIconItemButton.Props instead */
+export type TopBarNavIconItemButtonProps = TopBarNavIconItemButton.Props
 
 /**
  * A simple icon-only button for use in the Top Bar's secondary navigation region. It will typically be used
@@ -23,6 +28,6 @@ export interface TopBarNavIconItemButtonProps extends Omit<ButtonHTMLAttributes<
  * **Important:** ⚠️ Ensure you use this component via `TopBar.NavIconMenuItem` as it wraps the button element in a
  * list item (`<li>`) to ensure good semantics and accessibility when used with `TopBar.SecondaryNav`.
  */
-export function TopBarNavIconItemButton(props: TopBarNavIconItemButtonProps) {
+export function TopBarNavIconItemButton(props: TopBarNavIconItemButton.Props) {
   return <TopBarNavIconItemBase as="button" {...props} />
 }

--- a/src/core/top-bar/nav-icon-item/nav-icon-item.tsx
+++ b/src/core/top-bar/nav-icon-item/nav-icon-item.tsx
@@ -2,17 +2,19 @@ import { TopBarNavIconItemBase } from './nav-icon-item-base'
 
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-interface TopBarNavIconItemProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> {
-  /** Whether the nav item represents the current page. */
-  'aria-current': 'page' | false
-  /** The accessible name of the nav icon item. */
-  'aria-label': string
-  /** Optional badge to be displayed on the nav item */
-  hasBadge?: boolean
-  /** The URL to navigate to when the nav item is clicked. */
-  href: string
-  /** The nav item's icon. */
-  icon: ReactNode
+export namespace TopBarNavIconItem {
+  export interface Props extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> {
+    /** Whether the nav item represents the current page. */
+    'aria-current': 'page' | false
+    /** The accessible name of the nav icon item. */
+    'aria-label': string
+    /** Optional badge to be displayed on the nav item */
+    hasBadge?: boolean
+    /** The URL to navigate to when the nav item is clicked. */
+    href: string
+    /** The nav item's icon. */
+    icon: ReactNode
+  }
 }
 
 /**
@@ -35,6 +37,6 @@ interface TopBarNavIconItemProps extends Omit<AnchorHTMLAttributes<HTMLAnchorEle
  * }
  * ```
  */
-export function TopBarNavIconItem(props: TopBarNavIconItemProps) {
+export function TopBarNavIconItem(props: TopBarNavIconItem.Props) {
   return <TopBarNavIconItemBase {...props} as="a" />
 }

--- a/src/core/top-bar/nav-item/nav-item.tsx
+++ b/src/core/top-bar/nav-item/nav-item.tsx
@@ -3,15 +3,17 @@ import { ElTopBarNavItemLabel, elTopBarNavItem } from './styles'
 
 import type { AnchorHTMLAttributes } from 'react'
 
-interface TopBarNavItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /**
-   * Whether the nav item represents the current page.
-   */
-  'aria-current': 'page' | false
-  /**
-   * The URL to navigate to when this item is activated.
-   */
-  href: string
+export namespace TopBarNavItem {
+  export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    /**
+     * Whether the nav item represents the current page.
+     */
+    'aria-current': 'page' | false
+    /**
+     * The URL to navigate to when this item is activated.
+     */
+    href: string
+  }
 }
 
 /**
@@ -34,7 +36,7 @@ interface TopBarNavItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
  * }
  * ```
  */
-export function TopBarNavItem({ 'aria-current': ariaCurrent, children, className, ...rest }: TopBarNavItemProps) {
+export function TopBarNavItem({ 'aria-current': ariaCurrent, children, className, ...rest }: TopBarNavItem.Props) {
   return (
     <a {...rest} aria-current={ariaCurrent} className={cx(elTopBarNavItem, className)}>
       <ElTopBarNavItemLabel>{children}</ElTopBarNavItemLabel>

--- a/src/core/top-bar/nav-search-button/nav-search-button.tsx
+++ b/src/core/top-bar/nav-search-button/nav-search-button.tsx
@@ -7,26 +7,28 @@ import {
 
 import type { ComponentProps, MouseEventHandler, ReactNode } from 'react'
 
-interface TopBarNavSearchButtonProps extends ComponentProps<typeof ElTopBarNavSearchButton> {
-  /**
-   * Indicates the keyboard shortcut that has been implemented to activate this button. Should typically
-   * be Ctrl+K or Meta+K depending on the platform used by the currently logged in user.
-   */
-  'aria-keyshortcuts'?: string
-  /**
-   * A click handler that launches the product's search experience.
-   */
-  onClick: MouseEventHandler<HTMLButtonElement>
-  /**
-   * The keyboard shortcut, if any, that a product uses to launch the search experience. Should typically
-   * be Ctrl+K or ⌘K depending on the platform used by the currently logged in user. This only defines
-   * a visual indicator of the shortcut and therefore does not need to use the
-   * [\<kbd\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd) element;
-   * to communicate the shortcut to assistive technologies, the
-   * [aria-keyshortcuts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts)
-   * attribute should also be supplied.
-   */
-  shortcut?: ReactNode
+export namespace TopBarNavSearchButton {
+  export interface Props extends ComponentProps<typeof ElTopBarNavSearchButton> {
+    /**
+     * Indicates the keyboard shortcut that has been implemented to activate this button. Should typically
+     * be Ctrl+K or Meta+K depending on the platform used by the currently logged in user.
+     */
+    'aria-keyshortcuts'?: string
+    /**
+     * A click handler that launches the product's search experience.
+     */
+    onClick: MouseEventHandler<HTMLButtonElement>
+    /**
+     * The keyboard shortcut, if any, that a product uses to launch the search experience. Should typically
+     * be Ctrl+K or ⌘K depending on the platform used by the currently logged in user. This only defines
+     * a visual indicator of the shortcut and therefore does not need to use the
+     * [\<kbd\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd) element;
+     * to communicate the shortcut to assistive technologies, the
+     * [aria-keyshortcuts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts)
+     * attribute should also be supplied.
+     */
+    shortcut?: ReactNode
+  }
 }
 
 /**
@@ -35,7 +37,7 @@ interface TopBarNavSearchButtonProps extends ComponentProps<typeof ElTopBarNavSe
  * the search experience to be launched via a keyboard shortcut; usually `Ctrl+K` or `⌘K`. If so, the shortcut
  * should be displayed via the `shortcut` prop.
  */
-export function TopBarNavSearchButton({ shortcut, onClick, ...rest }: TopBarNavSearchButtonProps) {
+export function TopBarNavSearchButton({ shortcut, onClick, ...rest }: TopBarNavSearchButton.Props) {
   return (
     <ElTopBarNavSearchButton {...rest} onClick={onClick} type="button">
       <ElTopBarNavSearchButtonIcon aria-hidden="true" />

--- a/src/core/top-bar/nav-search-icon-item/nav-search-icon-item.tsx
+++ b/src/core/top-bar/nav-search-icon-item/nav-search-icon-item.tsx
@@ -3,15 +3,17 @@ import { TopBarNavIconItemBase } from '../nav-icon-item'
 
 import type { ButtonHTMLAttributes, MouseEventHandler } from 'react'
 
-interface TopBarNavSearchIconItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** A click handler that launches the product's search experience. */
-  onClick: MouseEventHandler<HTMLButtonElement>
+export namespace TopBarNavSearchIconItem {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    /** A click handler that launches the product's search experience. */
+    onClick: MouseEventHandler<HTMLButtonElement>
+  }
 }
 
 /**
  * A `NavIconItem` button used to launch the search experience for a product on mobile devices. It is designed
  * for use on mobile devices. For tablet devices and wider, `TopBar.NavSearchButton` should be used instead.
  */
-export function TopBarNavSearchIconItem({ 'aria-label': ariaLabel, ...rest }: TopBarNavSearchIconItemProps) {
+export function TopBarNavSearchIconItem({ 'aria-label': ariaLabel, ...rest }: TopBarNavSearchIconItem.Props) {
   return <TopBarNavIconItemBase {...rest} aria-label={ariaLabel ?? 'Search'} as="button" icon={<SearchIcon />} />
 }

--- a/src/core/top-bar/nav-search/nav-search.tsx
+++ b/src/core/top-bar/nav-search/nav-search.tsx
@@ -4,15 +4,17 @@ import { TopBarNavSearchIconItem } from '../nav-search-icon-item'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface TopBarNavSearchProps extends ComponentProps<typeof ElTopBarNavSearch> {
-  /**
-   * The button to display on tablet devices and wider. Will typically be a `TopBar.NavSearchButton`.
-   */
-  button?: ReactNode
-  /**
-   * The icon item to display on mobile devices. Will typically be a `TopBar.NavSearchIconItem`.
-   */
-  iconItem?: ReactNode
+export namespace TopBarNavSearch {
+  export interface Props extends ComponentProps<typeof ElTopBarNavSearch> {
+    /**
+     * The button to display on tablet devices and wider. Will typically be a `TopBar.NavSearchButton`.
+     */
+    button?: ReactNode
+    /**
+     * The icon item to display on mobile devices. Will typically be a `TopBar.NavSearchIconItem`.
+     */
+    iconItem?: ReactNode
+  }
 }
 
 /**
@@ -20,7 +22,7 @@ interface TopBarNavSearchProps extends ComponentProps<typeof ElTopBarNavSearch> 
  * (minimum of 150px), and the provided icon item when there isn't. Typically used with `TopBar.NavSearchButton`
  * and `TopBar.NavSearchIconItem`.
  */
-export function TopBarNavSearch({ button, iconItem, ...rest }: TopBarNavSearchProps) {
+export function TopBarNavSearch({ button, iconItem, ...rest }: TopBarNavSearch.Props) {
   return (
     <ElTopBarNavSearch {...rest}>
       <ElTopBarNavSearchButtonContainer>{button}</ElTopBarNavSearchButtonContainer>

--- a/src/core/top-bar/secondary-nav/secondary-nav-list-item.tsx
+++ b/src/core/top-bar/secondary-nav/secondary-nav-list-item.tsx
@@ -3,7 +3,9 @@ import { TopBarNavIconItem } from '../nav-icon-item'
 
 import type { ComponentProps } from 'react'
 
-interface TopBarSecondaryNavListItemProps extends ComponentProps<typeof TopBarNavIconItem> {}
+export namespace TopBarSecondaryNavListItem {
+  export interface Props extends ComponentProps<typeof TopBarNavIconItem> {}
+}
 
 /**
  * A thin wrapper around `TopBarNavIconItemAnchor` that ensures it is contained within a list item (`<li>`) for
@@ -11,7 +13,7 @@ interface TopBarSecondaryNavListItemProps extends ComponentProps<typeof TopBarNa
  *
  * All props are passed through to `TopBarNavIconItemAnchor`.
  */
-export function TopBarSecondaryNavListItem(props: TopBarSecondaryNavListItemProps) {
+export function TopBarSecondaryNavListItem(props: TopBarSecondaryNavListItem.Props) {
   return (
     <ElTopBarSecondaryNavListItem>
       <TopBarNavIconItem {...props} />

--- a/src/core/top-bar/secondary-nav/secondary-nav-menu-list-item.tsx
+++ b/src/core/top-bar/secondary-nav/secondary-nav-menu-list-item.tsx
@@ -5,12 +5,14 @@ import { useId } from 'react'
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface TopBarSecondaryNavMenuListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  'aria-label': string
-  children: ReactNode
-  icon: ReactNode
-  maxWidth?: `--size-${string}`
-  maxHeight?: `--size-${string}`
+export namespace TopBarSecondaryNavMenuListItem {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+    'aria-label': string
+    children: ReactNode
+    icon: ReactNode
+    maxWidth?: `--size-${string}`
+    maxHeight?: `--size-${string}`
+  }
 }
 
 /**
@@ -23,7 +25,7 @@ export function TopBarSecondaryNavMenuListItem({
   icon,
   id,
   ...rest
-}: TopBarSecondaryNavMenuListItemProps) {
+}: TopBarSecondaryNavMenuListItem.Props) {
   const triggerId = id ?? useId()
   const menuId = useId()
 

--- a/src/core/top-bar/secondary-nav/secondary-nav.tsx
+++ b/src/core/top-bar/secondary-nav/secondary-nav.tsx
@@ -4,16 +4,18 @@ import { TopBarSecondaryNavMenuListItem } from './secondary-nav-menu-list-item'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface TopBarSecondaryNavProps extends ComponentProps<typeof ElTopBarSecondaryNav> {
-  /**
-   * The accessible name for the secondary navigation.
-   * @default 'Secondary navigation'
-   */
-  'aria-label'?: string
-  /**
-   * The secondary navigation items for the product. Typically a collection of `TopBar.NavIconItem`'s.
-   */
-  children: ReactNode
+export namespace TopBarSecondaryNav {
+  export interface Props extends ComponentProps<typeof ElTopBarSecondaryNav> {
+    /**
+     * The accessible name for the secondary navigation.
+     * @default 'Secondary navigation'
+     */
+    'aria-label'?: string
+    /**
+     * The secondary navigation items for the product. Typically a collection of `TopBar.NavIconItem`'s.
+     */
+    children: ReactNode
+  }
 }
 
 /**
@@ -25,7 +27,7 @@ export function TopBarSecondaryNav({
   'aria-label': ariaLabel = 'Secondary navigation',
   children,
   ...rest
-}: TopBarSecondaryNavProps) {
+}: TopBarSecondaryNav.Props) {
   return (
     <ElTopBarSecondaryNav {...rest} aria-label={ariaLabel}>
       <ElTopBarSecondaryNavList>{children}</ElTopBarSecondaryNavList>

--- a/src/core/top-bar/top-bar.tsx
+++ b/src/core/top-bar/top-bar.tsx
@@ -18,36 +18,38 @@ import { TopBarSecondaryNav } from './secondary-nav'
 
 import type { ComponentProps, ReactNode } from 'react'
 
-interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> {
-  /**
-   * Typically an `AppSwitcher` component.
-   */
-  appSwitcher?: ReactNode
-  /**
-   * The user's profile menu. Typically an `AvatarMenu`.
-   */
-  avatar?: ReactNode
-  /**
-   * The product's logo.
-   */
-  logo: ReactNode
-  /**
-   * The main navigation region, typically containing `NavItem`'s for the product's top-level pages.
-   */
-  mainNav?: ReactNode
-  /**
-   * The overflow menu for all navigation items in the Top Bar. Usually, each section of the Top Bar will
-   * collapse into this menu as the viewport narrows.
-   */
-  menu?: ReactNode
-  /**
-   * The "global" search entry point for the product. Typically a `NavSeachButton`.
-   */
-  search?: ReactNode
-  /**
-   * The secondary navigation region, typically containing `NavIconItem`'s for the product's secondary pages.
-   */
-  secondaryNav?: ReactNode
+export namespace TopBar {
+  export interface Props extends Omit<ComponentProps<typeof ElTopBar>, 'children'> {
+    /**
+     * Typically an `AppSwitcher` component.
+     */
+    appSwitcher?: ReactNode
+    /**
+     * The user's profile menu. Typically an `AvatarMenu`.
+     */
+    avatar?: ReactNode
+    /**
+     * The product's logo.
+     */
+    logo: ReactNode
+    /**
+     * The main navigation region, typically containing `NavItem`'s for the product's top-level pages.
+     */
+    mainNav?: ReactNode
+    /**
+     * The overflow menu for all navigation items in the Top Bar. Usually, each section of the Top Bar will
+     * collapse into this menu as the viewport narrows.
+     */
+    menu?: ReactNode
+    /**
+     * The "global" search entry point for the product. Typically a `NavSeachButton`.
+     */
+    search?: ReactNode
+    /**
+     * The secondary navigation region, typically containing `NavIconItem`'s for the product's secondary pages.
+     */
+    secondaryNav?: ReactNode
+  }
 }
 
 /**
@@ -70,7 +72,7 @@ interface TopBarProps extends Omit<ComponentProps<typeof ElTopBar>, 'children'> 
  *   [TopBar.NavIconItem](/docs/core-topbar-naviconitem--docs),
  *   [TopBar.NavIconMenuItem](/docs/core-topbar-naviconmenuitem--docs)
  */
-export function TopBar({ appSwitcher, avatar, logo, mainNav, menu, search, secondaryNav, ...rest }: TopBarProps) {
+export function TopBar({ appSwitcher, avatar, logo, mainNav, menu, search, secondaryNav, ...rest }: TopBar.Props) {
   return (
     <ElTopBar {...rest}>
       <ElTopBarContentContainer>


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

Past PRs include:
- #766 
- #767 
- #768 
- #769 
- #770 
- #771 

### This PR

Applies this namespace pattern for component props to another group of components:
- `SideBar`
- `Table`
- `TopBar`