### PR TITLE
feat: add code connect for `Table`

### DIFF
--- a/figma.config.json
+++ b/figma.config.json
@@ -1,8 +1,6 @@
 {
   "codeConnect": {
-    "include": [
-      "src/core/{accordion,avatar,badge,bottom-bar,breadcrumbs,button,button-group,chip,chip-group,chip-select,compact-select-native,dialog,divider,drawer,empty-data,features,filter-bar,folder-tabs,label-text,link,menu,page-header,pagination,primary-tabs,secondary-tabs,select-native,side-bar,split-button,status-indicator,supplementary-info,tag,tag-group,tooltip,top-bar}/**/*.{tsx,jsx}"
-    ],
+    "include": ["src/core/**/*.tsx"],
     "importPaths": {
       "src/core/*": "@reapit/elements/core/*",
       "src/icons/*": "@reapit/elements/icons/*",
@@ -56,6 +54,8 @@
       "<PAGE_HEADER_SUPPLEMENTARY_INFO_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=13349-12535",
       "<PAGE_HEADER_TITLE_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=13350-15766",
       "<PAGINATION_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=6364-9402",
+      "<PRIMARY_TAB_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=60-1049",
+      "<PRIMARY_TABS_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=7076-9436",
       "<SIDE_BAR_COLLAPSE_BUTTON_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=12148-35369",
       "<SIDE_BAR_MENU_ITEM_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=12148-35439",
       "<SIDE_BAR_MENU_LIST_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=12148-35460",
@@ -66,8 +66,6 @@
       "<SPLIT_BUTTON_ACTION_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=2355-9778",
       "<SPLIT_BUTTON_MENU_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=2355-10149",
       "<SPLIT_BUTTON_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=2356-10273",
-      "<PRIMARY_TAB_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=60-1049",
-      "<PRIMARY_TABS_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=7076-9436",
       "<SECONDARY_TAB_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=209-5342",
       "<SECONDARY_TABS_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=7076-9436",
       "<STATUS_INDICATOR_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=5722-7495",
@@ -75,6 +73,16 @@
       "<SUPPLEMENTARY_INFO_ITEM_BASE_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=11918-14088",
       "<SUPPLEMENTARY_INFO_ITEM_SM_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=11918-14107",
       "<SUPPLEMENTARY_INFO_ITEM_XS_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=11918-14126",
+      "<TABLE_BODY_CHECKBOX_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-6937",
+      "<TABLE_BODY_ROW_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7210",
+      "<TABLE_DOUBLE_LINE_CELL_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-6971",
+      "<TABLE_HEADER_CELL_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7042",
+      "<TABLE_HEADER_CHECKBOX_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7118",
+      "<TABLE_HEADER_ROW_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7201",
+      "<TABLE_PRIMARY_DATA_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7032",
+      "<TABLE_SINGLE_LINE_CELL_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-6732",
+      "<TABLE_TEXT_SM_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7145",
+      "<TABLE_TOOLBAR_URL>": "https://www.figma.com/design/XJ6qcAV8gHscsUodqJMNEF/Reapit-Elements-production-ready-components?node-id=1091-7237",
       "<TAG_GROUP_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=118-6272",
       "<TAG_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=55-982",
       "<TOOLTIP_URL>": "https://www.figma.com/design/6CaivqdlTX0UkFYJkpBKDu/Reapit-DS?node-id=6462-8381",

--- a/src/core/table/body-cell/body-cell.figma.tsx
+++ b/src/core/table/body-cell/body-cell.figma.tsx
@@ -1,0 +1,95 @@
+import figma from '@figma/code-connect'
+import { Skeleton } from '../../skeleton'
+import { Table } from '../table'
+
+figma.connect(Table.BodyCell, '<TABLE_SINGLE_LINE_CELL_URL>', {
+  props: {
+    children: figma.enum('Data', {
+      Address: figma.textContent('Value'),
+      Alphanumeric: figma.textContent('Value'),
+      Badge: figma.children('Badge'),
+      'Data not available': 'Not available',
+      'Date and time': figma.textContent('Content'),
+      Features: figma.children('Features'),
+      Icon: figma.children('Icon'),
+      'Icon and value': figma.children('*'),
+      'Status indicator': figma.children('Status indicator'),
+      Tags: figma.children('Tag group'),
+      'Value and icon': figma.children('*'),
+    }),
+  },
+  example: (props) => <Table.BodyCell>{props.children}</Table.BodyCell>,
+})
+
+figma.connect(Table.BodyCell, '<TABLE_SINGLE_LINE_CELL_URL>', {
+  variant: { Skeleton: true },
+  example: () => (
+    <Table.BodyCell>
+      <Skeleton width="100px" />
+    </Table.BodyCell>
+  ),
+})
+
+figma.connect(Table.BodyCell, '<TABLE_DOUBLE_LINE_CELL_URL>', {
+  variant: { Data: 'Address' },
+  props: {
+    line1: figma.children('Row 1'),
+    line2: figma.textContent('Row 2'),
+    thumbnail: figma.children('Avatar rectangle'),
+  },
+  example: (props) => (
+    <Table.BodyCell>
+      <Table.DoubleLineLayout mediaItem={props.thumbnail} supplementaryData={props.line2}>
+        {props.line1}
+      </Table.DoubleLineLayout>
+    </Table.BodyCell>
+  ),
+})
+
+figma.connect(Table.BodyCell, '<TABLE_DOUBLE_LINE_CELL_URL>', {
+  variant: { Data: 'Avatar' },
+  props: {
+    avatar: figma.children('Avatar circle'),
+    line1: figma.children('Row 1'),
+    line2: figma.textContent('Row 2'),
+  },
+  example: (props) => (
+    <Table.BodyCell>
+      <Table.DoubleLineLayout mediaItem={props.avatar} supplementaryData={props.line2}>
+        {props.line1}
+      </Table.DoubleLineLayout>
+    </Table.BodyCell>
+  ),
+})
+
+figma.connect(Table.BodyCell, '<TABLE_DOUBLE_LINE_CELL_URL>', {
+  variant: { Data: 'Mixed data' },
+  props: {
+    line1: figma.children('First row data'),
+    line2: figma.children('Second row data'),
+  },
+  example: (props) => (
+    <Table.BodyCell>
+      <Table.DoubleLineLayout supplementaryData={props.line2}>{props.line1}</Table.DoubleLineLayout>
+    </Table.BodyCell>
+  ),
+})
+
+figma.connect(Table.BodyCell, '<TABLE_DOUBLE_LINE_CELL_URL>', {
+  variant: { Skeleton: true },
+  props: {
+    justifySelf: figma.enum('Alignment', { Left: 'start', Center: 'center', Right: 'end' }),
+    mediaItem: figma.enum('Data', {
+      Address: <Skeleton width="48px" height="40px" />,
+      Avatar: <Skeleton borderRadius="100%" width="36px" height="36px" />,
+      'Mixed data': undefined,
+    }),
+  },
+  example: (props) => (
+    <Table.BodyCell justifySelf={props.justifySelf}>
+      <Table.DoubleLineLayout mediaItem={props.mediaItem} supplementaryData={<Skeleton width="124px" />}>
+        <Skeleton width="148px" />
+      </Table.DoubleLineLayout>
+    </Table.BodyCell>
+  ),
+})

--- a/src/core/table/body-cell/body-cell.tsx
+++ b/src/core/table/body-cell/body-cell.tsx
@@ -64,5 +64,7 @@ export function TableBodyCell({
   )
 }
 
+TableBodyCell.displayName = 'Table.BodyCell'
+
 // Backward compatibility
 export type TableBodyCellProps = TableBodyCell.Props

--- a/src/core/table/body-row/body-row.figma.tsx
+++ b/src/core/table/body-row/body-row.figma.tsx
@@ -1,0 +1,33 @@
+import figma from '@figma/code-connect'
+import { Table } from '../table'
+
+figma.connect(Table.BodyRow, '<TABLE_BODY_ROW_URL>', {
+  props: {
+    checkbox: figma.boolean('Selectable', {
+      true: (
+        <Table.BodyCell>
+          <Table.Checkbox aria-label="Select all" />
+        </Table.BodyCell>
+      ),
+      false: undefined,
+    }),
+    moreActions: figma.boolean('More button', {
+      true: (
+        <Table.BodyCell>
+          <Table.MoreActions aria-label="Replace me">TODO: add menu items</Table.MoreActions>
+        </Table.BodyCell>
+      ),
+      false: undefined,
+    }),
+    content: figma.nestedProps('Content', {
+      cells: figma.children('*'),
+    }),
+  },
+  example: (props) => (
+    <Table.BodyRow>
+      {props.checkbox}
+      {props.content.cells}
+      {props.moreActions}
+    </Table.BodyRow>
+  ),
+})

--- a/src/core/table/body-row/body-row.tsx
+++ b/src/core/table/body-row/body-row.tsx
@@ -33,5 +33,7 @@ export function TableBodyRow({ as: Element = 'tr', children, className, ...rest 
   )
 }
 
+TableBodyRow.displayName = 'Table.BodyRow'
+
 // Backward compatibility
 export type TableBodyRowProps = TableBodyRow.Props

--- a/src/core/table/body/body.tsx
+++ b/src/core/table/body/body.tsx
@@ -33,5 +33,7 @@ export function TableBody({ as: Element = 'tbody', children, className, ...rest 
   )
 }
 
+TableBody.displayName = 'Table.Body'
+
 // Backward compatibility
 export type TableBodyProps = TableBody.Props

--- a/src/core/table/checkbox/checkbox.tsx
+++ b/src/core/table/checkbox/checkbox.tsx
@@ -44,7 +44,7 @@ export const TableCellCheckbox = forwardRef<HTMLInputElement, TableCellCheckbox.
   },
 )
 
-TableCellCheckbox.displayName = 'TableCellCheckbox'
+TableCellCheckbox.displayName = 'Table.Checkbox'
 
 // Backward compatibility
 export type TableCellCheckboxProps = TableCellCheckbox.Props

--- a/src/core/table/double-line-layout/double-line-layout.tsx
+++ b/src/core/table/double-line-layout/double-line-layout.tsx
@@ -42,5 +42,7 @@ export function TableCellDoubleLineLayout({
   )
 }
 
+TableCellDoubleLineLayout.displayName = 'Table.DoubleLineLayout'
+
 // Backward compatibility
 export type TableCellDoubleLineLayoutProps = TableCellDoubleLineLayout.Props

--- a/src/core/table/head/head.tsx
+++ b/src/core/table/head/head.tsx
@@ -33,5 +33,7 @@ export function TableHead({ as: Element = 'thead', children, className, ...rest 
   )
 }
 
+TableHead.displayName = 'Table.Head'
+
 // Backward compatibility
 export type TableHeadProps = TableHead.Props

--- a/src/core/table/header-cell/header-cell.figma.tsx
+++ b/src/core/table/header-cell/header-cell.figma.tsx
@@ -1,0 +1,41 @@
+import figma from '@figma/code-connect'
+import { Table } from '../table'
+
+figma.connect(Table.HeaderCell, '<TABLE_HEADER_CELL_URL>', {
+  variant: { Sortable: false },
+  props: {
+    children: figma.string('Value'),
+    justifySelf: figma.enum('Alignment', {
+      Center: 'center',
+      Left: 'start',
+      Right: 'end',
+    }),
+  },
+  example: (props) => <Table.HeaderCell justifySelf={props.justifySelf}>{props.children}</Table.HeaderCell>,
+})
+
+figma.connect(Table.HeaderCell, '<TABLE_HEADER_CELL_URL>', {
+  variant: { Sortable: true },
+  props: {
+    children: figma.string('Value'),
+    direction: figma.enum('State', {
+      Default: 'none',
+      Hover: 'none',
+      Focus: 'none',
+      Sorted: 'descending',
+      'n/a': 'none',
+    }),
+    justifySelf: figma.enum('Alignment', {
+      Center: 'center',
+      Left: 'start',
+      Right: 'end',
+    }),
+  },
+  example: (props) => (
+    <Table.HeaderCell justifySelf={props.justifySelf}>
+      <Table.SortButton name="replace-me" value={props.direction}>
+        {props.children}
+      </Table.SortButton>
+    </Table.HeaderCell>
+  ),
+})

--- a/src/core/table/header-cell/header-cell.tsx
+++ b/src/core/table/header-cell/header-cell.tsx
@@ -63,5 +63,7 @@ export function TableHeaderCell({
   )
 }
 
+TableHeaderCell.displayName = 'Table.HeaderCell'
+
 // Backward compatibility
 export type TableHeaderCellProps = TableHeaderCell.Props

--- a/src/core/table/header-row/header-row.figma.tsx
+++ b/src/core/table/header-row/header-row.figma.tsx
@@ -1,0 +1,29 @@
+import figma from '@figma/code-connect'
+import { Table } from '../table'
+
+figma.connect(Table.HeaderRow, '<TABLE_HEADER_ROW_URL>', {
+  props: {
+    checkbox: figma.boolean('Selectable', {
+      true: (
+        <Table.HeaderCell aria-label="Select rows">
+          <Table.Checkbox aria-label="Select all" />
+        </Table.HeaderCell>
+      ),
+      false: undefined,
+    }),
+    moreActions: figma.boolean('More button', {
+      true: <Table.HeaderCell aria-label="Actions" />,
+      false: undefined,
+    }),
+    content: figma.nestedProps('Content', {
+      cells: figma.children('Header cell'),
+    }),
+  },
+  example: (props) => (
+    <Table.HeaderRow>
+      {props.checkbox}
+      {props.content.cells}
+      {props.moreActions}
+    </Table.HeaderRow>
+  ),
+})

--- a/src/core/table/header-row/header-row.tsx
+++ b/src/core/table/header-row/header-row.tsx
@@ -33,5 +33,7 @@ export function TableHeaderRow({ as: Element = 'tr', children, className, ...res
   )
 }
 
+TableHeaderRow.displayName = 'Table.HeaderRow'
+
 // Backward compatibility
 export type TableHeaderRowProps = TableHeaderRow.Props

--- a/src/core/table/more-actions/more-actions.tsx
+++ b/src/core/table/more-actions/more-actions.tsx
@@ -47,5 +47,7 @@ export function TableRowMoreActions({ children, id, ...rest }: TableRowMoreActio
   )
 }
 
