### PR TITLE
fix: bump get-tag action to v2.1.4 to resolve set-output deprecation

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -34,7 +34,7 @@ jobs:
           ref: main
 
       - name: Get Tag
-        uses: olegtarasov/get-tag@v2.1
+        uses: olegtarasov/get-tag@v2.1.4
         id: tagName
         with:
           tagRegex: '(?<package>.*)_(?<version>.*)'


### PR DESCRIPTION
[Previous Prerelease workflows](https://github.com/reapit/elements/actions/runs/17667204630/job/50210988353#step:4:16) show deprecation warnings for the `set-output` command. The [latest Prerelease build](https://github.com/reapit/elements/actions/runs/17783383923/job/50546792229#step:10:1) shows failure on the `Package Version bump` step because no version number has been provided to the `yarn version` command. The version number is meant to be passed in through the `${{ steps.tagName.outputs.version }}` substitution, but it apparently isn't.

The [olegtarasov/get-tag](https://github.com/olegtarasov/get-tag) action being relied upon is up to `2.1.4`, with that version specifically calling out it resolves the deprecation warnings.