### PR TITLE
feat: Allow Reapit Sales product to display in AppSwitcher

### DIFF
--- a/src/core/app-switcher/__tests__/config.test.ts
+++ b/src/core/app-switcher/__tests__/config.test.ts
@@ -68,6 +68,7 @@ test('product display order should not change without updating this test', () =>
       [
         "ireWeb",
         "consoleCloud",
+        "agentBox",
         "keywhere",
         "bdm",
         "mmiWeb",

--- a/src/core/app-switcher/config.ts
+++ b/src/core/app-switcher/config.ts
@@ -75,10 +75,11 @@ export const productConfigs = {
  */
 export const productDisplayOrder_DO_NOT_ADD_PRODUCTS_TO_THIS_UNLESS_APPROVED_FOR_DISPLAY_AND_SSO_CAPABLE = [
   // Primary apps here (should be alphatically ordered by configured app name)
-  'ireWeb', // Reapit Lettings
-  'consoleCloud', // Reapit PM
+  'ireWeb', // => Reapit Lettings
+  'consoleCloud', // => Reapit PM
+  'agentBox', // => Reapit Sales
   // Secondary apps here (should be alphatically ordered by configured app name)
   'keywhere',
-  'bdm',
+  'bdm', // => Lettings BDM
   'mmiWeb',
 ] as const satisfies SupportedProductId[]

--- a/src/storybook/changelog.mdx
+++ b/src/storybook/changelog.mdx
@@ -19,6 +19,7 @@ Beta versions should be relatively stable but subject to occssional breaking cha
 ### **5.0.0-beta.53 - 22/09/25**
 
 - **feat:** Allow MMI product to display in the AppSwitcher
+- **feat:** Allow Reapit Sales product to display in the AppSwitcher
 
 ### **5.0.0-beta.52 - 17/09/25**
 


### PR DESCRIPTION
What it says on the tin.

<img width="997" height="489" alt="Screenshot 2025-09-22 at 4 45 31 pm" src="https://github.com/user-attachments/assets/25fa1304-f241-4545-b3bc-a6f8a22c1e79" />
<img width="996" height="472" alt="Screenshot 2025-09-22 at 4 45 44 pm" src="https://github.com/user-attachments/assets/458b444c-090f-4d8a-b697-3e275262fdba" />
