### PR TITLE
chore: use pnpm install mode with Yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,7 +4,7 @@ enableGlobalCache: false
 
 enableScripts: false
 
-nodeLinker: node-modules
+nodeLinker: pnpm
 
 npmAuthToken: "${NPM_TOKEN}"
 

--- a/src/core/app-switcher/__tests__/app-switcher.test.tsx
+++ b/src/core/app-switcher/__tests__/app-switcher.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../app-switcher.stories'
 

--- a/src/core/bottom-bar/item/__tests__/item-anchor.test.tsx
+++ b/src/core/bottom-bar/item/__tests__/item-anchor.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../item-anchor.stories'
 

--- a/src/core/bottom-bar/item/__tests__/item-button.test.tsx
+++ b/src/core/bottom-bar/item/__tests__/item-button.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../item-button.stories'
 

--- a/src/core/dialog/__story__/useDialogContextDecorator.tsx
+++ b/src/core/dialog/__story__/useDialogContextDecorator.tsx
@@ -1,6 +1,6 @@
 import { DialogContext } from '../context'
 
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 
 export function useDialogContextDecorator(): Decorator {
   return (Story) => (

--- a/src/core/drawer/__story__/useDrawerBreakpointDecorator.tsx
+++ b/src/core/drawer/__story__/useDrawerBreakpointDecorator.tsx
@@ -1,6 +1,6 @@
 import { DRAWER_WIDTH_XS_SM, DRAWER_WIDTH_MD_2XL, DRAWER_CSS_CONTAINER_NAME } from '../constants'
 
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 import type { ReactNode } from 'react'
 
 export function useDrawerBreakpointDecorator(): Decorator {

--- a/src/core/drawer/__story__/useDrawerContextDecorator.tsx
+++ b/src/core/drawer/__story__/useDrawerContextDecorator.tsx
@@ -1,6 +1,6 @@
 import { DrawerContext } from '../context'
 
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 
 export function useDrawerContextDecorator(): Decorator {
   return (Story) => (

--- a/src/core/folder-tabs/__story__/useFolderTabsContainerDecorator.tsx
+++ b/src/core/folder-tabs/__story__/useFolderTabsContainerDecorator.tsx
@@ -1,6 +1,6 @@
 import { FOLDER_TABS_CSS_CONTAINER_NAME } from '../constants'
 
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 
 export function useFolderTabsContainerDecorator(): Decorator {
   return (Story) => (

--- a/src/core/primary-tabs/__tests__/primary-tabs.test.tsx
+++ b/src/core/primary-tabs/__tests__/primary-tabs.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../primary-tabs.stories'
 

--- a/src/core/secondary-tabs/__tests__/secondary-tabs.test.tsx
+++ b/src/core/secondary-tabs/__tests__/secondary-tabs.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../secondary-tabs.stories'
 

--- a/src/core/side-bar/__story__/use-side-bar-context-decorator.tsx
+++ b/src/core/side-bar/__story__/use-side-bar-context-decorator.tsx
@@ -1,4 +1,4 @@
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 import { useSideBar } from '../use-side-bar'
 import { useId } from 'react'
 import { SideBarContextPublisher } from '../side-bar-context'

--- a/src/core/side-bar/__story__/use-side-bar-width-decorator.tsx
+++ b/src/core/side-bar/__story__/use-side-bar-width-decorator.tsx
@@ -1,4 +1,4 @@
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 import { useSideBarContext } from '../side-bar-context'
 
 export const useSideBarWidthDecorator: Decorator = (Story, context) => {

--- a/src/core/side-bar/__story__/use-viewport-height-decorator.tsx
+++ b/src/core/side-bar/__story__/use-viewport-height-decorator.tsx
@@ -1,4 +1,4 @@
-import type { Decorator } from '@storybook/react'
+import type { Decorator } from '@storybook/react-vite'
 
 export const useViewportHeightDecorator: Decorator = (Story) => {
   return (

--- a/src/core/side-bar/__tests__/side-bar.test.tsx
+++ b/src/core/side-bar/__tests__/side-bar.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../side-bar.stories'
 

--- a/src/core/side-bar/collapse-button/__tests__/collapse-button.test.tsx
+++ b/src/core/side-bar/collapse-button/__tests__/collapse-button.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as stories from '../collapse-button.stories'
 import { SideBarContextPublisher } from '../../side-bar-context'

--- a/src/core/side-bar/menu-group/__tests__/menu-group.test.tsx
+++ b/src/core/side-bar/menu-group/__tests__/menu-group.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import { SideBarMenuGroup } from '../menu-group'
 import * as stories from '../menu-group.stories'

--- a/src/core/side-bar/menu-item/__tests__/menu-item.test.tsx
+++ b/src/core/side-bar/menu-item/__tests__/menu-item.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../menu-item.stories'
 import { elSideBarMenuItem } from '../styles'

--- a/src/core/side-bar/submenu-item/__tests__/submenu-item.test.tsx
+++ b/src/core/side-bar/submenu-item/__tests__/submenu-item.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { elSideBarSubmenuItem } from '../styles'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../submenu-item.stories'

--- a/src/core/top-bar/avatar-button/__tests__/avatar-button.test.tsx
+++ b/src/core/top-bar/avatar-button/__tests__/avatar-button.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../avatar-button.stories'
 

--- a/src/core/top-bar/main-nav/__tests__/main-nav.test.tsx
+++ b/src/core/top-bar/main-nav/__tests__/main-nav.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../main-nav.stories'
 

--- a/src/core/top-bar/nav-dropdown-button/__tests__/nav-dropdown-button.test.tsx
+++ b/src/core/top-bar/nav-dropdown-button/__tests__/nav-dropdown-button.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../nav-dropdown-button.stories'
 

--- a/src/core/top-bar/nav-icon-item/__tests__/nav-icon-item-button.test.tsx
+++ b/src/core/top-bar/nav-icon-item/__tests__/nav-icon-item-button.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../nav-icon-item-button.stories'
 

--- a/src/core/top-bar/nav-item/__tests__/nav-item.test.tsx
+++ b/src/core/top-bar/nav-item/__tests__/nav-item.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { elTopBarNavItem } from '../styles'
 import { render, screen } from '@testing-library/react'
 import * as stories from '../nav-item.stories'

--- a/src/core/top-bar/nav-search-button/__tests__/nav-search-button.test.tsx
+++ b/src/core/top-bar/nav-search-button/__tests__/nav-search-button.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../nav-search-button.stories'
 

--- a/src/core/top-bar/nav-search-icon-item/__tests__/nav-search-icon-item.test.tsx
+++ b/src/core/top-bar/nav-search-icon-item/__tests__/nav-search-icon-item.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../nav-search-icon-item.stories'
 

--- a/src/lab/radio-group/__tests__/radio-group.test.tsx
+++ b/src/lab/radio-group/__tests__/radio-group.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { render, screen, fireEvent } from '@testing-library/react'
 import * as stories from '../radio-group.stories'
 

--- a/src/lab/radio/__tests__/radio.test.tsx
+++ b/src/lab/radio/__tests__/radio.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../radio.stories'
 

--- a/src/lab/search-input/__tests__/search-input.test.tsx
+++ b/src/lab/search-input/__tests__/search-input.test.tsx
@@ -1,4 +1,4 @@
-import { composeStories } from '@storybook/react'
+import { composeStories } from '@storybook/react-vite'
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as stories from '../search-input.stories'
 


### PR DESCRIPTION
Updates our Yarn install mode to `pnpm` rather than the current `node-modules`. This brings us some improvements: https://yarnpkg.com/features/linkers#nodelinker-pnpm

This change picked up ghost dependency imports (imports from `@storybook/react` which is not a direct dependency of the package). These have all been fixed.