### PR TITLE
feat: Allow MMI product to display in AppSwitcher

### DIFF
--- a/src/core/app-switcher/__tests__/config.test.ts
+++ b/src/core/app-switcher/__tests__/config.test.ts
@@ -70,6 +70,7 @@ test('product display order should not change without updating this test', () =>
         "consoleCloud",
         "keywhere",
         "bdm",
+        "mmiWeb",
       ]
     `)
 })

--- a/src/core/app-switcher/app-switcher.stories.tsx
+++ b/src/core/app-switcher/app-switcher.stories.tsx
@@ -125,11 +125,11 @@ export const AllAccessible: StoryObj<{ accessibleProductIds: string[] }> = {
  * const ids = AppSwitcher.getDisplayableProductsForExploreGroup(accessibleProductIds)
  *
  * return ids.length > 0 && (
- *  <AppSwitcher.YourAppsMenuGroup>
+ *  <AppSwitcher.ExploreMenuGroup>
  *    {ids.map((productId) => (
  *      <AppSwitcher.Product key={productId} productId={productId} url={href} />
  *    ))}
- *  </AppSwitcher.YourAppsMenuGroup>
+ *  </AppSwitcher.ExploreMenuGroup>
  * )
  * ```
  */

--- a/src/core/app-switcher/config.ts
+++ b/src/core/app-switcher/config.ts
@@ -80,4 +80,5 @@ export const productDisplayOrder_DO_NOT_ADD_PRODUCTS_TO_THIS_UNLESS_APPROVED_FOR
   // Secondary apps here (should be alphatically ordered by configured app name)
   'keywhere',
   'bdm',
+  'mmiWeb',
 ] as const satisfies SupportedProductId[]

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -16,9 +16,9 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
-### **5.0.0-beta.53 - ??/??/25**
+### **5.0.0-beta.53 - 22/09/25**
 
-- TBC
+- **feat:** Allow MMI product to display in the AppSwitcher
 
 ### **5.0.0-beta.52 - 17/09/25**
 


### PR DESCRIPTION
Allows the MMI product to display in the AppSwitcher.

<img width="964" height="401" alt="Screenshot 2025-09-22 at 2 27 41 pm" src="https://github.com/user-attachments/assets/d7c81101-0497-4fb7-b249-f3db72578e29" />
<img width="959" height="377" alt="Screenshot 2025-09-22 at 2 27 46 pm" src="https://github.com/user-attachments/assets/776e8bdd-a078-48a3-b95b-6290aa095588" />
