### PR TITLE
feat: add code connect for `Dialog`, `Drawer`, and `Menu`

### DIFF
--- a/figma.config.json
+++ b/figma.config.json
@@ -1,7 +1,7 @@
 {
   "codeConnect": {
     "include": [
-      "src/core/{accordion,avatar,badge,bottom-bar,breadcrumbs,button,button-group,chip,chip-group,chip-select,compact-select-native,divider,empty-data,features,filter-bar,folder-tabs,link,primary-tabs,secondary-tabs,select-native,split-button,status-indicator,supplementary-info,tag,tag-group,tooltip}/**/*.{tsx,jsx}"
+      "src/core/{accordion,avatar,badge,bottom-bar,breadcrumbs,button,button-group,chip,chip-group,chip-select,compact-select-native,dialog,divider,drawer,empty-data,features,filter-bar,folder-tabs,link,menu,primary-tabs,secondary-tabs,select-native,split-button,status-indicator,supplementary-info,tag,tag-group,tooltip}/**/*.{tsx,jsx}"
     ],
     "importPaths": {
       "src/core/*": "@reapit/elements/core/*",
@@ -27,7 +27,9 @@
       "<CHIP_SELECT_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=12386-28584",
       "<CHIP_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=7051-11054",
       "<COMPACT_SELECT_NATIVE_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=14083-70317",
+      "<DIALOG_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=7206-13663",
       "<DIVIDER_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=11095-10396",
+      "<DRAWER_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=13321-19292",
       "<EMPTY_DATA_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=86-1823",
       "<FEATURE_ITEM_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=12955-37788",
       "<FEATURES_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=2355-9645",
@@ -43,6 +45,9 @@
       "<FOLDER_TABS_XS_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=15272-53111",
       "<FOLDER_TABS_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=15254-63400",
       "<LINK_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=11867-66681",
+      "<MENU_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=9952-3115",
+      "<MENU_GROUP_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=9952-3180",
+      "<MENU_ITEM_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=9952-3123",
       "<SELECT_NATIVE_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=12404-18248",
       "<SPLIT_BUTTON_ACTION_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=2355-9778",
       "<SPLIT_BUTTON_MENU_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=2355-10149",

--- a/src/core/dialog/body/body.tsx
+++ b/src/core/dialog/body/body.tsx
@@ -18,3 +18,5 @@ export namespace DialogBody {
 export function DialogBody({ children, ...rest }: DialogBody.Props) {
   return <ElDialogBody {...rest}>{children}</ElDialogBody>
 }
+
+DialogBody.displayName = 'Dialog.Body'

--- a/src/core/dialog/dialog.figma.tsx
+++ b/src/core/dialog/dialog.figma.tsx
@@ -1,0 +1,80 @@
+import { Dialog } from './dialog'
+import figma from '@figma/code-connect'
+
+figma.connect(Dialog, '<DIALOG_URL>', {
+  variant: { Footer: true, 'Show title': true },
+  props: {
+    footer: figma.children('Button group'),
+    size: figma.enum('Size', {
+      Small: 'small',
+      Medium: 'medium',
+      Large: 'large',
+      'Full screen': 'full-screen',
+    }),
+    title: figma.textContent('Title'),
+  },
+  example: (props) => (
+    <Dialog size={props.size}>
+      <Dialog.Header>{props.title}</Dialog.Header>
+      <Dialog.Body>TODO: Add dialog content</Dialog.Body>
+      <Dialog.Footer>{props.footer}</Dialog.Footer>
+    </Dialog>
+  ),
+})
+
+figma.connect(Dialog, '<DIALOG_URL>', {
+  variant: { Footer: true, 'Show title': false },
+  props: {
+    footer: figma.children('Button group'),
+    size: figma.enum('Size', {
+      Small: 'small',
+      Medium: 'medium',
+      Large: 'large',
+      'Full screen': 'full-screen',
+    }),
+  },
+  example: (props) => (
+    <Dialog size={props.size}>
+      <Dialog.Header aria-label="Replace me with an accessible title" />
+      <Dialog.Body>TODO: Add dialog content</Dialog.Body>
+      <Dialog.Footer>{props.footer}</Dialog.Footer>
+    </Dialog>
+  ),
+})
+
+figma.connect(Dialog, '<DIALOG_URL>', {
+  variant: { Footer: false, 'Show title': true },
+  props: {
+    size: figma.enum('Size', {
+      Small: 'small',
+      Medium: 'medium',
+      Large: 'large',
+      'Full screen': 'full-screen',
+    }),
+    title: figma.textContent('Title'),
+  },
+  example: (props) => (
+    <Dialog size={props.size}>
+      <Dialog.Header action={<Dialog.HeaderCloseButton />}>{props.title}</Dialog.Header>
+      <Dialog.Body>TODO: Add dialog content</Dialog.Body>
+    </Dialog>
+  ),
+})
+
+figma.connect(Dialog, '<DIALOG_URL>', {
+  variant: { Footer: false, 'Show title': false },
+  props: {
+    size: figma.enum('Size', {
+      Small: 'small',
+      Medium: 'medium',
+      Large: 'large',
+      'Full screen': 'full-screen',
+    }),
+  },
+  example: (props) => (
+    <Dialog size={props.size}>
+      <Dialog.Header action={<Dialog.HeaderCloseButton />} aria-label="Replace me with an accessible title" />
+      <Dialog.Body>TODO: Add dialog content</Dialog.Body>
+    </Dialog>
+  ),
+})

--- a/src/core/dialog/footer/footer.tsx
+++ b/src/core/dialog/footer/footer.tsx
@@ -16,3 +16,5 @@ export namespace DialogFooter {
 export function DialogFooter({ children, ...rest }: DialogFooter.Props) {
   return <ElDialogFooter {...rest}>{children}</ElDialogFooter>
 }
+
+DialogFooter.displayName = 'Dialog.Footer'

--- a/src/core/dialog/header/close-button.tsx
+++ b/src/core/dialog/header/close-button.tsx
@@ -21,3 +21,5 @@ export function DialogHeaderCloseButton() {
     </form>
   )
 }
+
+DialogHeaderCloseButton.displayName = 'Dialog.HeaderCloseButton'

--- a/src/core/dialog/header/header.tsx
+++ b/src/core/dialog/header/header.tsx
@@ -33,4 +33,6 @@ export function DialogHeader({ action, children, 'aria-label': ariaLabel, ...res
   )
 }
 
+DialogHeader.displayName = 'Dialog.Header'
+
 DialogHeader.CloseButton = DialogHeaderCloseButton

--- a/src/core/drawer/body/body.tsx
+++ b/src/core/drawer/body/body.tsx
@@ -18,3 +18,5 @@ export namespace DrawerBody {
 export function DrawerBody({ children, ...rest }: DrawerBody.Props) {
   return <ElDrawerBody {...rest}>{children}</ElDrawerBody>
 }
+
+DrawerBody.displayName = 'Drawer.Body'

--- a/src/core/drawer/drawer.figma.tsx
+++ b/src/core/drawer/drawer.figma.tsx
@@ -1,0 +1,44 @@
+import { Drawer } from './drawer'
+import figma from '@figma/code-connect'
+
+figma.connect(Drawer, '<DRAWER_URL>', {
+  variant: { Variant: 'Simple' },
+  props: {
+    overline: figma.string('Overline'),
+    supplementaryInfo: figma.children('Supplementary info'),
+    tabs: figma.children('Tabs'),
+    title: figma.string('Drawer title'),
+  },
+  example: (props) => (
+    <Drawer>
+      <Drawer.Header
+        action={<Drawer.HeaderCloseButton />}
+        overline={props.overline}
+        supplementaryInfo={props.supplementaryInfo}
+        tabs={props.tabs}
+      >
+        {props.title}
+      </Drawer.Header>
+      <Drawer.Body>TODO: Add drawer content</Drawer.Body>
+    </Drawer>
+  ),
+})
+
+figma.connect(Drawer, '<DRAWER_URL>', {
+  variant: { Variant: 'With footer' },
+  props: {
+    footer: figma.children('Button group'),
+    overline: figma.string('Overline'),
+    supplementaryInfo: figma.children('Supplementary info'),
+    title: figma.string('Drawer title'),
+  },
+  example: (props) => (
+    <Drawer>
+      <Drawer.Header overline={props.overline} supplementaryInfo={props.supplementaryInfo}>
+        {props.title}
+      </Drawer.Header>
+      <Drawer.Body>TODO: Add drawer content</Drawer.Body>
+      <Drawer.Footer>{props.footer}</Drawer.Footer>
+    </Drawer>
+  ),
+})

--- a/src/core/drawer/footer/footer.tsx
+++ b/src/core/drawer/footer/footer.tsx
@@ -16,3 +16,5 @@ export namespace DrawerFooter {
 export function DrawerFooter({ children, ...rest }: DrawerFooter.Props) {
   return <ElDrawerFooter {...rest}>{children}</ElDrawerFooter>
 }
+
+DrawerFooter.displayName = 'Drawer.Footer'

--- a/src/core/drawer/header/close-button.tsx
+++ b/src/core/drawer/header/close-button.tsx
@@ -21,3 +21,5 @@ export function DrawerHeaderCloseButton() {
     </form>
   )
 }
+
+DrawerHeaderCloseButton.displayName = 'Drawer.HeaderCloseButton'

--- a/src/core/drawer/header/header.tsx
+++ b/src/core/drawer/header/header.tsx
@@ -48,4 +48,6 @@ export function DrawerHeader({ action, overline, children, supplementaryInfo, ta
   )
 }
 
+DrawerHeader.displayName = 'Drawer.Header'
+
 DrawerHeader.CloseButton = DrawerHeaderCloseButton

--- a/src/core/menu/group/group.figma.tsx
+++ b/src/core/menu/group/group.figma.tsx
@@ -1,0 +1,10 @@
+import figma from '@figma/code-connect'
+import { Menu } from '../menu'
+
+figma.connect(Menu.Group, '<MENU_GROUP_URL>', {
+  props: {
+    children: figma.children('Menu item'),
+    label: figma.string('Group title'),
+  },
+  example: (props) => <Menu.Group label={props.label}>{props.children}</Menu.Group>,
+})

--- a/src/core/menu/group/group.tsx
+++ b/src/core/menu/group/group.tsx
@@ -30,3 +30,5 @@ export function MenuGroup({ 'aria-label': ariaLabel, children, label, role = 'gr
     </ElMenuGroup>
   )
 }
+
+MenuGroup.displayName = 'Menu.Group'

--- a/src/core/menu/item/anchor-item.tsx
+++ b/src/core/menu/item/anchor-item.tsx
@@ -22,5 +22,7 @@ export function AnchorMenuItem(props: AnchorMenuItem.Props) {
   return <MenuItemBase as="a" {...props} />
 }
 
+AnchorMenuItem.displayName = 'Menu.AnchorItem'
+
 /** @deprecated Use AnchorMenuItem.Props instead */
 export type MenuAnchorItemProps = AnchorMenuItem.Props

--- a/src/core/menu/item/item.figma.tsx
+++ b/src/core/menu/item/item.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect'
+import { Menu } from '../menu'
+
+figma.connect(Menu.Item, '<MENU_ITEM_URL>', {
+  props: {
+    badge: figma.children('Badge'),
+    children: figma.string('Item label'),
+    iconLeft: figma.instance('Icon L'),
+    iconRight: figma.instance('Icon R'),
+    supplementaryInfo: figma.string('Supplementary info'),
+  },
+  example: (props) => (
+    <Menu.Item
+      badge={props.badge}
+      iconLeft={props.iconLeft}
+      iconRight={props.iconRight}
+      supplementaryInfo={props.supplementaryInfo}
+    >
+      {props.children}
+    </Menu.Item>
+  ),
+})

--- a/src/core/menu/item/item.tsx
+++ b/src/core/menu/item/item.tsx
@@ -25,5 +25,7 @@ export function MenuItem(props: MenuItem.Props) {
   return <MenuItemBase as="button" {...props} />
 }
 
+MenuItem.displayName = 'Menu.Item'
+
 /** @deprecated Use MenuItem.Props instead */
 export type MenuItemProps = MenuItem.Props

--- a/src/core/menu/menu.figma.tsx
+++ b/src/core/menu/menu.figma.tsx
@@ -1,0 +1,13 @@
+import figma from '@figma/code-connect'
+import { Menu } from './menu'
+
+figma.connect(Menu, '<MENU_URL>', {
+  props: {
+    children: figma.children('*'),
+  },
+  example: (props) => (
+    <Menu aria-labelledby="trigger-id" id="menu-id" placement="top">
+      {props.children}
+    </Menu>
+  ),
+})

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -26,6 +26,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Added Figma Code Connect for `Divider`, `EmptyData`, `SelectNative`, and `SplitButton`.
 - **feat:** Added Figma Code Connect for `FolderTabs`, `PrimaryTabs`, `SecondaryTabs`, and `Tooltip`.
 - **feat:** Added Figma Code Connect for `FilterBar`, `StatusIndicator`, and `SupplementaryInfo`.
+- **feat:** Added Figma Code Connect for `Dialog`, `Drawer`, and `Menu`.
 
 ### **5.0.0-beta.51 - 12/09/25**
 


### PR DESCRIPTION
### Context

- Currently, our engineers have a relatively steep learning curve when implementing UI provided by Design using Elements components for the first time.
- They need to read the minimal documentation provided for the component in Elements' storybook, understand it, then apply it correctly based on the design their implementing.
- Figma's Code Connect is intended to reduce this learning curve by providing code snippets for React within Figma itself that devs can copy-paste into their product. This should bootstrap their usage of Elements and reduce some of the learning curve.
- Further, with Figma's MCP server available, its possible to have an AI agent retrieve this code snippet itself when asked to scaffold out the UI for a selection the engineer has made within the Figma desktop app.
- Previous PRs include:
  - Part 1: #781 
  - Part 2: #782 
  - Part 3: #783 
  - Part 4: #784 
  - Part 5: #785 
  - Part 6: #786 

### This PR

- Connects dialog, drawer and menu.