+TableRowMoreActions.displayName = 'Table.MoreActions'
+
 // Backward compatibility
 export type TableRowMoreActionsProps = TableRowMoreActions.Props

--- a/src/core/table/primary-action/primary-action-button.tsx
+++ b/src/core/table/primary-action/primary-action-button.tsx
@@ -24,5 +24,7 @@ export function TableRowPrimaryActionButton({ className, ...rest }: TableRowPrim
   return <button {...rest} className={cx(elTableRowPrimaryAction, className)} />
 }
 
+TableRowPrimaryActionButton.displayName = 'Table.PrimaryActionButton'
+
 // Backward compatibility
 export type TableRowPrimaryActionButtonProps = TableRowPrimaryActionButton.Props

--- a/src/core/table/primary-action/primary-action.figma.tsx
+++ b/src/core/table/primary-action/primary-action.figma.tsx
@@ -1,0 +1,17 @@
+import figma from '@figma/code-connect'
+import { Table } from '../table'
+
+figma.connect(Table.PrimaryAction, '<TABLE_TEXT_SM_URL>', {
+  props: {
+    children: figma.textContent('Value'),
+  },
+  example: (props) => <>{props.children}</>,
+})
+
+figma.connect(Table.PrimaryAction, '<TABLE_TEXT_SM_URL>', {
+  variant: { Style: 'Primary' },
+  props: {
+    children: figma.textContent('Value'),
+  },
+  example: (props) => <Table.PrimaryAction href="#replace-me">{props.children}</Table.PrimaryAction>,
+})

