### PR TITLE
chore: apply namespace pattern for component props (part 8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ yarn generate:tokens # Generate CSS variables
 - Include unit tests and Storybook stories
 - Use design tokens for consistent styling
 - Ensure accessibility compliance
+- **All components MUST follow the namespace interface pattern (see guidelines/interface-pattern.md)**

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ This project was imported from the Reapit Foundations Monorepo at version 4.0.2.
 - If you are interested in our future roadmap, you can view [here](https://github.com/orgs/reapit/projects/16/views/2).
 
 Please read our [disclaimer](./DISCLAIMER.md) before proceeding.
+
+## For Contributors & AI Agents
+
+- **[AGENTS.md](./AGENTS.md)** - Essential guide for AI agents working on this project
+- **[guidelines/interface-pattern.md](./guidelines/interface-pattern.md)** - TypeScript interface pattern requirements and code review checklist

--- a/guidelines/interface-pattern.md
+++ b/guidelines/interface-pattern.md
@@ -1,0 +1,117 @@
+# Interface Pattern Code Review Checklist
+
+Quick reference for AI agents when reviewing or writing component code.
+
+## ✅ Required Pattern
+
+```typescript
+export function ComponentName({ prop }: ComponentName.Props) {
+  // implementation
+}
+
+export namespace ComponentName {
+  export interface Props {
+    /** JSDoc for each prop */
+    prop: string
+  }
+}
+```
+
+## 🔍 Code Review Checklist
+
+### For New Components
+
+- [ ] Uses `ComponentName.Props` pattern (not `ComponentNameProps`)
+- [ ] Namespace exported and matches component name exactly
+- [ ] Props interface inside namespace
+- [ ] All props have JSDoc documentation
+- [ ] No standalone interface definitions
+
+### For Component Migrations
+
+- [ ] Original `ComponentNameProps` converted to namespace
+- [ ] Deprecated type alias added: `export type ComponentNameProps = ComponentName.Props`
+- [ ] Component function signature updated to use `ComponentName.Props`
+- [ ] Tests still pass after migration
+
+### For Compound Components
+
+- [ ] Subcomponents use nested namespaces: `Parent.Child.Props`
+- [ ] Static properties properly typed
+- [ ] Each subcomponent follows same pattern
+
+### For Utility Functions
+
+- [ ] Input/output types use function name as namespace
+- [ ] Example: `utilityFunction.Input` and `utilityFunction.Output`
+
+## 🚫 Common Mistakes to Flag
+
+```typescript
+// ❌ Standalone interface
+interface ButtonProps { }
+
+// ❌ Wrong namespace name
+export namespace ButtonComponent {
+  export interface Props { }
+}
+
+// ❌ Missing JSDoc
+export namespace Button {
+  export interface Props {
+    variant: string // No documentation
+  }
+}
+
+// ❌ Props outside namespace
+export interface Props { }
+export namespace Button { }
+```
+
+## 🎯 Quick Fix Examples
+
+**Before (wrong):**
+```typescript
+interface DialogProps {
+  open: boolean
+}
+
+export function Dialog({ open }: DialogProps) {
+  return <div>{open ? 'Open' : 'Closed'}</div>
+}
+```
+
+**After (correct):**
+```typescript
+export namespace Dialog {
+  export interface Props {
+    /** Whether the dialog is open */
+    open: boolean
+  }
+}
+
+/**
+ * @deprecated Use `Dialog.Props` instead.
+ */
+export type DialogProps = Dialog.Props
+
+export function Dialog({ open }: Dialog.Props) {
+  return <div>{open ? 'Open' : 'Closed'}</div>
+}
+```
+
+## 📋 Review Guidelines
+
+When reviewing code, check these locations:
+
+- `src/core/*/` - All core components
+- `src/utils/*/` - All utility components  
+- `src/lab/*/` - Lab components (should follow pattern)
+
+Skip these locations:
+
+- `src/deprecated/*/` - Legacy components (don't modify)
+- `src/icons/*/` - Generated components
+- `src/tokens/*/` - Generated tokens
+
+All new components must follow the namespace interface pattern before merging.

--- a/src/core/checkbox-group/checkbox-group.tsx
+++ b/src/core/checkbox-group/checkbox-group.tsx
@@ -2,12 +2,14 @@ import { FC, ReactNode, HTMLAttributes } from 'react'
 import { CheckboxGroupLabel } from './checkbox-group.atoms'
 import { ElCheckboxGroup } from './styles'
 
-export interface CheckboxGroupProps extends HTMLAttributes<HTMLDivElement> {
-  orientation?: 'vertical' | 'horizontal'
-  children?: ReactNode
+export namespace CheckboxGroup {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    orientation?: 'vertical' | 'horizontal'
+    children?: ReactNode
+  }
 }
 
-export interface CheckboxGroupFC extends FC<CheckboxGroupProps> {
+export interface CheckboxGroupFC extends FC<CheckboxGroup.Props> {
   Label: typeof CheckboxGroupLabel
 }
 

--- a/src/core/checkbox/checkbox.tsx
+++ b/src/core/checkbox/checkbox.tsx
@@ -3,24 +3,26 @@ import { ElCheckboxIcon, ElCheckboxSelectedIcon, ElCheckboxIndeterminateIcon } f
 import { ElCheckbox, ElCheckboxInput, ElCheckboxLabelText, ElCheckboxSupplementaryInfo } from './styles'
 import mergeRefs from '#src/helpers/mergeRefs'
 
-/**
- * Interface for the Checkbox component props.
- *
- * Optional label text to display next to the checkbox.
- * Provides a user-friendly description of the checkbox's purpose.
- *
- * Optional supplementary information to display below the label.
- * Offers additional context or details related to the checkbox.
- *
- * Optional required to make input element required.
- *
- * Optional isIndeterminate to make input element as an indeterminate state.
- */
-export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
-  label?: string
-  supplementaryInfo?: string
-  required?: boolean
-  isIndeterminate?: boolean
+export namespace Checkbox {
+  /**
+   * Interface for the Checkbox component props.
+   *
+   * Optional label text to display next to the checkbox.
+   * Provides a user-friendly description of the checkbox's purpose.
+   *
+   * Optional supplementary information to display below the label.
+   * Offers additional context or details related to the checkbox.
+   *
+   * Optional required to make input element required.
+   *
+   * Optional isIndeterminate to make input element as an indeterminate state.
+   */
+  export interface Props extends InputHTMLAttributes<HTMLInputElement> {
+    label?: string
+    supplementaryInfo?: string
+    required?: boolean
+    isIndeterminate?: boolean
+  }
 }
 
 /**
@@ -28,7 +30,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
  * This component combines the atomic checkbox components (ElCheckbox, ElCheckboxInput, etc.)
  * into a single, reusable checkbox component.
  */
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+export const Checkbox = forwardRef<HTMLInputElement, Checkbox.Props>(
   ({ label, supplementaryInfo, required, isIndeterminate = false, className, ...rest }, ref) => {
     const inputRef = useRef<HTMLInputElement>(null)
     useEffect(() => {

--- a/src/core/empty-data/action/action-button.tsx
+++ b/src/core/empty-data/action/action-button.tsx
@@ -3,13 +3,20 @@ import { Button } from '#src/core/button'
 import type { AttributesToOmit } from './common'
 import type { ComponentProps, MouseEventHandler, ReactNode } from 'react'
 
-interface EmptyDataActionButtonProps extends Omit<ComponentProps<typeof Button>, AttributesToOmit> {
-  /** The action's label. */
-  children: ReactNode
-  /** The action to perform. */
-  onClick?: MouseEventHandler<HTMLButtonElement>
+export namespace EmptyDataActionButton {
+  export interface Props extends Omit<ComponentProps<typeof Button>, AttributesToOmit> {
+    /** The action's label. */
+    children: ReactNode
+    /** The action to perform. */
+    onClick?: MouseEventHandler<HTMLButtonElement>
+  }
 }
 
-export function EmptyDataActionButton(props: EmptyDataActionButtonProps) {
+/**
+ * @deprecated Use `EmptyDataActionButton.Props` instead.
+ */
+export type EmptyDataActionButtonProps = EmptyDataActionButton.Props
+
+export function EmptyDataActionButton(props: EmptyDataActionButton.Props) {
   return <Button {...props} size="medium" variant="tertiary" useLinkStyle />
 }

--- a/src/core/empty-data/action/action.tsx
+++ b/src/core/empty-data/action/action.tsx
@@ -3,12 +3,19 @@ import { AnchorButton } from '#src/core/button'
 import type { AttributesToOmit } from './common'
 import type { ComponentProps, ReactNode } from 'react'
 
-interface EmptyDataActionProps extends Omit<ComponentProps<typeof AnchorButton>, AttributesToOmit> {
-  /** The action's label. */
-  children: ReactNode
-  /** The URL to navigate to; will typically be an entity creation page or drawer. */
-  href: string
+export namespace EmptyDataAction {
+  export interface Props extends Omit<ComponentProps<typeof AnchorButton>, AttributesToOmit> {
+    /** The action's label. */
+    children: ReactNode
+    /** The URL to navigate to; will typically be an entity creation page or drawer. */
+    href: string
+  }
 }
+
+/**
+ * @deprecated Use `EmptyDataAction.Props` instead.
+ */
+export type EmptyDataActionProps = EmptyDataAction.Props
 
 /**
  * A simple action component. Comes in two varieties: `EmptyData.Action`, which renders as an
@@ -17,6 +24,6 @@ interface EmptyDataActionProps extends Omit<ComponentProps<typeof AnchorButton>,
  * Use `EmptyData.Action` when you need button-like styling but want to navigate to a URL. Use
  * `EmptyData.ActionButton` when the action needs to occur on click.
  */
-export function EmptyDataAction(props: EmptyDataActionProps) {
+export function EmptyDataAction(props: EmptyDataAction.Props) {
   return <AnchorButton {...props} size="medium" variant="tertiary" useLinkStyle />
 }

--- a/src/core/empty-data/description/description.tsx
+++ b/src/core/empty-data/description/description.tsx
@@ -2,17 +2,24 @@ import { ElEmptyDataDescription, ElEmptyDataDescriptionSecondaryText, ElEmptyDat
 
 import type { HTMLAttributes, ReactNode } from 'react'
 
-interface EmptyDataDescriptionProps extends HTMLAttributes<HTMLDivElement> {
-  /** The empty data's title text. */
-  children: ReactNode
-  /** The empty data's secondary text. */
-  secondaryText?: ReactNode
+export namespace EmptyDataDescription {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The empty data's title text. */
+    children: ReactNode
+    /** The empty data's secondary text. */
+    secondaryText?: ReactNode
+  }
 }
+
+/**
+ * @deprecated Use `EmptyDataDescription.Props` instead.
+ */
+export type EmptyDataDescriptionProps = EmptyDataDescription.Props
 
 /**
  * A simple component that displays a title and optional secondary text for the `EmptyData`.
  */
-export function EmptyDataDescription({ children, secondaryText, ...rest }: EmptyDataDescriptionProps) {
+export function EmptyDataDescription({ children, secondaryText, ...rest }: EmptyDataDescription.Props) {
   return (
     <ElEmptyDataDescription {...rest}>
       <ElEmptyDataDescriptionTitle>{children}</ElEmptyDataDescriptionTitle>

--- a/src/core/mobile-nav-item/mobile-nav-item.tsx
+++ b/src/core/mobile-nav-item/mobile-nav-item.tsx
@@ -3,13 +3,15 @@ import type { FC } from 'react'
 import { MobileNavItemExpandable, MobileNavItemSimple } from './mobile-nav-item.atoms'
 import type { MobileNavItemExpandableProps, MobileNavItemSimpleProps } from './mobile-nav-item.atoms'
 
-const isExpandableVariant = (props: MobileNavItemProps): props is MobileNavItemExpandableProps => {
+export namespace MobileNavItem {
+  export type Props = MobileNavItemSimpleProps | MobileNavItemExpandableProps
+}
+
+const isExpandableVariant = (props: MobileNavItem.Props): props is MobileNavItemExpandableProps => {
   return 'children' in props
 }
 
-export type MobileNavItemProps = MobileNavItemSimpleProps | MobileNavItemExpandableProps
-
-export const MobileNavItem: FC<MobileNavItemProps> = (props) => {
+export const MobileNavItem: FC<MobileNavItem.Props> = (props) => {
   if (isExpandableVariant(props)) {
     return <MobileNavItemExpandable {...props} />
   } else {

--- a/src/deprecated/drawer/drawer.tsx
+++ b/src/deprecated/drawer/drawer.tsx
@@ -13,7 +13,7 @@ import { elIsActive } from '../../styles/deprecated-states'
 import { DeprecatedIcon } from '../icon'
 
 /** @deprecated */
-export interface DrawerProps extends HTMLAttributes<HTMLDivElement> {
+export interface DeprecatedDrawerProps extends HTMLAttributes<HTMLDivElement> {
   isOpen: boolean
   onDrawerClose: () => void
   title?: string
@@ -24,52 +24,80 @@ export interface DrawerProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /** @deprecated */
-export interface DrawerBaseProps extends HTMLAttributes<HTMLElement> {}
+export interface DeprecatedDrawerBaseProps extends HTMLAttributes<HTMLElement> {}
 
 /** @deprecated */
-export const DeprecatedDrawerBg: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerBg: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawerBg className={cx(className)} {...rest}>
     {children}
   </ElDrawerBg>
 )
 
 /** @deprecated */
-export const DeprecatedDrawerContainer: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerContainer: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawer className={cx(className)} {...rest}>
     {children}
   </ElDrawer>
 )
 
 /** @deprecated */
-export const DeprecatedDrawerHeader: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerHeader: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawerHeader className={cx(className)} {...rest}>
     {children}
   </ElDrawerHeader>
 )
 
 /** @deprecated */
-export const DeprecatedDrawerTitle: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerTitle: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawerTitle className={cx(className)} {...rest}>
     {children}
   </ElDrawerTitle>
 )
 
 /** @deprecated */
-export const DeprecatedDrawerSubtitle: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerSubtitle: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawerSubtitle className={cx(className)} {...rest}>
     {children}
   </ElDrawerSubtitle>
 )
 
 /** @deprecated */
-export const DeprecatedDrawerBody: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerBody: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawerBody className={cx(className)} {...rest}>
     {children}
   </ElDrawerBody>
 )
 
 /** @deprecated */
-export const DeprecatedDrawerFooter: FC<DrawerBaseProps> = ({ className, children, ...rest }: DrawerBaseProps) => (
+export const DeprecatedDrawerFooter: FC<DeprecatedDrawerBaseProps> = ({
+  className,
+  children,
+  ...rest
+}: DeprecatedDrawerBaseProps) => (
   <ElDrawerFooter className={cx(className)} {...rest}>
     {children}
   </ElDrawerFooter>
@@ -83,7 +111,7 @@ export const handleDrawerFocus = (drawerRef: React.RefObject<HTMLDivElement>, is
 }
 
 /** @deprecated */
-export const DeprecatedDrawer: FC<DrawerProps> = ({
+export const DeprecatedDrawer: FC<DeprecatedDrawerProps> = ({
   isOpen,
   onDrawerClose,
   title,

--- a/src/polyfills/css-anchor-positioning/polyfill.ts
+++ b/src/polyfills/css-anchor-positioning/polyfill.ts
@@ -1,31 +1,33 @@
 import { isCSSAnchorPositioningSupported } from './is-css-anchor-positioning-supported'
 
-// This matches the `AnchorPositioningPolyfillOptions` type accepted by `@oddbird/css-anchor-positioning/fn`
-// JS Doc content copied from https://github.com/oddbird/css-anchor-positioning?tab=readme-ov-file#configuration
-interface ApplyCSSAnchorPositioningPolyfillOptions {
-  /**
-   * If set, the polyfill will only be applied to the specified elements instead of to all styles.
-   * This works by polyfilling each elements inline styles, if any. Any specified `<link>` and `<style>`
-   * elements will also be polyfilled.
-   */
-  elements?: HTMLElement[]
-  /**
-   * When not defined or set to false, the polyfill will be applied to all elements that have eligible
-   * inline styles, regardless of whether the elements option is defined. When set to true (the default),
-   * elements with eligible inline styles listed in the elements option will still be polyfilled, but no
-   * other elements in the document will be implicitly polyfilled.
-   *
-   * @default true
-   */
-  excludeInlineStyles?: boolean
-  /**
-   * Determines whether anchor calculations should update on every animation frame (e.g. when the anchor
-   * element is animated using transforms), in addition to always updating on scroll/resize. While this
-   * option is optimized for performance, it should be used sparingly.
-   *
-   * @default false
-   */
-  useAnimationFrame?: boolean
+export namespace applyCSSAnchorPositioningPolyfill {
+  // This matches the `AnchorPositioningPolyfillOptions` type accepted by `@oddbird/css-anchor-positioning/fn`
+  // JS Doc content copied from https://github.com/oddbird/css-anchor-positioning?tab=readme-ov-file#configuration
+  export interface Options {
+    /**
+     * If set, the polyfill will only be applied to the specified elements instead of to all styles.
+     * This works by polyfilling each elements inline styles, if any. Any specified `<link>` and `<style>`
+     * elements will also be polyfilled.
+     */
+    elements?: HTMLElement[]
+    /**
+     * When not defined or set to false, the polyfill will be applied to all elements that have eligible
+     * inline styles, regardless of whether the elements option is defined. When set to true (the default),
+     * elements with eligible inline styles listed in the elements option will still be polyfilled, but no
+     * other elements in the document will be implicitly polyfilled.
+     *
+     * @default true
+     */
+    excludeInlineStyles?: boolean
+    /**
+     * Determines whether anchor calculations should update on every animation frame (e.g. when the anchor
+     * element is animated using transforms), in addition to always updating on scroll/resize. While this
+     * option is optimized for performance, it should be used sparingly.
+     *
+     * @default false
+     */
+    useAnimationFrame?: boolean
+  }
 }
 
 /**
@@ -39,7 +41,7 @@ export async function applyCSSAnchorPositioningPolyfill({
   // By default, we don't want to recalculate on every animation frame because we don't typically
   // animate anchors.
   useAnimationFrame = false,
-}: ApplyCSSAnchorPositioningPolyfillOptions = {}): Promise<void> {
+}: applyCSSAnchorPositioningPolyfill.Options = {}): Promise<void> {
   if (!isCSSAnchorPositioningSupported()) {
     // Dynamic import is cached by browser's module system - no repeated network requests
     const { default: polyfillFn } = await import('@oddbird/css-anchor-positioning/fn')

--- a/src/utils/css-container-query/css-container-query.tsx
+++ b/src/utils/css-container-query/css-container-query.tsx
@@ -1,13 +1,22 @@
-import { ReactNode, useRef, type FC } from 'react'
+import { useRef } from 'react'
+
+import type { FC, ReactNode } from 'react'
 
 let baseId = 1
 
-interface CSSContainerQueryProps {
-  children: ReactNode
-  condition: string
+export namespace CSSContainerQuery {
+  export interface Props {
+    children: ReactNode
+    condition: string
+  }
 }
 
-export const CSSContainerQuery: FC<CSSContainerQueryProps> = ({ children, condition }) => {
+/**
+ * @deprecated Use `CSSContainerQuery.Props` instead.
+ */
+export type CSSContainerQueryProps = CSSContainerQuery.Props
+
+export const CSSContainerQuery: FC<CSSContainerQuery.Props> = ({ children, condition }) => {
   /**
    * We need to create a unique class name to allow these styles to apply to the div being rendered here.
    * This is only necessary because Firefox does not yet support the @scope CSS at-rule

--- a/src/utils/keyboard-navigation/handle-arrow-navigation.ts
+++ b/src/utils/keyboard-navigation/handle-arrow-navigation.ts
@@ -1,12 +1,14 @@
 import type { KeyboardEvent } from 'react'
 
-interface HandleArrowNavigationOptions {
-  /**
-   * A string containing one or more selectors to match. This string must be a valid CSS
-   * selector string; if it isn't, a SyntaxError exception is thrown. Defaults to selecting
-   * all `<a>` and `<button>` elements.
-   */
-  selectors?: string
+export namespace handleArrowNavigation {
+  export interface Options {
+    /**
+     * A string containing one or more selectors to match. This string must be a valid CSS
+     * selector string; if it isn't, a SyntaxError exception is thrown. Defaults to selecting
+     * all `<a>` and `<button>` elements.
+     */
+    selectors?: string
+  }
 }
 
 /**
@@ -19,7 +21,7 @@ interface HandleArrowNavigationOptions {
 export function handleArrowNavigation(
   event: KeyboardEvent<HTMLElement>,
   // By default, we'll navigate all descendant anchors and buttons.
-  { selectors = 'a, button' }: HandleArrowNavigationOptions = {},
+  { selectors = 'a, button' }: handleArrowNavigation.Options = {},
 ) {
   const key = event.key
 

--- a/src/utils/match-media/match-media.tsx
+++ b/src/utils/match-media/match-media.tsx
@@ -2,12 +2,19 @@ import { useMatchMedia } from './use-match-media'
 
 import type { ReactNode } from 'react'
 
-interface MatchMediaProps {
-  /** The media query condition to match against (e.g., "(min-width: 768px)", "(prefers-color-scheme: dark)") */
-  condition: string
-  /** The content to render when the media query matches */
-  children: ReactNode
+export namespace MatchMedia {
+  export interface Props {
+    /** The media query condition to match against (e.g., "(min-width: 768px)", "(prefers-color-scheme: dark)") */
+    condition: string
+    /** The content to render when the media query matches */
+    children: ReactNode
+  }
 }
+
+/**
+ * @deprecated Use `MatchMedia.Props` instead.
+ */
+export type MatchMediaProps = MatchMedia.Props
 
 /**
  * A component that conditionally renders its children based on a media query condition. Uses the
@@ -16,7 +23,7 @@ interface MatchMediaProps {
  *
  * `useMatchMedia` is also available if you want a hook API rather than a component.
  */
-export function MatchMedia({ condition, children }: MatchMediaProps) {
+export function MatchMedia({ condition, children }: MatchMedia.Props) {
   const matches = useMatchMedia(condition)
   return matches ? children : null
 }

--- a/src/utils/popover/get-popover-trigger-props.ts
+++ b/src/utils/popover/get-popover-trigger-props.ts
@@ -1,15 +1,3 @@
-export interface GetPopoverTriggerPropsInput {
-  id: string
-  popoverTarget: string
-  popoverTargetAction: 'hide' | 'show' | 'toggle'
-}
-
-export interface GetPopoverTriggerPropsOutput {
-  id: string
-  popovertarget: string
-  popovertargetaction: 'hide' | 'show' | 'toggle'
-}
-
 /**
  * React 18 does not support the HTML attributes involved in the
  * [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API). This helper
@@ -28,10 +16,34 @@ export function getPopoverTriggerProps({
   id,
   popoverTarget,
   popoverTargetAction,
-}: GetPopoverTriggerPropsInput): GetPopoverTriggerPropsOutput {
+}: getPopoverTriggerProps.Input): getPopoverTriggerProps.Output {
   return {
     id,
     popovertarget: popoverTarget,
     popovertargetaction: popoverTargetAction,
   }
 }
+
+export namespace getPopoverTriggerProps {
+  export interface Input {
+    id: string
+    popoverTarget: string
+    popoverTargetAction: 'hide' | 'show' | 'toggle'
+  }
+
+  export interface Output {
+    id: string
+    popovertarget: string
+    popovertargetaction: 'hide' | 'show' | 'toggle'
+  }
+}
+
+/**
+ * @deprecated Use `getPopoverTriggerProps.Input` instead.
+ */
+export type GetPopoverTriggerPropsInput = getPopoverTriggerProps.Input
+
+/**
+ * @deprecated Use `getPopoverTriggerProps.Output` instead.
+ */
+export type GetPopoverTriggerPropsOutput = getPopoverTriggerProps.Output

--- a/src/utils/popover/popover.tsx
+++ b/src/utils/popover/popover.tsx
@@ -9,64 +9,71 @@ import { useLayoutEffect, useRef } from 'react'
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
 import type { PopoverPlacement } from './map-placement-to-css'
 
-export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
-  /** The ID of the element this popover to which this popover should be anchored. */
-  anchorId: string
-  /**
-   * The border radius of the popover. Can be any valid CSS length, though a border radius
-   * CSS variable is recommended. By default, the radius will be zero.
-   */
-  borderRadius?: string
-  /** The content of the popover. */
-  children: ReactNode
-  /** The visual elevation of the popover. Determines how much shadow the popover casts. */
-  elevation?: 'none' | 'xl'
-  /**
-   * The gap between the popover and the anchor. Can be any valid CSS length, though `--spacing-*`
-   * CSS variables are recommended. By default, the gap will be zero.
-   */
-  gap?: string
-  /**
-   * The ID of this popover. This is mandatory because the popover's trigger will need to reference
-   * this in it's `popovertarget` attribute.
-   */
-  id: string
-  /**
-   * The maximum height of the popover. Can be any valid CSS length, though `--size-*`
-   * CSS variables are recommended. By default, the popover will be as tall as its content requires.
-   */
-  maxHeight?: string
-  /**
-   * The maximum width of the popover. Can be any valid CSS length, though `--size-*`
-   * CSS variables are recommended. By default, the popover will be as wide as its content requires.
-   */
-  maxWidth?: string
-  /**
-   * The "kind" of popover this should be. See
-   * [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover)
-   * for more details.
-   *
-   * For browsers that do not support `hint`, they will fallback to `manual`.
-   *
-   * A special value of `null` allows the popover to not be a popover. This can be useful when you need
-   * to display a popover element permanently in the UI (such as in documentation or example code). Just
-   * note that the absence of the `popover` attribute means the element will not be displayed within the
-   * top-layer, so may be susceptible to z-index issues.
-   */
-  popover?: 'auto' | 'hint' | 'manual' | null
-  /** Where the popover should be placed relative to its anchor. */
-  placement: PopoverPlacement
-  /**
-   * Fallback positions for the popover that should be tried when it would otherwise overflow the viewport.
-   * See [position-try-fallbacks](https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks)
-   * for more details. Note that the [polyfill](https://anchor-positioning.oddbird.net/) we rely on for
-   * anchor positioning in some browsers will not play nicely with all available options.
-   *
-   * Typically, "flip-block", "flip-inline" or both will be sufficient for most use cases.
-   * Defaults to "none".
-   */
-  positionTryFallbacks?: string
+export namespace Popover {
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /** The ID of the element this popover to which this popover should be anchored. */
+    anchorId: string
+    /**
+     * The border radius of the popover. Can be any valid CSS length, though a border radius
+     * CSS variable is recommended. By default, the radius will be zero.
+     */
+    borderRadius?: string
+    /** The content of the popover. */
+    children: ReactNode
+    /** The visual elevation of the popover. Determines how much shadow the popover casts. */
+    elevation?: 'none' | 'xl'
+    /**
+     * The gap between the popover and the anchor. Can be any valid CSS length, though `--spacing-*`
+     * CSS variables are recommended. By default, the gap will be zero.
+     */
+    gap?: string
+    /**
+     * The ID of this popover. This is mandatory because the popover's trigger will need to reference
+     * this in it's `popovertarget` attribute.
+     */
+    id: string
+    /**
+     * The maximum height of the popover. Can be any valid CSS length, though `--size-*`
+     * CSS variables are recommended. By default, the popover will be as tall as its content requires.
+     */
+    maxHeight?: string
+    /**
+     * The maximum width of the popover. Can be any valid CSS length, though `--size-*`
+     * CSS variables are recommended. By default, the popover will be as wide as its content requires.
+     */
+    maxWidth?: string
+    /**
+     * The "kind" of popover this should be. See
+     * [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover)
+     * for more details.
+     *
+     * For browsers that do not support `hint`, they will fallback to `manual`.
+     *
+     * A special value of `null` allows the popover to not be a popover. This can be useful when you need
+     * to display a popover element permanently in the UI (such as in documentation or example code). Just
+     * note that the absence of the `popover` attribute means the element will not be displayed within the
+     * top-layer, so may be susceptible to z-index issues.
+     */
+    popover?: 'auto' | 'hint' | 'manual' | null
+    /** Where the popover should be placed relative to its anchor. */
+    placement: PopoverPlacement
+    /**
+     * Fallback positions for the popover that should be tried when it would otherwise overflow the viewport.
+     * See [position-try-fallbacks](https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks)
+     * for more details. Note that the [polyfill](https://anchor-positioning.oddbird.net/) we rely on for
+     * anchor positioning in some browsers will not play nicely with all available options.
+     *
+     * Typically, "flip-block", "flip-inline" or both will be sufficient for most use cases.
+     * Defaults to "none".
+     */
+    positionTryFallbacks?: string
+  }
 }
+
+/**
+ * @deprecated Use `Popover.Props` instead.
+ */
+export type PopoverProps = Popover.Props
 
 /**
  * A simple popover that can be positioned relative to an anchor. It is designed to work with the
@@ -100,7 +107,7 @@ export function Popover({
   popover = 'auto',
   style,
   ...rest
-}: PopoverProps) {
+}: Popover.Props) {
   const styleRef = useRef<HTMLStyleElement>(null)
 
   // NOTE: The polyfill we're using supports inline styles on elements, however, because React


### PR DESCRIPTION
### Context

- Some components currently export their prop interfaces, while others do not. This leads to an inconsistent experience for consumers.
- Further, when exporting component props via a separate export to the component itself, this forces consumers to have two separate imports, one for the component and another for the component's props. This does provide any improvement over the use of React's `ComponentProps`.
- To provide a consistent approach, and to help consumers avoid needing to separately import component props, the following pattern will be applied to all core components:
```tsx
export namespace MyComponent {
  export Props extends ... {
    ...
  }
}

export function MyComponent(props: MyComponent.Props) {
  ...
}
```

This way, when consumers import `MyComponent`, they will automatically have access to its prop interface via `MyComponent.Props`.

Past PRs include:
- #766 
- #767 
- #768 
- #769 
- #770 
- #771 
- #772 

### This PR

Applies this namespace pattern for component props to the last group of components:
- `EmptyData` subcomponents (these were missed originally)
- `CSSContainerQuery`
- `MatchMedia`
- `Popover`

Also documents the interface pattern in a new `guidelines/interface-pattern.md` file.