--- a/src/core/table/primary-action/primary-action.tsx
+++ b/src/core/table/primary-action/primary-action.tsx
@@ -22,5 +22,7 @@ export function TableRowPrimaryAction({ className, ...rest }: TableRowPrimaryAct
   return <a {...rest} className={cx(elTableRowPrimaryAction, className)} />
 }
 
+TableRowPrimaryAction.displayName = 'Table.PrimaryAction'
+
 // Backward compatibility
 export type TableRowPrimaryActionProps = TableRowPrimaryAction.Props

--- a/src/core/table/primary-data/primary-data.figma.tsx
+++ b/src/core/table/primary-data/primary-data.figma.tsx
@@ -1,0 +1,42 @@
+import figma from '@figma/code-connect'
+import { Table } from '../table'
+
+figma.connect(Table.PrimaryData, '<TABLE_PRIMARY_DATA_URL>', {
+  variant: { Data: 'Alphanumeric' },
+  props: {
+    iconLeft: figma.children('Icon L'),
+    iconRight: figma.children('Icon R'),
+    data: figma.nestedProps('Alphanumeric value', {
+      children: figma.textContent('Value'),
+    }),
+  },
+  example: (props) => (
+    <Table.PrimaryData iconLeft={props.iconLeft} iconRight={props.iconRight}>
+      {props.data.children}
+    </Table.PrimaryData>
+  ),
+})
+
+figma.connect(Table.PrimaryData, '<TABLE_PRIMARY_DATA_URL>', {
+  variant: { Data: 'Date and Time' },
+  props: {
+    iconLeft: figma.children('Icon L'),
+    iconRight: figma.children('Icon R'),
+    date: figma.nestedProps('Date', {
+      value: figma.textContent('Value'),
+    }),
+    comma: figma.nestedProps('Comma', {
+      value: figma.textContent('Value'),
+    }),
+    time: figma.nestedProps('Time', {
+      value: figma.textContent('Value'),
+    }),
+  },
+  example: (props) => (
+    <Table.PrimaryData iconLeft={props.iconLeft} iconRight={props.iconRight}>
+      {props.date.value}
+      {props.comma.value}
+      {props.time.value}
+    </Table.PrimaryData>
+  ),
+})

--- a/src/core/table/primary-data/primary-data.tsx
+++ b/src/core/table/primary-data/primary-data.tsx
@@ -47,5 +47,7 @@ export function TableCellPrimaryData({ children, iconLeft, iconRight, ...rest }:
   )
 }
 
+TableCellPrimaryData.displayName = 'Table.PrimaryData'
+
 // Backward compatibility
 export type TableCellPrimaryDataProps = TableCellPrimaryData.Props

--- a/src/core/table/sort-button/sort-button.tsx
+++ b/src/core/table/sort-button/sort-button.tsx
@@ -33,5 +33,7 @@ export function TableCellSortButton({ children, className, name, value, ...rest 
   )
 }
 
+TableCellSortButton.displayName = 'Table.SortButton'
+
 // Backward compatibility
 export type TableCellSortButtonProps = TableCellSortButton.Props

--- a/src/core/table/toolbar/toolbar.figma.tsx
+++ b/src/core/table/toolbar/toolbar.figma.tsx
@@ -1,0 +1,26 @@
+import figma from '@figma/code-connect'
+import { Table } from '../table'
+
+figma.connect(Table.Toolbar, '<TABLE_TOOLBAR_URL>', {
+  variant: { Variant: 'Standard' },
+  props: {
+    itemCount: figma.textContent('Item count'),
+    entityName: figma.textContent('Item count'),
+  },
+  example: (props) => (
+    <Table.Toolbar leftContent={`${props.itemCount} ${props.entityName}`} rightContent="TODO: Add page size select" />
+  ),
+})
+
+figma.connect(Table.Toolbar, '<TABLE_TOOLBAR_URL>', {
+  variant: { Variant: 'Bulk actions' },
+  props: {
+    itemCount: figma.textContent('Item count'),
+    entityName: figma.textContent('Item count'),
+    bulkActions: figma.children('Bulk actions'),
+    selectionCount: figma.string('Selection count'),
+  },
+  example: (props) => (
+    <Table.Toolbar leftContent={`${props.itemCount} ${props.entityName}`} rightContent={props.bulkActions} />
+  ),
+})

--- a/src/core/table/toolbar/toolbar.tsx
+++ b/src/core/table/toolbar/toolbar.tsx
@@ -32,5 +32,7 @@ export function TableToolbar({ leftContent, rightContent, ...rest }: TableToolba
   )
 }
 
+TableToolbar.displayName = 'Table.Toolbar'
+
 // Backward compatibility
 export type TableToolbarProps = TableToolbar.Props

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -29,7 +29,8 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 - **feat:** Added Figma Code Connect for `Dialog`, `Drawer`, and `Menu`.
 - **feat:** Added Figma Code Connect for `LabelText`, `PageHeader` and `Pagination`. Includes the following breaking changes:
   - Renamed `breadcrumbs` prop on `PageHeader` to `navigation` to better align with Figma component.
-- **feat:** Added Figma Code Connect for `SideBr` and `TopBar`.
+- **feat:** Added Figma Code Connect for `SideBar` and `TopBar`.
+- **feat:** Added Figma Code Connect for `Table`.
 
 ### **5.0.0-beta.51 - 12/09/25**
 


### PR DESCRIPTION
### Context

- Currently, our engineers have a relatively steep learning curve when implementing UI provided by Design using Elements components for the first time.
- They need to read the minimal documentation provided for the component in Elements' storybook, understand it, then apply it correctly based on the design their implementing.
- Figma's Code Connect is intended to reduce this learning curve by providing code snippets for React within Figma itself that devs can copy-paste into their product. This should bootstrap their usage of Elements and reduce some of the learning curve.
- Further, with Figma's MCP server available, its possible to have an AI agent retrieve this code snippet itself when asked to scaffold out the UI for a selection the engineer has made within the Figma desktop app.
- Previous PRs include:
  - Part 1: #781 
  - Part 2: #782 
  - Part 3: #783 
  - Part 4: #784 
  - Part 5: #785 
  - Part 6: #786 
  - Part 7: #787 
  - Part 8: #788 
  - Part 9: #789 

### This PR

- Connects table
- Removes the include whitelist from `figma.config.json` so that any figma file will now be discovered.